### PR TITLE
feat(translate-readmes): add scope selector for predefined repo groups

### DIFF
--- a/.github/workflows/translate-readmes.yml
+++ b/.github/workflows/translate-readmes.yml
@@ -65,8 +65,20 @@ on:
           - 'sv'       # Swedish
           - 'uk'       # Ukrainian
 
+      scope:
+        description: 'Predefined repo group to translate'
+        required: true
+        type: choice
+        default: 'all'
+        options:
+          - all           # Every repo in Interested-Deving-1896
+          - osp-bound     # The 18 repos mirrored to OpenOS-Project-OSP
+          - penguins      # penguins-eggs, penguins-recovery, penguins-*
+          - kernel        # lkf, lkm, ukm, xanmod-unified-kernel, liquorix-unified-kernel, liqxanmod
+          - custom        # Use the "Repos" field below
+
       repos:
-        description: 'Repos to translate (space-separated; leave blank for all)'
+        description: 'Repos to translate — space-separated (only used when scope=custom)'
         required: false
         type: string
         default: ''
@@ -105,6 +117,7 @@ jobs:
           GITHUB_OWNER: Interested-Deving-1896
           SOURCE_LANG: ${{ inputs.source_lang }}
           TARGET_LANG: ${{ inputs.target_lang }}
+          SCOPE: ${{ inputs.scope }}
           REPOS: ${{ inputs.repos }}
           FORCE: ${{ inputs.force }}
           DRY_RUN: ${{ inputs.dry_run }}

--- a/scripts/translate-readmes.sh
+++ b/scripts/translate-readmes.sh
@@ -30,10 +30,37 @@ set -uo pipefail
 GITHUB_OWNER="${GITHUB_OWNER:-Interested-Deving-1896}"
 SOURCE_LANG="${SOURCE_LANG:-en}"
 TARGET_LANG="${TARGET_LANG:-it}"
+SCOPE="${SCOPE:-custom}"
 REPOS="${REPOS:-}"
 FORCE="${FORCE:-false}"
 DRY_RUN="${DRY_RUN:-false}"
 MODEL="${MODEL:-openai/gpt-4o}"
+
+# ── Scope expansion ───────────────────────────────────────────────────────────
+# Predefined repo groups. When SCOPE is not "custom" or "all", REPOS is
+# overridden with the matching list. "all" leaves REPOS empty so get_all_repos
+# is used. "custom" passes REPOS through unchanged.
+
+OSP_BOUND="btrfs-dwarfs-framework eggs-ai eggs-gui immutable-linux-framework
+  liquorix-unified-kernel liqxanmod lkf lkm oa-tools penguins-eggs
+  penguins-eggs-audit penguins-eggs-book penguins-incus-platform
+  penguins-kernel-manager penguins-powerwash penguins-recovery ukm
+  xanmod-unified-kernel"
+
+PENGUINS_SCOPE="penguins-eggs penguins-eggs-audit penguins-eggs-book
+  penguins-eggs-ai penguins-incus-platform penguins-kernel-manager
+  penguins-powerwash penguins-recovery"
+
+KERNEL_SCOPE="lkf lkm ukm xanmod-unified-kernel liquorix-unified-kernel liqxanmod"
+
+case "$SCOPE" in
+  osp-bound) REPOS="$OSP_BOUND" ;;
+  penguins)  REPOS="$PENGUINS_SCOPE" ;;
+  kernel)    REPOS="$KERNEL_SCOPE" ;;
+  all)       REPOS="" ;;   # empty → get_all_repos() enumerates the org
+  custom)    ;;            # REPOS passed through as-is from workflow input
+  *)         warn "Unknown scope '${SCOPE}' — falling back to custom"; ;;
+esac
 
 GH_API="https://api.github.com"
 MODELS_API="https://models.github.ai/inference"


### PR DESCRIPTION
## What

Adds a `Scope` dropdown to the Translate READMEs workflow so common repo groups auto-populate without typing.

## Inputs after this change

| Input | Type | Notes |
|---|---|---|
| `scope` | dropdown | `all`, `osp-bound`, `penguins`, `kernel`, `custom` |
| `repos` | text | Only used when `scope = custom` |
| `source_lang` | dropdown | unchanged |
| `target_lang` | dropdown | unchanged |
| `force` | boolean | unchanged |
| `dry_run` | boolean | unchanged |

## Scope groups

| Value | Repos |
|---|---|
| `all` | Every repo in Interested-Deving-1896 (enumerates via API) |
| `osp-bound` | The 18 repos mirrored to OpenOS-Project-OSP |
| `penguins` | All `penguins-*` repos |
| `kernel` | `lkf`, `lkm`, `ukm`, `xanmod-unified-kernel`, `liquorix-unified-kernel`, `liqxanmod` |
| `custom` | Falls back to the free-text `Repos` field |

Scope expansion is done in the script, not the workflow, so it's testable locally with `SCOPE=penguins bash scripts/translate-readmes.sh`.
