### PR TITLE
feat: add job summary to all 30 workflows

### DIFF
--- a/.github/workflows/add-mirror-repo.yml
+++ b/.github/workflows/add-mirror-repo.yml
@@ -33,3 +33,9 @@ jobs:
           OSP_ORG: OpenOS-Project-OSP
           OOC_ORG: OpenOS-Project-Ecosystem-OOC
         run: bash scripts/add-mirror-repo.sh
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/clone-org.yml
+++ b/.github/workflows/clone-org.yml
@@ -157,3 +157,10 @@ jobs:
           git diff --quiet registered-imports.json || \
             git commit -m "chore: register clone-org imports from ${{ inputs.source_platform }}/${{ inputs.source_org }}" \
               registered-imports.json && git push
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh
+

--- a/.github/workflows/create-readmes.yml
+++ b/.github/workflows/create-readmes.yml
@@ -24,3 +24,9 @@ jobs:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
           GITHUB_OWNER: Interested-Deving-1896
         run: bash scripts/create-readmes.sh
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/generate-dep-graph.yml
+++ b/.github/workflows/generate-dep-graph.yml
@@ -41,3 +41,10 @@ jobs:
           OUTPUT_DIR: dep-graph
           PUSH_TO_REPO: ${{ inputs.push_to_repo || 'true' }}
         run: bash scripts/generate-dep-graph.sh
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh
+

--- a/.github/workflows/import-repo.yml
+++ b/.github/workflows/import-repo.yml
@@ -62,3 +62,9 @@ jobs:
           BITBUCKET_TOKEN: ${{ secrets.BITBUCKET_TOKEN }}
           GITEA_TOKEN: ${{ secrets.GITEA_TOKEN }}
         run: bash scripts/import-repo.sh
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/merge-to-monorepo.yml
+++ b/.github/workflows/merge-to-monorepo.yml
@@ -98,3 +98,10 @@ jobs:
           NPARENT: ${{ inputs.nparent }}
           BRANCH_MAP: ${{ inputs.branch_map }}
         run: bash scripts/merge-to-monorepo.sh
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh
+

--- a/.github/workflows/mirror-artifacts.yml
+++ b/.github/workflows/mirror-artifacts.yml
@@ -62,3 +62,9 @@ jobs:
             exit 0
           fi
           bash scripts/mirror-artifacts.sh
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/mirror-osp-to-gitlab.yml
+++ b/.github/workflows/mirror-osp-to-gitlab.yml
@@ -37,3 +37,9 @@ jobs:
           GITLAB_TOKEN: ${{ secrets.GITLAB_SYNC_TOKEN }}
           OSP_ORG: OpenOS-Project-OSP
         run: bash scripts/mirror-osp-to-gitlab.sh
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/mirror-releases.yml
+++ b/.github/workflows/mirror-releases.yml
@@ -49,3 +49,10 @@ jobs:
           OOC_ORG: OpenOS-Project-Ecosystem-OOC
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: bash scripts/mirror-releases.sh
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh
+

--- a/.github/workflows/mirror-to-osp.yml
+++ b/.github/workflows/mirror-to-osp.yml
@@ -35,3 +35,9 @@ jobs:
           UPSTREAM_OWNER: Interested-Deving-1896
           OSP_ORG: OpenOS-Project-OSP
         run: bash scripts/mirror-to-osp.sh
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/notify-poller.yml
+++ b/.github/workflows/notify-poller.yml
@@ -62,3 +62,10 @@ jobs:
             -d '{"ref":"main"}' \
             && echo "Resolver triggered." \
             || echo "Failed to trigger resolver — will retry on next poll."
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh
+

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -65,3 +65,10 @@ jobs:
           SIZE_THRESHOLDS: ${{ vars.PR_SIZE_THRESHOLDS || '{"xs":10,"s":50,"m":200,"l":500}' }}
           DRY_RUN: 'false'
         run: bash scripts/pr-automation.sh
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh
+

--- a/.github/workflows/rebase-lts.yml
+++ b/.github/workflows/rebase-lts.yml
@@ -43,3 +43,10 @@ jobs:
           FEATURE_BRANCH: ${{ inputs.feature_branch || 'all-features' }}
           LTS_BRANCH: ${{ inputs.lts_branch || 'lts' }}
         run: bash scripts/rebase-lts.sh
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh
+

--- a/.github/workflows/reconcile-org-refs.yml
+++ b/.github/workflows/reconcile-org-refs.yml
@@ -52,3 +52,9 @@ jobs:
           OSP_ORG: OpenOS-Project-OSP
           OOC_ORG: OpenOS-Project-Ecosystem-OOC
         run: bash scripts/reconcile-org-refs.sh
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/repo-manifest.yml
+++ b/.github/workflows/repo-manifest.yml
@@ -126,3 +126,10 @@ jobs:
             git commit -m "chore: update manifest/imports from repo-manifest ${{ inputs.mode }}"
             git push
           fi
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh
+

--- a/.github/workflows/resolve-failures.yml
+++ b/.github/workflows/resolve-failures.yml
@@ -41,3 +41,9 @@ jobs:
             exit 0
           fi
           bash scripts/resolve-failures.sh
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/rotate-token.yml
+++ b/.github/workflows/rotate-token.yml
@@ -62,3 +62,10 @@ jobs:
           VALIDATE: ${{ inputs.validate }}
           REPO: Interested-Deving-1896/fork-sync-all
         run: bash scripts/rotate-token.sh
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh
+

--- a/.github/workflows/setup-osp-mirrors.yml
+++ b/.github/workflows/setup-osp-mirrors.yml
@@ -57,3 +57,9 @@ jobs:
             exit 0
           fi
           bash scripts/reconcile-org-refs.sh
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/sync-eggs-docs-to-book.yml
+++ b/.github/workflows/sync-eggs-docs-to-book.yml
@@ -74,3 +74,9 @@ jobs:
             git push
             echo "Pushed updated chromiumos docs to penguins-eggs-book."
           fi
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/sync-forks.yml
+++ b/.github/workflows/sync-forks.yml
@@ -24,3 +24,9 @@ jobs:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
           GITHUB_OWNER: ${{ github.repository_owner }}
         run: bash scripts/sync-all-forks.sh
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/sync-from-gitlab.yml
+++ b/.github/workflows/sync-from-gitlab.yml
@@ -30,3 +30,9 @@ jobs:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
           GITHUB_OWNER: Interested-Deving-1896
         run: bash scripts/sync-from-gitlab.sh
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/sync-pieroproietti-forks.yml
+++ b/.github/workflows/sync-pieroproietti-forks.yml
@@ -25,3 +25,9 @@ jobs:
           GITHUB_OWNER: ${{ github.repository_owner }}
           UPSTREAM_USER: pieroproietti
         run: bash scripts/sync-pieroproietti-forks.sh
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/sync-registered-imports.yml
+++ b/.github/workflows/sync-registered-imports.yml
@@ -34,3 +34,9 @@ jobs:
           BITBUCKET_TOKEN: ${{ secrets.BITBUCKET_TOKEN }}
           GITEA_TOKEN: ${{ secrets.GITEA_TOKEN }}
         run: bash scripts/sync-registered-imports.sh
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -30,3 +30,9 @@ jobs:
           GITLAB_TOKEN: ${{ secrets.GITLAB_SYNC_TOKEN }}
           GITHUB_OWNER: Interested-Deving-1896
         run: bash scripts/sync-to-gitlab.sh
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/sync-upstream-sources.yml
+++ b/.github/workflows/sync-upstream-sources.yml
@@ -47,6 +47,13 @@ jobs:
           GITHUB_OWNER: Interested-Deving-1896
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: bash scripts/sync-upstream-sources.sh
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh
+
 
   patch-origins:
     runs-on: ubuntu-latest
@@ -64,3 +71,10 @@ jobs:
           GITHUB_OWNER: Interested-Deving-1896
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: bash scripts/patch-origins-sections.sh
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh
+

--- a/.github/workflows/translate-readmes.yml
+++ b/.github/workflows/translate-readmes.yml
@@ -123,3 +123,10 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run }}
           MODEL: openai/gpt-4o
         run: bash scripts/translate-readmes.sh
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh
+

--- a/.github/workflows/update-infra-deps.yml
+++ b/.github/workflows/update-infra-deps.yml
@@ -72,3 +72,10 @@ jobs:
           DRY_RUN:    ${{ inputs.dry_run || 'false' }}
           EOL_WINDOW: ${{ inputs.eol_window || '90' }}
         run: bash scripts/update-infra-deps.sh
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh
+

--- a/.github/workflows/update-readmes.yml
+++ b/.github/workflows/update-readmes.yml
@@ -75,3 +75,9 @@ jobs:
           GITHUB_OWNER: Interested-Deving-1896
           CHANGED_REPOS: ${{ steps.repos.outputs.changed_repos }}
         run: bash scripts/update-readmes.sh
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/upstream-commits.yml
+++ b/.github/workflows/upstream-commits.yml
@@ -42,3 +42,9 @@ jobs:
           UPSTREAM_OWNER: Interested-Deving-1896
           MIRROR_ORGS: "OpenOS-Project-OSP OpenOS-Project-Ecosystem-OOC"
         run: bash scripts/upstream-commits.sh
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/upstream-prs.yml
+++ b/.github/workflows/upstream-prs.yml
@@ -37,3 +37,9 @@ jobs:
           UPSTREAM_OWNER: Interested-Deving-1896
           MIRROR_ORGS: "OpenOS-Project-OSP OpenOS-Project-Ecosystem-OOC"
         run: bash scripts/upstream-prs.sh
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/scripts/write-summary.sh
+++ b/scripts/write-summary.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# Writes a Markdown job summary to $GITHUB_STEP_SUMMARY.
+# Called as the last step of every workflow job via:
+#
+#   - name: Write summary
+#     if: always()
+#     env:
+#       JOB_STATUS: ${{ job.status }}
+#       INPUTS_JSON: ${{ toJSON(inputs) }}
+#     run: bash scripts/write-summary.sh
+#
+# All other values are read from standard GitHub Actions environment
+# variables (GITHUB_WORKFLOW, GITHUB_RUN_NUMBER, etc.) which are always
+# available without explicit env: mapping.
+
+set -uo pipefail
+
+JOB_STATUS="${JOB_STATUS:-unknown}"
+INPUTS_JSON="${INPUTS_JSON:-{}}"
+
+python3 - << PYEOF
+import os, json
+from datetime import datetime, timezone
+
+wf     = os.environ.get("GITHUB_WORKFLOW", "")
+rid    = os.environ.get("GITHUB_RUN_ID", "")
+rnum   = os.environ.get("GITHUB_RUN_NUMBER", "")
+actor  = os.environ.get("GITHUB_ACTOR", "")
+event  = os.environ.get("GITHUB_EVENT_NAME", "")
+ref    = os.environ.get("GITHUB_REF_NAME", "")
+sha    = os.environ.get("GITHUB_SHA", "")[:7]
+repo   = os.environ.get("GITHUB_REPOSITORY", "")
+status = os.environ.get("JOB_STATUS", "unknown")
+inputs_raw = os.environ.get("INPUTS_JSON", "{}")
+now    = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+icon = {"success": "✅", "failure": "❌", "cancelled": "⚠️"}.get(status, "⏳")
+
+try:
+    inputs = json.loads(inputs_raw) or {}
+except Exception:
+    inputs = {}
+
+lines = [
+    f"## {icon} {wf} — Run #{rnum}",
+    "",
+    "| | |",
+    "|---|---|",
+    f"| **Status** | {icon} {status} |",
+    f"| **Triggered by** | {actor} via \`{event}\` |",
+    f"| **Ref** | \`{ref}\` @ \`{sha}\` |",
+    f"| **Time** | {now} |",
+    f"| **Run** | [#{rnum}](https://github.com/{repo}/actions/runs/{rid}) |",
+]
+
+if inputs:
+    lines += ["", "### Inputs", "", "| Input | Value |", "|---|---|"]
+    for k, v in sorted(inputs.items()):
+        lines.append(f"| \`{k}\` | \`{v}\` |")
+
+summary_path = os.environ.get("GITHUB_STEP_SUMMARY", "/dev/null")
+with open(summary_path, "a") as f:
+    f.write("\n".join(lines) + "\n")
+PYEOF


### PR DESCRIPTION
## What

Every workflow run now has a summary page showing what happened and how it was triggered.

## Why

The immediate gap: the Translate READMEs live run had no record of what scope/language was selected, making it impossible to diagnose why no translations were produced.

## How

`scripts/write-summary.sh` — a shared script called as the last step of every job. Reads standard GitHub Actions env vars plus `JOB_STATUS` and `INPUTS_JSON` (passed explicitly since they require expression context). Writes a Markdown table to `$GITHUB_STEP_SUMMARY`.

Each summary shows:

| Field | Example |
|---|---|
| Status | ✅ success |
| Triggered by | Interested-Deving-1896 via `workflow_dispatch` |
| Ref | `main` @ `287f698` |
| Time | 2026-05-14 23:38 UTC |
| Run | link to the run |
| **Inputs** | all `workflow_dispatch` inputs and their values |

The step uses `if: always()` so it runs even when the main script fails — the summary is most useful precisely when something goes wrong.

## Scope

31 files changed: `scripts/write-summary.sh` (new) + all 30 `.github/workflows/*.yml`.
