### PR TITLE
feat: sync kdave/btrfs-devel branches into linux-merge

### DIFF
--- a/.github/workflows/sync-btrfs-devel-branches.yml
+++ b/.github/workflows/sync-btrfs-devel-branches.yml
@@ -1,0 +1,53 @@
+name: Sync btrfs-devel branches
+
+# Fetches master, for-next, misc-next, misc-7.1 from kdave/btrfs-devel and
+# pushes them to Interested-Deving-1896/linux-merge as btrfs-devel/* branches.
+#
+# Background: kdave/btrfs-devel and linux-merge share the same root repo
+# (torvalds/linux). GitHub only allows one fork per root per account, so a
+# separate fork is not possible. Tracking via prefixed branches is the
+# standard workaround.
+#
+# Used by: btrfs-dwarfs-framework kernel module (builds against btrfs headers)
+
+on:
+  schedule:
+    # Daily at 02:30 UTC — after mirror-orgs (02:00) and sync-upstream-sources (01:30)
+    - cron: '30 2 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Fetch but skip push'
+        type: boolean
+        default: false
+      branches:
+        description: 'Space-separated branch list (leave blank for defaults)'
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    name: Sync kdave/btrfs-devel → linux-merge
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout fork-sync-all
+        uses: actions/checkout@v4
+
+      - name: Sync branches
+        env:
+          SYNC_TOKEN: ${{ secrets.SYNC_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          BRANCHES: ${{ inputs.branches }}
+        run: bash scripts/sync-btrfs-devel-branches.sh
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/scripts/sync-btrfs-devel-branches.sh
+++ b/scripts/sync-btrfs-devel-branches.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# Fetches selected integration branches from kdave/btrfs-devel and pushes
+# them to Interested-Deving-1896/linux-merge with a btrfs-devel/ prefix.
+#
+# kdave/btrfs-devel is a fork of torvalds/linux. GitHub only allows one fork
+# of a root repo per account, so linux-merge (also rooted at torvalds/linux)
+# is the correct home for these branches.
+#
+# Branches tracked (stable integration branches only — not dev/wip/fix):
+#   kdave/btrfs-devel:master    → linux-merge:btrfs-devel/master
+#   kdave/btrfs-devel:for-next  → linux-merge:btrfs-devel/for-next
+#   kdave/btrfs-devel:misc-next → linux-merge:btrfs-devel/misc-next
+#   kdave/btrfs-devel:misc-7.1  → linux-merge:btrfs-devel/misc-7.1
+#
+# Required env vars:
+#   SYNC_TOKEN  — PAT with push access to Interested-Deving-1896/linux-merge
+#
+# Optional env vars:
+#   DRY_RUN     — set to "true" to fetch but skip push (default: false)
+#   BRANCHES    — space-separated override list (default: the four above)
+
+set -euo pipefail
+
+: "${SYNC_TOKEN:?SYNC_TOKEN is required}"
+DRY_RUN="${DRY_RUN:-false}"
+
+UPSTREAM="https://github.com/kdave/btrfs-devel.git"
+TARGET="https://x-access-token:${SYNC_TOKEN}@github.com/Interested-Deving-1896/linux-merge.git"
+TARGET_DISPLAY="https://github.com/Interested-Deving-1896/linux-merge"
+PREFIX="btrfs-devel"
+
+DEFAULT_BRANCHES="master for-next misc-next misc-7.1"
+read -ra BRANCHES <<< "${BRANCHES:-${DEFAULT_BRANCHES}}"
+
+info()  { echo "[sync-btrfs-devel] $*"; }
+warn()  { echo "[warn] $*" >&2; }
+
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+info "Cloning linux-merge (bare)..."
+git clone --bare "${TARGET}" "${WORK_DIR}/linux-merge.git" 2>&1
+cd "${WORK_DIR}/linux-merge.git"
+
+info "Fetching branches from kdave/btrfs-devel..."
+git fetch "${UPSTREAM}" "${BRANCHES[@]}" 2>&1
+
+ok=0
+fail=0
+skipped=0
+declare -a RESULTS=()
+
+for branch in "${BRANCHES[@]}"; do
+  target_branch="${PREFIX}/${branch}"
+  info "── ${branch} → ${target_branch}"
+
+  # Get the fetched SHA
+  fetched_sha=$(git rev-parse FETCH_HEAD 2>/dev/null || true)
+  # Re-fetch individually to get per-branch SHA
+  git fetch "${UPSTREAM}" "${branch}" 2>/dev/null
+  fetched_sha=$(git rev-parse FETCH_HEAD)
+  short_sha="${fetched_sha:0:7}"
+
+  # Check if target branch already exists and is up to date
+  existing_sha=$(git rev-parse "refs/heads/${target_branch}" 2>/dev/null || true)
+  if [[ "${existing_sha}" == "${fetched_sha}" ]]; then
+    info "  already up to date (${short_sha})"
+    RESULTS+=("| \`${target_branch}\` | ⏭ up to date | \`${short_sha}\` |")
+    (( skipped++ )) || true
+    continue
+  fi
+
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    info "  [dry-run] would push ${short_sha} → ${TARGET_DISPLAY}:${target_branch}"
+    RESULTS+=("| \`${target_branch}\` | ⏭ dry-run | \`${short_sha}\` |")
+    (( skipped++ )) || true
+    continue
+  fi
+
+  # Update the ref locally then push
+  git update-ref "refs/heads/${target_branch}" "${fetched_sha}"
+  if git push origin "refs/heads/${target_branch}:refs/heads/${target_branch}" --force 2>&1; then
+    info "  pushed ${short_sha}"
+    RESULTS+=("| \`${target_branch}\` | ✅ pushed | \`${short_sha}\` |")
+    (( ok++ )) || true
+  else
+    warn "  push failed for ${target_branch}"
+    RESULTS+=("| \`${target_branch}\` | ❌ push failed | \`${short_sha}\` |")
+    (( fail++ )) || true
+  fi
+done
+
+echo ""
+echo "════════════════════════════════════════════"
+echo "  sync-btrfs-devel-branches complete"
+echo "  Pushed  : ${ok}"
+echo "  Skipped : ${skipped}"
+echo "  Failed  : ${fail}"
+echo "════════════════════════════════════════════"
+
+# Write job summary
+STATUS_ICON="✅"
+[[ "${fail}" -gt 0 ]] && STATUS_ICON="⚠️"
+[[ "${DRY_RUN}" == "true" ]] && STATUS_ICON="⏭"
+
+export SUMMARY_TITLE="Sync btrfs-devel branches ${STATUS_ICON}"
+export SUMMARY_BODY="$(cat <<MDEOF
+**Upstream:** \`kdave/btrfs-devel\` → \`Interested-Deving-1896/linux-merge\` (prefix: \`${PREFIX}/\`)
+
+**Pushed:** ${ok} | **Skipped:** ${skipped} | **Failed:** ${fail}
+$([ "${DRY_RUN}" == "true" ] && echo "_Dry-run — no pushes performed._")
+
+| Branch | Status | SHA |
+|---|---|---|
+$(printf '%s\n' "${RESULTS[@]}")
+MDEOF
+)"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+bash "${SCRIPT_DIR}/write-summary.sh"
+
+[[ "${fail}" -eq 0 ]]


### PR DESCRIPTION
## Problem

`btrfs-dwarfs-framework` lists `kdave/btrfs-devel` as an origin — the kernel module builds against btrfs kernel headers. A separate fork isn't possible because GitHub only allows one fork of a root repo per account, and `linux-merge` already occupies the `torvalds/linux` slot.

## Solution

Track the four stable integration branches from `kdave/btrfs-devel` as prefixed branches on `linux-merge`:

| Upstream | linux-merge branch |
|---|---|
| `kdave/btrfs-devel:master` | `btrfs-devel/master` |
| `kdave/btrfs-devel:for-next` | `btrfs-devel/for-next` |
| `kdave/btrfs-devel:misc-next` | `btrfs-devel/misc-next` |
| `kdave/btrfs-devel:misc-7.1` | `btrfs-devel/misc-7.1` |

Dev/wip/fix branches (30+) are intentionally excluded — only the stable integration branches that `btrfs-dwarfs-framework` would actually build against are tracked.

## What's added

| File | Purpose |
|---|---|
| `scripts/sync-btrfs-devel-branches.sh` | Bare-clones `linux-merge`, fetches each branch from `kdave/btrfs-devel`, pushes with `btrfs-devel/` prefix. Skips if already up to date. |
| `.github/workflows/sync-btrfs-devel-branches.yml` | Daily at 02:30 UTC + `workflow_dispatch` with dry-run and branch override inputs. |

## After merging

Trigger the workflow manually once (dry-run first, then live) to populate the branches on `linux-merge`.
