### PR TITLE
feat: dep graph, mirror-releases workflow, sync fixes

### DIFF
--- a/.github/workflows/generate-dep-graph.yml
+++ b/.github/workflows/generate-dep-graph.yml
@@ -1,0 +1,43 @@
+name: Generate OSP Dependency Graph
+
+# Reads ## Origins sections from all OSP-bound Interested-Deving-1896 repos
+# and produces three artefacts in dep-graph/:
+#
+#   origins.json  — machine-readable map of repo → origins
+#   origins.md    — human-readable Markdown table
+#   origins.dot   — Graphviz DOT file for visual rendering
+#
+# Runs weekly and on demand. Commits artefacts back to the repo so the
+# graph is always up to date alongside the codebase.
+
+on:
+  schedule:
+    # Weekly on Sunday at 03:00 UTC — after sync-upstream-sources (01:30)
+    # so Origins sections are current before the graph is regenerated.
+    - cron: '0 3 * * 0'
+  workflow_dispatch:
+    inputs:
+      push_to_repo:
+        description: 'Commit artefacts back to fork-sync-all'
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+
+jobs:
+  graph:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Generate dependency graph
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+          GITHUB_OWNER: Interested-Deving-1896
+          OUTPUT_DIR: dep-graph
+          PUSH_TO_REPO: ${{ inputs.push_to_repo || 'true' }}
+        run: bash scripts/generate-dep-graph.sh

--- a/.github/workflows/mirror-releases.yml
+++ b/.github/workflows/mirror-releases.yml
@@ -1,0 +1,51 @@
+name: Mirror Releases
+
+# Mirrors GitHub Releases from Interested-Deving-1896 to OpenOS-Project-OSP
+# and OpenOS-Project-Ecosystem-OOC. For each release not yet present in the
+# mirror org, creates it and re-uploads all release assets. Appends a
+# "Mirrored from" footer to each release body.
+#
+# Skips draft releases. Idempotent — existing releases are not modified.
+#
+# Requires:
+#   SYNC_TOKEN — PAT with repo scope on all three orgs
+
+on:
+  schedule:
+    # Hourly at :20 UTC — after mirror-to-osp (:00) and before
+    # mirror-osp-to-gitlab (:30) so releases are present before GitLab sync.
+    - cron: '20 * * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Report without creating releases'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+# ── Rate limits ───────────────────────────────────────────────────────────────
+# GitHub REST API (SYNC_TOKEN): 5 000 req/hr.
+#   Per repo: 1 call to list upstream releases + 1 to list mirror releases.
+#   Per new release: 1 POST to create + N asset uploads (download + re-upload).
+#   Asset uploads use the uploads.github.com endpoint (separate limit).
+#   With ~35 repos and typically 0–2 new releases per run: well within limits.
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Mirror releases to OSP and OOC
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+          UPSTREAM_OWNER: Interested-Deving-1896
+          OSP_ORG: OpenOS-Project-OSP
+          OOC_ORG: OpenOS-Project-Ecosystem-OOC
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: bash scripts/mirror-releases.sh

--- a/scripts/generate-dep-graph.sh
+++ b/scripts/generate-dep-graph.sh
@@ -1,0 +1,314 @@
+#!/usr/bin/env bash
+#
+# Generates a dependency graph of the OSP stack by reading ## Origins sections
+# from all OSP-bound Interested-Deving-1896 repos.
+#
+# Outputs three artefacts to OUTPUT_DIR (default: dep-graph/):
+#
+#   origins.json      — machine-readable map of repo → [origin, ...]
+#   origins.md        — human-readable Markdown table
+#   origins.dot       — Graphviz DOT file for visual rendering
+#
+# Each origin entry records:
+#   - host (github | kde | gitlab | internal)
+#   - slug (owner/repo)
+#   - url  (canonical upstream URL)
+#   - fork_exists (true/false — whether I-D-1896 has a fork)
+#
+# Required env vars:
+#   GH_TOKEN      — GitHub PAT with repo read scope
+#   GITHUB_OWNER  — org to scan (default: Interested-Deving-1896)
+#
+# Optional env vars:
+#   OUTPUT_DIR    — directory to write artefacts (default: dep-graph)
+#   PUSH_TO_REPO  — set to "true" to commit artefacts back to fork-sync-all
+
+set -uo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+GITHUB_OWNER="${GITHUB_OWNER:-Interested-Deving-1896}"
+OUTPUT_DIR="${OUTPUT_DIR:-dep-graph}"
+PUSH_TO_REPO="${PUSH_TO_REPO:-false}"
+
+GH_API="https://api.github.com"
+HEADER_FILE=$(mktemp)
+trap 'rm -f "$HEADER_FILE"' EXIT
+
+info() { echo "[generate-dep-graph] $*"; }
+warn() { echo "[warn] $*" >&2; }
+
+# ── OSP-bound repo list (from sync-to-gitlab.sh) ─────────────────────────────
+
+OSP_REPOS=(
+  btrfs-dwarfs-framework
+  eggs-ai
+  eggs-gui
+  immutable-linux-framework
+  liquorix-unified-kernel
+  liqxanmod
+  lkf
+  lkm
+  oa-tools
+  penguins-eggs
+  penguins-eggs-audit
+  penguins-eggs-book
+  penguins-incus-platform
+  penguins-kernel-manager
+  penguins-powerwash
+  penguins-recovery
+  ukm
+  xanmod-unified-kernel
+)
+
+# ── GitHub API helper ─────────────────────────────────────────────────────────
+
+gh_api() {
+  local method="$1" url="$2"; shift 2
+  local attempt=0 max_retries=3
+  while true; do
+    local response http_code body
+    response=$(curl -s -w "\n%{http_code}" -X "$method" \
+      -H "Authorization: token ${GH_TOKEN}" \
+      -H "Accept: application/vnd.github+json" \
+      -H "X-GitHub-Api-Version: 2022-11-28" \
+      -D "$HEADER_FILE" \
+      "$@" "$url" 2>/dev/null) || true
+    http_code=$(echo "$response" | tail -1)
+    body=$(echo "$response" | sed '$d')
+    if [[ "$http_code" == "403" || "$http_code" == "429" ]]; then
+      (( attempt++ )) || true
+      [[ $attempt -gt $max_retries ]] && { echo "$body"; return 1; }
+      local reset now wait
+      reset=$(grep -i "x-ratelimit-reset:" "$HEADER_FILE" 2>/dev/null | tr -d '\r' | awk '{print $2}')
+      now=$(date +%s); wait=$(( ${reset:-0} - now + 5 ))
+      [[ "$wait" -gt 0 && "$wait" -lt 3700 ]] && sleep "$wait" || sleep 60
+      continue
+    fi
+    echo "$body"; return 0
+  done
+}
+
+get_readme_text() {
+  local repo="$1"
+  for branch in main master develop; do
+    local info content
+    info=$(gh_api GET "${GH_API}/repos/${GITHUB_OWNER}/${repo}/contents/README.md?ref=${branch}" 2>/dev/null) || continue
+    content=$(echo "$info" | python3 -c \
+      "import sys,json,base64; d=json.load(sys.stdin); print(base64.b64decode(d.get('content','')).decode('utf-8','replace'))" \
+      2>/dev/null) || continue
+    [[ -n "$content" ]] && echo "$content" && return 0
+  done
+  return 1
+}
+
+fork_exists() {
+  local name="$1"
+  local info
+  info=$(gh_api GET "${GH_API}/repos/${GITHUB_OWNER}/${name}" 2>/dev/null) || return 1
+  echo "$info" | python3 -c \
+    "import sys,json; d=json.load(sys.stdin); exit(0 if d.get('name') else 1)" 2>/dev/null
+}
+
+# ── Origins parser (mirrors sync-upstream-sources.sh logic) ──────────────────
+
+parse_origins() {
+  local readme="$1"
+  local origins_block
+  origins_block=$(echo "$readme" | awk '/^## Origins/{f=1;next} f && /^## /{exit} f{print}')
+  [[ -z "$origins_block" ]] && return 0
+
+  # GitHub
+  echo "$origins_block" \
+    | grep -oP 'https://github\.com/[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+' \
+    | sed 's|https://github.com/||' \
+    | sort -u \
+    | while read -r slug; do
+        if echo "$slug" | grep -qi "^${GITHUB_OWNER}/"; then
+          echo "internal|${slug}|https://github.com/${slug}"
+        else
+          echo "github|${slug}|https://github.com/${slug}"
+        fi
+      done
+
+  # KDE Invent
+  echo "$origins_block" \
+    | grep -oP 'https://invent\.kde\.org/[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+' \
+    | sed 's|https://invent.kde.org/||' \
+    | sort -u \
+    | while read -r slug; do echo "kde|${slug}|https://invent.kde.org/${slug}"; done
+
+  # GitLab.com (non-openos-project)
+  echo "$origins_block" \
+    | grep -oP 'https://gitlab\.com/[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+' \
+    | sed 's|https://gitlab.com/||' \
+    | grep -iv "^openos-project/" \
+    | sort -u \
+    | while read -r slug; do echo "gitlab|${slug}|https://gitlab.com/${slug}"; done
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+mkdir -p "$OUTPUT_DIR"
+
+info "Scanning ${#OSP_REPOS[@]} OSP-bound repos..."
+echo ""
+
+# Collect all data into a temp JSON builder
+json_entries="[]"
+md_rows=""
+dot_edges=""
+
+repos_with_origins=0
+repos_without_origins=0
+total_origins=0
+declare -A seen_slugs  # for dedup in DOT/summary
+
+for repo in "${OSP_REPOS[@]}"; do
+  info "── ${repo}"
+
+  readme=$(get_readme_text "$repo") || {
+    warn "  No README — skipping"
+    (( repos_without_origins++ )) || true
+    continue
+  }
+
+  if ! echo "$readme" | grep -q "^## Origins"; then
+    info "  No Origins section (run patch-origins-sections.sh first)"
+    (( repos_without_origins++ )) || true
+    continue
+  fi
+
+  (( repos_with_origins++ )) || true
+
+  repo_origins="[]"
+
+  while IFS='|' read -r host slug url; do
+    [[ -z "$host" || -z "$slug" ]] && continue
+
+    fork_name="${slug##*/}"
+    exists="false"
+    if [[ "$host" == "internal" ]]; then
+      exists="true"
+    elif fork_exists "$fork_name" 2>/dev/null; then
+      exists="true"
+    fi
+
+    info "  ${host}: ${slug} (fork_exists=${exists})"
+    (( total_origins++ )) || true
+
+    # Append to this repo's origins array
+    repo_origins=$(echo "$repo_origins" | python3 -c "
+import json, sys
+arr = json.load(sys.stdin)
+arr.append({'host': '${host}', 'slug': '${slug}', 'url': '${url}', 'fork_exists': ${exists}})
+print(json.dumps(arr))
+")
+
+    # Markdown row
+    host_badge=""
+    case "$host" in
+      github)   host_badge="GitHub" ;;
+      kde)      host_badge="KDE Invent" ;;
+      gitlab)   host_badge="GitLab" ;;
+      internal) host_badge="Internal" ;;
+    esac
+    fork_col="❌"
+    [[ "$exists" == "true" ]] && fork_col="✅"
+    md_rows+="| \`${repo}\` | [${slug}](${url}) | ${host_badge} | ${fork_col} |"$'\n'
+
+    # DOT edge (deduplicate external nodes)
+    dot_node="${slug//\//__}"
+    if [[ "$host" != "internal" ]]; then
+      if [[ ! -v seen_slugs["$slug"] ]]; then
+        seen_slugs["$slug"]=1
+        case "$host" in
+          github) dot_edges+="  \"${dot_node}\" [label=\"${slug}\", shape=box, style=filled, fillcolor=\"#ddeeff\"];"$'\n' ;;
+          kde)    dot_edges+="  \"${dot_node}\" [label=\"${slug}\", shape=box, style=filled, fillcolor=\"#eeddff\"];"$'\n' ;;
+          gitlab) dot_edges+="  \"${dot_node}\" [label=\"${slug}\", shape=box, style=filled, fillcolor=\"#ffeedd\"];"$'\n' ;;
+        esac
+      fi
+      dot_edges+="  \"${repo}\" -> \"${dot_node}\";"$'\n'
+    else
+      dot_edges+="  \"${repo}\" -> \"${slug##*/}\";"$'\n'
+    fi
+
+  done < <(parse_origins "$readme")
+
+  # Append repo entry to master JSON
+  json_entries=$(echo "$json_entries" | python3 -c "
+import json, sys
+arr = json.load(sys.stdin)
+arr.append({'repo': '${repo}', 'origins': $(echo "$repo_origins")})
+print(json.dumps(arr, indent=2))
+")
+
+done
+
+# ── Write origins.json ────────────────────────────────────────────────────────
+
+echo "$json_entries" > "${OUTPUT_DIR}/origins.json"
+info "Written: ${OUTPUT_DIR}/origins.json"
+
+# ── Write origins.md ──────────────────────────────────────────────────────────
+
+cat > "${OUTPUT_DIR}/origins.md" << MDEOF
+# OSP Stack Dependency Graph
+
+Generated: $(date -u '+%Y-%m-%d %H:%M UTC')
+
+| Repo | Origin | Host | Fork in I-D-1896 |
+|------|--------|------|-----------------|
+${md_rows}
+
+## Summary
+
+- OSP-bound repos scanned: **${#OSP_REPOS[@]}**
+- Repos with Origins sections: **${repos_with_origins}**
+- Repos missing Origins sections: **${repos_without_origins}** *(run patch-origins-sections.sh)*
+- Total origin references: **${total_origins}**
+MDEOF
+info "Written: ${OUTPUT_DIR}/origins.md"
+
+# ── Write origins.dot ─────────────────────────────────────────────────────────
+
+cat > "${OUTPUT_DIR}/origins.dot" << DOTEOF
+digraph osp_origins {
+  rankdir=LR;
+  node [fontname="Helvetica", fontsize=10];
+  edge [fontsize=8];
+
+  // OSP-bound repos (source nodes)
+$(for repo in "${OSP_REPOS[@]}"; do
+    echo "  \"${repo}\" [shape=ellipse, style=filled, fillcolor=\"#ddffdd\"];"
+  done)
+
+  // Edges and external nodes
+${dot_edges}
+}
+DOTEOF
+info "Written: ${OUTPUT_DIR}/origins.dot"
+
+# ── Optionally push artefacts back to fork-sync-all ──────────────────────────
+
+if [[ "$PUSH_TO_REPO" == "true" ]]; then
+  info "Committing artefacts to fork-sync-all..."
+  git config user.email "actions@github.com"
+  git config user.name "github-actions[bot]"
+  git add "${OUTPUT_DIR}/"
+  if git diff --cached --quiet; then
+    info "No changes to commit."
+  else
+    git commit -m "chore: update OSP dependency graph [auto]"
+    git push
+    info "Pushed."
+  fi
+fi
+
+echo ""
+echo "════════════════════════════════════════════"
+echo "  generate-dep-graph complete"
+echo "  Repos with Origins : ${repos_with_origins}"
+echo "  Repos missing      : ${repos_without_origins}"
+echo "  Total origins      : ${total_origins}"
+echo "  Output dir         : ${OUTPUT_DIR}/"
+echo "════════════════════════════════════════════"

--- a/scripts/mirror-releases.sh
+++ b/scripts/mirror-releases.sh
@@ -16,6 +16,7 @@ set -uo pipefail
 : "${UPSTREAM_OWNER:?UPSTREAM_OWNER is required}"
 : "${OSP_ORG:?OSP_ORG is required}"
 : "${OOC_ORG:?OOC_ORG is required}"
+DRY_RUN="${DRY_RUN:-false}"
 
 API="https://api.github.com"
 AUTH=(-H "Authorization: token ${GH_TOKEN}" -H "Accept: application/vnd.github+json")
@@ -45,6 +46,7 @@ mirror_releases() {
   local src_org="$1" src_repo="$2" dst_org="$3"
   local tmpdir
   tmpdir=$(mktemp -d)
+  # shellcheck disable=SC2064
   trap "rm -rf '$tmpdir'" RETURN
 
   # Get upstream releases
@@ -80,6 +82,12 @@ mirror_releases() {
     fi
 
     echo "    Mirroring release: $tag ($name)"
+
+    if [[ "${DRY_RUN}" == "true" ]]; then
+      echo "    [dry-run] Would create release ${tag} in ${dst_org}/${src_repo}"
+      (( mirrored++ )) || true
+      continue
+    fi
 
     # Append mirror attribution to body
     local mirror_body
@@ -119,8 +127,7 @@ mirror_releases() {
 
     while IFS= read -r asset_line; do
       [[ -z "$asset_line" ]] && continue
-      local asset_id asset_name content_type download_url
-      asset_id=$(echo "$asset_line" | awk '{print $1}')
+      local asset_name content_type download_url
       asset_name=$(echo "$asset_line" | awk '{print $2}')
       content_type=$(echo "$asset_line" | awk '{print $3}')
       download_url=$(echo "$asset_line" | awk '{print $4}')

--- a/scripts/sync-upstream-sources.sh
+++ b/scripts/sync-upstream-sources.sh
@@ -231,11 +231,13 @@ for repo in "${OSP_REPOS[@]}"; do
     continue
   fi
 
+  origin_count=0
   while IFS='|' read -r host slug; do
     [[ -z "$host" || -z "$slug" ]] && continue
     local_key="${host}|${slug}"
     [[ -v seen_origins["$local_key"] ]] && continue
     seen_origins["$local_key"]=1
+    (( origin_count++ )) || true
 
     fork_name="${slug##*/}"
     info "  ${host}: ${slug}"
@@ -280,6 +282,14 @@ for repo in "${OSP_REPOS[@]}"; do
         ;;
     esac
   done < <(parse_origins "$readme")
+
+  # A repo whose Origins section only references internal I-D-1896 repos
+  # (e.g. lkm = lkf + ukm) will have origin_count=0 here because internal
+  # links are filtered out by parse_origins. That is correct — there are no
+  # external forks to sync for such repos.
+  if echo "$readme" | grep -q "^## Origins" && [[ "${origin_count:-0}" -eq 0 ]]; then
+    info "  Origins section present but all references are internal — nothing to sync"
+  fi
 done
 
 echo ""

--- a/scripts/update-infra-deps.sh
+++ b/scripts/update-infra-deps.sh
@@ -27,6 +27,9 @@
 # Requires:
 #   GH_TOKEN     — PAT with repo + workflow + pull_request scopes on all SCAN_OWNERS
 #   SCAN_OWNERS  — space-separated org/user names to scan
+#                  Defaults (set in update-infra-deps.yml) to all three orgs:
+#                  Interested-Deving-1896 OpenOS-Project-OSP OpenOS-Project-Ecosystem-OOC
+#                  This means fork-sync-all itself is always scanned.
 #
 # Optional:
 #   DRY_RUN      — set to "true" to print changes without creating branches/PRs


### PR DESCRIPTION
## What

Closes 5 of the 7 items identified in the post-session audit. The remaining 2 (patch-origins dry-run and translate-readmes dry-run) require manual `workflow_dispatch` triggers once `SYNC_TOKEN` is available.

---

## Changes

### `scripts/generate-dep-graph.sh` + `.github/workflows/generate-dep-graph.yml`

Reads `## Origins` from all 18 OSP-bound repos and writes three artefacts to `dep-graph/`:

| File | Purpose |
|---|---|
| `origins.json` | Machine-readable map of repo → origins (host, slug, url, fork_exists) |
| `origins.md` | Human-readable Markdown table |
| `origins.dot` | Graphviz DOT file for visual rendering |

Runs weekly Sunday 03:00 UTC (after `sync-upstream-sources` at 01:30 so Origins sections are current). Commits artefacts back to the repo by default. Useful for impact analysis when an upstream releases a breaking change.

### `.github/workflows/mirror-releases.yml`

Wires the existing `mirror-releases.sh` script into a scheduled workflow — it had no trigger before this PR. Runs hourly at :20 UTC, slotted between `mirror-to-osp` (:00) and `mirror-osp-to-gitlab` (:30). Adds `dry_run` input and corresponding `DRY_RUN` support to the script.

### `scripts/sync-upstream-sources.sh`

Adds an explicit log message when a repo's Origins section contains only internal I-D-1896 references (e.g. `lkm` = `lkf` + `ukm`). Zero external syncs is correct for such repos — the message prevents it looking like a silent failure.

### `scripts/update-infra-deps.sh`

Documents in the script header that `SCAN_OWNERS` defaults to all three orgs (including `Interested-Deving-1896` / `fork-sync-all` itself) — confirming the scanner covers its own repo.

---

## Items not in this PR (manual triggers needed)

| Item | Action |
|---|---|
| patch-origins-sections | `workflow_dispatch` on `sync-upstream-sources.yml` with `dry_run: true`, then `false` |
| translate-readmes | `workflow_dispatch` on `translate-readmes.yml` with `dry_run: true` after Origins sections are live |
