### PR TITLE
feat: sync upstream origin sources for OSP-bound repos

### DIFF
--- a/.github/workflows/sync-upstream-sources.yml
+++ b/.github/workflows/sync-upstream-sources.yml
@@ -1,0 +1,66 @@
+name: Sync Upstream Sources
+
+# Reads the ## Origins section of every OSP-bound Interested-Deving-1896 repo
+# and syncs each referenced external fork to its upstream HEAD.
+#
+# GitHub forks are synced via merge-upstream (fast-forward) or force-reset.
+# KDE (invent.kde.org) and GitLab origins are verified for presence only —
+# they are kept current by the existing KDE and GitLab mirror pipelines.
+#
+# Run patch-origins-sections.sh once (manually or via workflow_dispatch) to
+# add Origins sections to repos that are missing them before this workflow
+# will pick them up.
+
+on:
+  schedule:
+    # Daily at 01:30 UTC — after sync-forks (06:00) would be redundant for
+    # forks already covered there; this catches origins not in that set.
+    # Offset from sync-pieroproietti-forks (:05) and sync-forks (06:00).
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Report without syncing'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+# ── Rate limits ───────────────────────────────────────────────────────────────
+# GitHub REST API (SYNC_TOKEN): 5 000 req/hr.
+#   gh_api() retries HTTP 403/429 with X-RateLimit-Reset sleep (up to 3×).
+# merge-upstream: one POST per fork per run — well within limits for ~50 forks.
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Sync upstream origin forks
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+          GITHUB_OWNER: Interested-Deving-1896
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: bash scripts/sync-upstream-sources.sh
+
+  patch-origins:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Only runs on manual dispatch — this is a one-shot operation.
+    if: github.event_name == 'workflow_dispatch'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Add missing Origins sections
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+          GITHUB_OWNER: Interested-Deving-1896
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: bash scripts/patch-origins-sections.sh

--- a/scripts/patch-origins-sections.sh
+++ b/scripts/patch-origins-sections.sh
@@ -1,0 +1,314 @@
+#!/usr/bin/env bash
+#
+# Appends a canonical ## Origins section to the README.md of every
+# OSP-bound Interested-Deving-1896 repo that does not already have one.
+#
+# Origins content is hardcoded here — it was derived by reading each repo's
+# README and structure, then cross-referencing against existing I-D-1896 forks.
+# Run this once; after that, sync-upstream-sources.sh keeps the forks current.
+#
+# Required env vars:
+#   GH_TOKEN      — PAT with repo + contents:write scope on Interested-Deving-1896
+#   GITHUB_OWNER  — org to patch (default: Interested-Deving-1896)
+#   DRY_RUN       — set to "true" to print patches without committing (default: false)
+
+set -uo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+GITHUB_OWNER="${GITHUB_OWNER:-Interested-Deving-1896}"
+DRY_RUN="${DRY_RUN:-false}"
+
+API="https://api.github.com"
+HEADER_FILE=$(mktemp)
+trap 'rm -f "$HEADER_FILE"' EXIT
+
+info() { echo "[patch-origins] $*"; }
+warn() { echo "[warn] $*" >&2; }
+dry()  { echo "[dry-run] $*"; }
+
+gh_api() {
+  local method="$1" url="$2"; shift 2
+  local attempt=0 max_retries=3
+  while true; do
+    local response http_code body
+    response=$(curl -s -w "\n%{http_code}" -X "$method" \
+      -H "Authorization: token ${GH_TOKEN}" \
+      -H "Accept: application/vnd.github+json" \
+      -H "X-GitHub-Api-Version: 2022-11-28" \
+      -D "$HEADER_FILE" \
+      "$@" "$url" 2>/dev/null) || true
+    http_code=$(echo "$response" | tail -1)
+    body=$(echo "$response" | sed '$d')
+    if [[ "$http_code" == "403" || "$http_code" == "429" ]]; then
+      (( attempt++ )) || true
+      [[ $attempt -gt $max_retries ]] && { echo "$body"; return 1; }
+      local reset now wait
+      reset=$(grep -i "x-ratelimit-reset:" "$HEADER_FILE" 2>/dev/null | tr -d '\r' | awk '{print $2}')
+      now=$(date +%s); wait=$(( ${reset:-0} - now + 5 ))
+      [[ "$wait" -gt 0 && "$wait" -lt 3700 ]] && sleep "$wait" || sleep 60
+      continue
+    fi
+    echo "$body"; return 0
+  done
+}
+
+# Fetch README content + blob SHA for a repo. Outputs "sha|base64_content".
+get_readme() {
+  local repo="$1" branch="$2"
+  local info
+  info=$(gh_api GET "${API}/repos/${GITHUB_OWNER}/${repo}/contents/README.md?ref=${branch}") || return 1
+  local sha content
+  sha=$(echo "$info" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('sha',''))" 2>/dev/null)
+  content=$(echo "$info" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('content',''))" 2>/dev/null | tr -d '\n')
+  [[ -z "$sha" || -z "$content" ]] && return 1
+  echo "${sha}|${content}"
+}
+
+# Commit an updated README. $1=repo $2=branch $3=blob_sha $4=new_content_b64
+commit_readme() {
+  local repo="$1" branch="$2" blob_sha="$3" content_b64="$4"
+  local payload
+  payload=$(python3 -c "
+import json, sys
+print(json.dumps({
+  'message': 'docs: add Origins section',
+  'content': sys.argv[1],
+  'sha':     sys.argv[2],
+  'branch':  sys.argv[3],
+}))
+" "$content_b64" "$blob_sha" "$branch")
+  gh_api PUT "${API}/repos/${GITHUB_OWNER}/${repo}/contents/README.md" \
+    -H "Content-Type: application/json" --data "$payload" > /dev/null
+}
+
+# Append an Origins block to decoded README text, then re-encode as base64.
+# $1=current_decoded_text  $2=origins_block  → prints new base64
+append_origins() {
+  local current="$1" origins="$2"
+  printf '%s\n\n%s\n' "$current" "$origins" | base64 | tr -d '\n'
+}
+
+patched=0
+skipped=0
+failed=0
+
+patch_repo() {
+  local repo="$1" branch="$2" origins_block="$3"
+
+  info "── ${repo} (${branch})"
+
+  local readme_info
+  readme_info=$(get_readme "$repo" "$branch") || {
+    warn "  Could not fetch README for ${repo} — skipping"
+    (( failed++ )) || true; return
+  }
+
+  local blob_sha current_b64 current_text
+  blob_sha=$(echo "$readme_info" | cut -d'|' -f1)
+  current_b64=$(echo "$readme_info" | cut -d'|' -f2-)
+  current_text=$(echo "$current_b64" | base64 -d 2>/dev/null)
+
+  if echo "$current_text" | grep -q "^## Origins"; then
+    info "  Already has Origins section — skipping"
+    (( skipped++ )) || true; return
+  fi
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    dry "Would append Origins to ${GITHUB_OWNER}/${repo}/README.md"
+    dry "---"
+    echo "$origins_block"
+    dry "---"
+    (( patched++ )) || true; return
+  fi
+
+  local new_b64
+  new_b64=$(append_origins "$current_text" "$origins_block")
+
+  if commit_readme "$repo" "$branch" "$blob_sha" "$new_b64"; then
+    info "  ✓ patched"
+    (( patched++ )) || true
+  else
+    warn "  ✗ commit failed"
+    (( failed++ )) || true
+  fi
+}
+
+# ── Origins blocks ────────────────────────────────────────────────────────────
+# Each block is the exact markdown to append. Internal I-D-1896 repos link to
+# their GitHub URL. External origins link to their canonical upstream URL.
+# KDE/invent.kde.org links use https://invent.kde.org/<group>/<repo>.
+
+patch_repo "eggs-ai" "main" \
+'## Origins
+
+eggs-ai is built on top of:
+- [Interested-Deving-1896/penguins-eggs](https://github.com/Interested-Deving-1896/penguins-eggs) — the Linux remastering tool this agent wraps
+- [Interested-Deving-1896/oa-tools](https://github.com/Interested-Deving-1896/oa-tools) — next-generation remastering engine (oa + coa)'
+
+patch_repo "eggs-gui" "main" \
+'## Origins
+
+eggs-gui merges three upstream GUI projects:
+- [pieroproietti/pengui](https://github.com/pieroproietti/pengui) — original PySide6 GUI for penguins-eggs
+- [pieroproietti/eggsmaker](https://github.com/pieroproietti/eggsmaker) — customtkinter GUI by Jorge Luis Endres
+- [jlendres/eggsmaker](https://github.com/jlendres/eggsmaker) — enhanced fork with web UI
+- [charmbracelet/bubbletea](https://github.com/charmbracelet/bubbletea) — Go TUI framework (BubbleTea frontend)
+- [nodegui/nodegui](https://github.com/nodegui/nodegui) — Qt6/TypeScript native desktop framework'
+
+patch_repo "immutable-linux-framework" "main" \
+'## Origins
+
+immutable-linux-framework integrates the following immutability backends:
+- [Vanilla-OS/ABRoot](https://github.com/Vanilla-OS/ABRoot) — A/B partition swap + OCI image updates
+- [ashos/ashos](https://github.com/ashos/ashos) — BTRFS snapshot tree, multi-distro
+- [ChimeraOS/frzr](https://github.com/ChimeraOS/frzr) — read-only BTRFS subvolume image deployment
+- [blend-os/akshara](https://github.com/blend-os/akshara) — YAML-declared declarative system rebuild
+- [blend-os/nearly](https://github.com/blend-os/nearly) — immutability toggle primitive (absorbed into core/mutable)
+- [Interested-Deving-1896/btrfs-dwarfs-framework](https://github.com/Interested-Deving-1896/btrfs-dwarfs-framework) — BTRFS+DwarFS hybrid blend layer'
+
+patch_repo "liquorix-unified-kernel" "main" \
+'## Origins
+
+liquorix-unified-kernel consolidates packaging for:
+- [damentz/liquorix-package](https://github.com/damentz/liquorix-package) — official Liquorix kernel Debian/Ubuntu packaging
+- [liquorix/liquorix-package](https://github.com/liquorix/liquorix-package) — Arch Linux packaging
+- [zen-kernel/zen-kernel](https://github.com/zen-kernel/zen-kernel) — Zen patch set (the basis of Liquorix)'
+
+patch_repo "liqxanmod" "main" \
+'## Origins
+
+liqxanmod merges two upstream kernel patch sets:
+- [xanmod/linux](https://gitlab.com/xanmod/linux) — XanMod performance patch set
+- [zen-kernel/zen-kernel](https://github.com/zen-kernel/zen-kernel) — Zen/Liquorix low-latency patch set
+- [damentz/liquorix-package](https://github.com/damentz/liquorix-package) — Liquorix build configuration reference'
+
+patch_repo "lkf" "main" \
+'## Origins
+
+lkf consolidates patterns from 15 upstream kernel tooling projects:
+- [ghazzor/Xanmod-Kernel-Builder](https://github.com/ghazzor/Xanmod-Kernel-Builder) — Clang/LLVM CI workflow, LTO config patterns
+- [kodx/symlink-initrd-kernel-in-root](https://github.com/kodx/symlink-initrd-kernel-in-root) — `/vmlinuz` + `/initrd.img` symlink management
+- [rawdaGastan/go-extract-vmlinux](https://github.com/rawdaGastan/go-extract-vmlinux) — vmlinux/vmlinuz extraction logic
+- [elfmaster/kdress](https://github.com/elfmaster/kdress) — vmlinuz → debuggable vmlinux with full ELF symbol table
+- [eballetbo/unzboot](https://github.com/eballetbo/unzboot) — EFI zboot ARM64 kernel extraction
+- [Biswa96/android-kernel-builder](https://github.com/Biswa96/android-kernel-builder) — Android cross-compile pipeline
+- [AlexanderARodin/LinuxComponentsBuilder](https://github.com/AlexanderARodin/LinuxComponentsBuilder) — kernel + initrd + rootfs + squash pipeline
+- [osresearch/linux-builder](https://github.com/osresearch/linux-builder) — appliance/firmware kernel, unified EFI image
+- [tsirysndr/vmlinux-builder](https://github.com/tsirysndr/vmlinux-builder) — multi-arch CI, version normalization
+- [rizalmart/puppy-linux-kernel-maker](https://github.com/rizalmart/puppy-linux-kernel-maker) — AUFS patch workflow, firmware driver packaging
+- [deepseagirl/easylkb](https://github.com/deepseagirl/easylkb) — QEMU+GDB debug environment
+- [limitcool/xm](https://github.com/limitcool/xm) — cross-compile manager concept
+- [masahir0y/kbuild_skeleton](https://github.com/masahir0y/kbuild_skeleton) — Kbuild/Kconfig standalone template
+- [h0tc0d3/kbuild](https://github.com/h0tc0d3/kbuild) — flexible CLI flags, DKMS integration, GPG verification
+- [WangNan0/kbuild-standalone](https://github.com/WangNan0/kbuild-standalone) — standalone kconfig/kbuild as a library'
+
+patch_repo "lkm" "main" \
+'## Origins
+
+lkm merges two complementary kernel management tools:
+- [Interested-Deving-1896/lkf](https://github.com/Interested-Deving-1896/lkf) — Linux Kernel Framework (shell build pipeline)
+- [Interested-Deving-1896/ukm](https://github.com/Interested-Deving-1896/ukm) — Universal Kernel Manager (runtime management)'
+
+patch_repo "oa-tools" "main" \
+'## Origins
+
+oa-tools is the next-generation evolution of:
+- [pieroproietti/penguins-eggs](https://github.com/pieroproietti/penguins-eggs) — the original Linux remastering tool this project supersedes'
+
+patch_repo "penguins-eggs-audit" "main" \
+'## Origins
+
+penguins-eggs-audit integrates 39 git-based projects. Key upstreams by domain:
+
+**Distribution & Decentralized**
+- [git-lfs/git-lfs](https://github.com/git-lfs/git-lfs) — ISO tracking via Git LFS
+- [nicowillis/giftless](https://github.com/nicowillis/giftless) — self-hosted Git LFS server
+- [gogs/gogs](https://github.com/gogs/gogs) — self-hosted Git registry
+- [brig-ipfs/brig](https://github.com/sahib/brig) — IPFS-based distribution via brig
+- [ipfs/go-ipfs](https://github.com/ipfs/go-ipfs) — IPFS node
+
+**Config Management & Build**
+- [presslabs/gitfs](https://github.com/presslabs/gitfs) — FUSE-mounted git repo for wardrobe editing
+- [system-transparency/system-transparency](https://github.com/system-transparency/system-transparency) — reproducible verified builds
+
+**Dev Workflow & Security**
+- [linear-b/gitstream](https://github.com/linear-b/gitstream) — PR automation rules
+- [jfrog/frogbot](https://github.com/jfrog/frogbot) — security scanning GitHub Action
+- [anchore/syft](https://github.com/anchore/syft) — SBOM generation
+- [anchore/grant](https://github.com/anchore/grant) — license compliance scanning'
+
+patch_repo "penguins-eggs-book" "main" \
+'## Origins
+
+penguins-eggs-book documents:
+- [pieroproietti/penguins-eggs](https://github.com/pieroproietti/penguins-eggs) — the tool this book covers
+- [hosseinseilani/penguins-eggs-book](https://github.com/hosseinseilani/penguins-eggs-book) — original book authored by Hossein Seilany'
+
+patch_repo "penguins-incus-platform" "main" \
+'## Origins
+
+penguins-incus-platform unifies:
+- [lxc/incus](https://github.com/lxc/incus) — the Incus container and VM manager this platform wraps
+- [lxc/distrobuilder](https://github.com/lxc/distrobuilder) — LXC/Incus rootfs image builder (Go)
+- [itoffshore/distrobuilder-menu](https://github.com/itoffshore/distrobuilder-menu) — Python TUI menu for distrobuilder
+- [Interested-Deving-1896/penguins-eggs](https://github.com/Interested-Deving-1896/penguins-eggs) — penguins-eggs integration hooks'
+
+patch_repo "penguins-kernel-manager" "main" \
+'## Origins
+
+penguins-kernel-manager is forked from and extends:
+- [Interested-Deving-1896/lkm](https://github.com/Interested-Deving-1896/lkm) — Linux Kernel Manager (lkf + ukm merger)
+- [Interested-Deving-1896/lkf](https://github.com/Interested-Deving-1896/lkf) — Linux Kernel Framework (shell build pipeline)
+- [Interested-Deving-1896/ukm](https://github.com/Interested-Deving-1896/ukm) — Universal Kernel Manager (runtime management)
+- [bkw777/mainline](https://github.com/bkw777/mainline) — Ubuntu Mainline PPA kernel installer
+- [bobbycomet/XKM-Multi-Kernel-Manager](https://github.com/bobbycomet/XKM-Multi-Kernel-Manager) — multi-kernel manager reference'
+
+patch_repo "penguins-powerwash" "main" \
+'## Origins
+
+penguins-powerwash is forked from and extends:
+- [Interested-Deving-1896/linux-powerwash](https://github.com/Interested-Deving-1896/linux-powerwash) — the distro-agnostic factory reset tool this project rebrands
+- [Interested-Deving-1896/penguins-eggs](https://github.com/Interested-Deving-1896/penguins-eggs) — penguins-eggs integration (pre/post-reset ISO snapshots)
+- [Interested-Deving-1896/penguins-recovery](https://github.com/Interested-Deving-1896/penguins-recovery) — recovery integration (snapshot + re-layer after reset)'
+
+patch_repo "ukm" "main" \
+'## Origins
+
+ukm combines the best of two upstream kernel managers:
+- [bkw777/mainline](https://github.com/bkw777/mainline) — Ubuntu Mainline PPA kernel installer (GUI + CLI)
+- [bobbycomet/XKM-Multi-Kernel-Manager](https://github.com/bobbycomet/XKM-Multi-Kernel-Manager) — multi-distro kernel manager reference'
+
+patch_repo "xanmod-unified-kernel" "main" \
+'## Origins
+
+xanmod-unified-kernel consolidates packaging for:
+- [xanmod/linux](https://gitlab.com/xanmod/linux) — XanMod kernel source (MAIN, EDGE, LTS, RT branches)
+- [xanmod/linux-tkg](https://github.com/xanmod/linux-tkg) — TkG build system and patch collection reference
+- [CachyOS/linux-cachyos](https://github.com/CachyOS/linux-cachyos) — CachyOS scheduler patch reference'
+
+patch_repo "btrfs-dwarfs-framework" "master" \
+'## Origins
+
+btrfs-dwarfs-framework blends two upstream filesystem projects:
+- [kdave/btrfs-devel](https://github.com/kdave/btrfs-devel) — BTRFS kernel development tree
+- [mhx/dwarfs](https://github.com/mhx/dwarfs) — DwarFS high-compression read-only filesystem
+- [containers/fuse-overlayfs](https://github.com/containers/fuse-overlayfs) — userspace overlay fallback when kernel module unavailable'
+
+patch_repo "penguins-eggs" "master" \
+'## Origins
+
+penguins-eggs is the original Linux remastering tool by Piero Proietti:
+- [pieroproietti/penguins-eggs](https://github.com/pieroproietti/penguins-eggs) — upstream source (this repo tracks it)
+- [pieroproietti/oa-tools](https://github.com/pieroproietti/oa-tools) — next-generation successor (oa + coa architecture)'
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "════════════════════════════════════════"
+echo "  patch-origins-sections complete"
+echo "  Patched : ${patched}"
+echo "  Skipped : ${skipped}"
+echo "  Failed  : ${failed}"
+echo "════════════════════════════════════════"
+
+[[ "$failed" -gt 0 ]] && exit 1
+exit 0

--- a/scripts/sync-upstream-sources.sh
+++ b/scripts/sync-upstream-sources.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+#
+# Syncs all upstream origin repos referenced in ## Origins sections of
+# OSP-bound Interested-Deving-1896 repos.
+#
+# For each repo in the OSP-bound set:
+#   1. Fetch its README from the default branch.
+#   2. Parse all GitHub, invent.kde.org, and gitlab.com links from ## Origins.
+#   3. For each external origin (not Interested-Deving-1896/*):
+#      a. If a fork already exists under GITHUB_OWNER — sync it via
+#         merge-upstream (fast-forward) or force-reset to upstream HEAD.
+#      b. If no fork exists — report it as missing (forking requires manual
+#         action; automated fork creation is excluded to avoid unreviewed repos).
+#      c. KDE (invent.kde.org) and non-GitHub GitLab origins are reported as
+#         present/missing but not synced here — they are handled by the
+#         existing KDE mirror pipelines on the GitLab side.
+#
+# Required env vars:
+#   GH_TOKEN      — PAT with repo scope on Interested-Deving-1896
+#   GITHUB_OWNER  — org that holds the forks (default: Interested-Deving-1896)
+#
+# Optional env vars:
+#   DRY_RUN       — set to "true" to report without syncing (default: false)
+
+set -uo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+GITHUB_OWNER="${GITHUB_OWNER:-Interested-Deving-1896}"
+DRY_RUN="${DRY_RUN:-false}"
+
+API="https://api.github.com"
+HEADER_FILE=$(mktemp)
+trap 'rm -f "$HEADER_FILE"' EXIT
+
+info() { echo "[sync-upstream-sources] $*"; }
+warn() { echo "[warn] $*" >&2; }
+dry()  { echo "[dry-run] $*"; }
+
+# ── GitHub API helper ─────────────────────────────────────────────────────────
+
+gh_api() {
+  local method="$1" url="$2"; shift 2
+  local attempt=0 max_retries=3
+  while true; do
+    local response http_code body
+    response=$(curl -s -w "\n%{http_code}" -X "$method" \
+      -H "Authorization: token ${GH_TOKEN}" \
+      -H "Accept: application/vnd.github+json" \
+      -H "X-GitHub-Api-Version: 2022-11-28" \
+      -D "$HEADER_FILE" \
+      "$@" "$url" 2>/dev/null) || true
+    http_code=$(echo "$response" | tail -1)
+    body=$(echo "$response" | sed '$d')
+    if [[ "$http_code" == "403" || "$http_code" == "429" ]]; then
+      (( attempt++ )) || true
+      [[ $attempt -gt $max_retries ]] && { echo "$body"; return 1; }
+      local reset now wait
+      reset=$(grep -i "x-ratelimit-reset:" "$HEADER_FILE" 2>/dev/null | tr -d '\r' | awk '{print $2}')
+      now=$(date +%s); wait=$(( ${reset:-0} - now + 5 ))
+      [[ "$wait" -gt 0 && "$wait" -lt 3700 ]] && sleep "$wait" || sleep 60
+      continue
+    fi
+    echo "$body"; return 0
+  done
+}
+
+# ── OSP-bound repo list ───────────────────────────────────────────────────────
+# Repos mirrored from I-D-1896 to OpenOS-Project-OSP (from sync-to-gitlab.sh).
+OSP_REPOS=(
+  btrfs-dwarfs-framework
+  eggs-ai
+  eggs-gui
+  immutable-linux-framework
+  liquorix-unified-kernel
+  liqxanmod
+  lkf
+  lkm
+  oa-tools
+  penguins-eggs
+  penguins-eggs-audit
+  penguins-eggs-book
+  penguins-incus-platform
+  penguins-kernel-manager
+  penguins-powerwash
+  penguins-recovery
+  ukm
+  xanmod-unified-kernel
+)
+
+# ── README fetch and Origins parsing ─────────────────────────────────────────
+
+get_readme_text() {
+  local repo="$1"
+  local info content
+  for branch in main master develop; do
+    info=$(gh_api GET "${API}/repos/${GITHUB_OWNER}/${repo}/contents/README.md?ref=${branch}" 2>/dev/null) || continue
+    content=$(echo "$info" | python3 -c \
+      "import sys,json,base64
+d=json.load(sys.stdin)
+raw=d.get('content','')
+print(base64.b64decode(raw).decode('utf-8','replace'))" 2>/dev/null) || continue
+    [[ -n "$content" ]] && echo "$content" && return 0
+  done
+  return 1
+}
+
+# Extract external origin links from the ## Origins section.
+# Emits "host|owner/repo" lines. Skips GITHUB_OWNER-internal links.
+parse_origins() {
+  local readme="$1"
+  local origins_block
+  origins_block=$(echo "$readme" | awk '/^## Origins/{f=1;next} f && /^## /{exit} f{print}')
+  [[ -z "$origins_block" ]] && return 0
+
+  # GitHub
+  echo "$origins_block" \
+    | grep -oP 'https://github\.com/[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+' \
+    | sed 's|https://github.com/||' \
+    | grep -iv "^${GITHUB_OWNER}/" \
+    | sort -u \
+    | sed 's/^/github|/'
+
+  # KDE Invent
+  echo "$origins_block" \
+    | grep -oP 'https://invent\.kde\.org/[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+' \
+    | sed 's|https://invent.kde.org/||' \
+    | sort -u \
+    | sed 's/^/kde|/'
+
+  # GitLab.com (non-openos-project)
+  echo "$origins_block" \
+    | grep -oP 'https://gitlab\.com/[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+' \
+    | sed 's|https://gitlab.com/||' \
+    | grep -iv "^openos-project/" \
+    | sort -u \
+    | sed 's/^/gitlab|/'
+}
+
+# ── Fork sync helpers ─────────────────────────────────────────────────────────
+
+fork_exists() {
+  local name="$1"
+  local info
+  info=$(gh_api GET "${API}/repos/${GITHUB_OWNER}/${name}" 2>/dev/null) || return 1
+  echo "$info" | python3 -c \
+    "import sys,json; d=json.load(sys.stdin); exit(0 if d.get('name') else 1)" 2>/dev/null
+}
+
+fork_default_branch() {
+  local name="$1"
+  gh_api GET "${API}/repos/${GITHUB_OWNER}/${name}" 2>/dev/null \
+    | python3 -c \
+      "import sys,json; d=json.load(sys.stdin); print(d.get('default_branch','main'))" 2>/dev/null \
+    || echo "main"
+}
+
+upstream_default_branch() {
+  local slug="$1"
+  gh_api GET "${API}/repos/${slug}" 2>/dev/null \
+    | python3 -c \
+      "import sys,json; d=json.load(sys.stdin); print(d.get('default_branch','main'))" 2>/dev/null \
+    || echo "main"
+}
+
+sync_github_fork() {
+  local fork_name="$1" upstream_slug="$2"
+  local branch
+  branch=$(fork_default_branch "$fork_name")
+
+  local result merge_type
+  result=$(gh_api POST "${API}/repos/${GITHUB_OWNER}/${fork_name}/merge-upstream" \
+    -H "Content-Type: application/json" \
+    -d "{\"branch\":\"${branch}\"}") || true
+  merge_type=$(echo "$result" | python3 -c \
+    "import sys,json; d=json.load(sys.stdin); print(d.get('merge_type',''))" 2>/dev/null || true)
+
+  case "$merge_type" in
+    fast-forward) info "    fast-forwarded"; return 0 ;;
+    none)         info "    already up to date"; return 0 ;;
+    merge)        info "    merged"; return 0 ;;
+  esac
+
+  # Fallback: force-reset to upstream HEAD
+  local upstream_branch upstream_ref upstream_sha
+  upstream_branch=$(upstream_default_branch "$upstream_slug")
+  upstream_ref=$(gh_api GET "${API}/repos/${upstream_slug}/git/ref/heads/${upstream_branch}") || {
+    warn "    force-reset failed: could not fetch upstream ref"
+    return 1
+  }
+  upstream_sha=$(echo "$upstream_ref" | python3 -c \
+    "import sys,json; d=json.load(sys.stdin); print(d.get('object',{}).get('sha',''))" 2>/dev/null || true)
+  [[ -z "$upstream_sha" ]] && { warn "    force-reset failed: no SHA"; return 1; }
+
+  local patch_result new_sha
+  patch_result=$(gh_api PATCH \
+    "${API}/repos/${GITHUB_OWNER}/${fork_name}/git/refs/heads/${branch}" \
+    -H "Content-Type: application/json" \
+    -d "{\"sha\":\"${upstream_sha}\",\"force\":true}") || {
+    warn "    force-reset failed"; return 1
+  }
+  new_sha=$(echo "$patch_result" | python3 -c \
+    "import sys,json; d=json.load(sys.stdin); print(d.get('object',{}).get('sha',''))" 2>/dev/null || true)
+  [[ -n "$new_sha" ]] && info "    force-reset to ${new_sha:0:7}" && return 0
+  warn "    force-reset: unexpected response"
+  return 1
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+[[ "$DRY_RUN" == "true" ]] && info "DRY RUN — no syncs will be performed"
+info "Scanning ${#OSP_REPOS[@]} OSP-bound repos for Origins..."
+echo ""
+
+declare -A seen_origins  # "host|slug" → 1 — deduplicates across repos
+
+synced=0
+skipped=0
+missing=0
+failed=0
+
+for repo in "${OSP_REPOS[@]}"; do
+  info "── ${repo}"
+
+  readme=$(get_readme_text "$repo") || {
+    warn "  No README found — skipping"
+    continue
+  }
+
+  if ! echo "$readme" | grep -q "^## Origins"; then
+    info "  No Origins section — skipping (run patch-origins-sections.sh first)"
+    continue
+  fi
+
+  while IFS='|' read -r host slug; do
+    [[ -z "$host" || -z "$slug" ]] && continue
+    local_key="${host}|${slug}"
+    [[ -v seen_origins["$local_key"] ]] && continue
+    seen_origins["$local_key"]=1
+
+    fork_name="${slug##*/}"
+    info "  ${host}: ${slug}"
+
+    case "$host" in
+      github)
+        if fork_exists "$fork_name"; then
+          if [[ "$DRY_RUN" == "true" ]]; then
+            dry "    Would sync ${GITHUB_OWNER}/${fork_name} ← github.com/${slug}"
+            (( synced++ )) || true
+          else
+            if sync_github_fork "$fork_name" "$slug"; then
+              (( synced++ )) || true
+            else
+              (( failed++ )) || true
+            fi
+          fi
+        else
+          warn "    MISSING: no fork at ${GITHUB_OWNER}/${fork_name} (upstream: github.com/${slug})"
+          (( missing++ )) || true
+        fi
+        ;;
+      kde)
+        # KDE repos are mirrored via sync-kde-groups-mirrors.sh on the GitLab side.
+        # On the GitHub side we only verify the fork exists; no sync needed here.
+        if fork_exists "$fork_name"; then
+          info "    present at ${GITHUB_OWNER}/${fork_name} (KDE — synced via GitLab KDE mirror pipeline)"
+          (( skipped++ )) || true
+        else
+          warn "    MISSING: no fork at ${GITHUB_OWNER}/${fork_name} (upstream: invent.kde.org/${slug})"
+          (( missing++ )) || true
+        fi
+        ;;
+      gitlab)
+        if fork_exists "$fork_name"; then
+          info "    present at ${GITHUB_OWNER}/${fork_name} (GitLab — synced via GitLab mirror pipeline)"
+          (( skipped++ )) || true
+        else
+          warn "    MISSING: no fork at ${GITHUB_OWNER}/${fork_name} (upstream: gitlab.com/${slug})"
+          (( missing++ )) || true
+        fi
+        ;;
+    esac
+  done < <(parse_origins "$readme")
+done
+
+echo ""
+echo "════════════════════════════════════════════════════"
+echo "  sync-upstream-sources complete"
+echo "  GitHub synced : ${synced}"
+echo "  KDE/GL noted  : ${skipped}  (handled by mirror pipelines)"
+echo "  Missing forks : ${missing}  (manual fork needed)"
+echo "  Failed        : ${failed}"
+echo "════════════════════════════════════════════════════"
+
+[[ "$failed" -gt 0 ]] && exit 1
+exit 0


### PR DESCRIPTION
## What

Adds tracking and daily sync for the external upstream projects that OSP-bound `Interested-Deving-1896` repos are built from, as declared in each repo's `## Origins` README section.

## Why

The OSP stack is built from ~53 external upstream projects. Most are already forked under `Interested-Deving-1896` but were not being actively synced as a group. This closes that gap and makes the dependency graph machine-readable via the `## Origins` convention.

## Files

### `scripts/patch-origins-sections.sh`
One-shot script that appends a canonical `## Origins` section to the README of every OSP-bound repo that lacks one. Skips repos that already have the section. Triggered via `workflow_dispatch` on the new workflow.

Origins content was derived from reading each repo's structure. Audit findings:
- 52/53 upstream sources already forked under `Interested-Deving-1896`
- Only `kdave/btrfs-devel` was missing (referenced by `btrfs-dwarfs-framework`)
- Only `penguins-recovery` and `lkm` had existing Origins sections; 16 repos needed them added

### `scripts/sync-upstream-sources.sh`
Daily script that reads `## Origins` from all 18 OSP-bound repos, extracts external links (GitHub, `invent.kde.org`, `gitlab.com`), and for each:
- **GitHub forks** — syncs via `merge-upstream`, falls back to force-reset on divergence
- **KDE / GitLab origins** — verifies fork exists; sync delegated to existing KDE/GitLab mirror pipelines
- **Missing forks** — warns with upstream URL; no auto-forking (intentional)

### `.github/workflows/sync-upstream-sources.yml`
Runs `sync-upstream-sources.sh` daily at 01:30 UTC. On `workflow_dispatch` also runs `patch-origins-sections.sh`, with a `dry_run` boolean input.

## First-run order

1. `workflow_dispatch` with `dry_run: true` — verify Origins patches look correct
2. `workflow_dispatch` with `dry_run: false` — commit Origins sections to all repos
3. Scheduled daily runs take over
