### PR TITLE
fix(generate-dep-graph): correct Python bool literals and JSON parsing

### DIFF
--- a/scripts/generate-dep-graph.sh
+++ b/scripts/generate-dep-graph.sh
@@ -197,10 +197,10 @@ for repo in "${OSP_REPOS[@]}"; do
     (( total_origins++ )) || true
 
     # Append to this repo's origins array
-    repo_origins=$(echo "$repo_origins" | python3 -c "
-import json, sys
-arr = json.load(sys.stdin)
-arr.append({'host': '${host}', 'slug': '${slug}', 'url': '${url}', 'fork_exists': ${exists}})
+    repo_origins=$(python3 -c "
+import json
+arr = json.loads('''${repo_origins}''')
+arr.append({'host': '${host}', 'slug': '${slug}', 'url': '${url}', 'fork_exists': ${exists^}})
 print(json.dumps(arr))
 ")
 
@@ -235,10 +235,11 @@ print(json.dumps(arr))
   done < <(parse_origins "$readme")
 
   # Append repo entry to master JSON
-  json_entries=$(echo "$json_entries" | python3 -c "
-import json, sys
-arr = json.load(sys.stdin)
-arr.append({'repo': '${repo}', 'origins': $(echo "$repo_origins")})
+  json_entries=$(python3 -c "
+import json
+arr = json.loads('''${json_entries}''')
+origins = json.loads('''${repo_origins}''')
+arr.append({'repo': '${repo}', 'origins': origins})
 print(json.dumps(arr, indent=2))
 ")
 


### PR DESCRIPTION
## Problem

Two non-fatal Python errors fired on every repo during the first `generate-dep-graph` run (run [#25892918162](https://github.com/Interested-Deving-1896/fork-sync-all/actions/runs/25892918162)):

1. `NameError: name 'true' is not defined` — bash `true`/`false` strings were interpolated directly into Python where `True`/`False` is required.
2. `JSONDecodeError: Expecting value` — `repo_origins` and `json_entries` were passed via stdin pipe; if a prior `python3` call failed the variable was left as an empty string, breaking the next `json.load(sys.stdin)` call.

The run still succeeded because errors were non-fatal, but the JSON output had missing `fork_exists` fields and incomplete origin arrays for affected repos.

## Fix

- `${exists^}` — bash first-character capitalise gives `True`/`False`
- Switch both Python snippets from `json.load(sys.stdin)` to `json.loads('''${var}''')` inline, eliminating the stdin dependency entirely
