### PR TITLE
fix(sync-btrfs-devel): use GitHub API instead of git clone

### DIFF
--- a/.github/workflows/sync-btrfs-devel-branches.yml
+++ b/.github/workflows/sync-btrfs-devel-branches.yml
@@ -8,6 +8,10 @@ name: Sync btrfs-devel branches
 # separate fork is not possible. Tracking via prefixed branches is the
 # standard workaround.
 #
+# Implementation: uses the GitHub API only (no git clone). Since both repos
+# are in the same fork network, GitHub's object store already contains all
+# btrfs-devel commits — refs can be created/updated via API directly.
+#
 # Used by: btrfs-dwarfs-framework kernel module (builds against btrfs headers)
 
 on:
@@ -32,7 +36,7 @@ jobs:
   sync:
     name: Sync kdave/btrfs-devel → linux-merge
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 5
 
     steps:
       - name: Checkout fork-sync-all

--- a/scripts/sync-btrfs-devel-branches.sh
+++ b/scripts/sync-btrfs-devel-branches.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 #
-# Fetches selected integration branches from kdave/btrfs-devel and pushes
-# them to Interested-Deving-1896/linux-merge with a btrfs-devel/ prefix.
+# Syncs selected branches from kdave/btrfs-devel into
+# Interested-Deving-1896/linux-merge as btrfs-devel/* refs.
 #
-# kdave/btrfs-devel is a fork of torvalds/linux. GitHub only allows one fork
-# of a root repo per account, so linux-merge (also rooted at torvalds/linux)
-# is the correct home for these branches.
+# Uses the GitHub API exclusively — no git clone required.
+# This works because kdave/btrfs-devel and linux-merge share the same fork
+# network (both rooted at torvalds/linux), so GitHub's object store already
+# contains every commit from btrfs-devel and refs can be created/updated
+# directly via the API.
 #
-# Branches tracked (stable integration branches only — not dev/wip/fix):
+# Branches tracked (stable integration branches only):
 #   kdave/btrfs-devel:master    → linux-merge:btrfs-devel/master
 #   kdave/btrfs-devel:for-next  → linux-merge:btrfs-devel/for-next
 #   kdave/btrfs-devel:misc-next → linux-merge:btrfs-devel/misc-next
@@ -17,7 +19,7 @@
 #   SYNC_TOKEN  — PAT with push access to Interested-Deving-1896/linux-merge
 #
 # Optional env vars:
-#   DRY_RUN     — set to "true" to fetch but skip push (default: false)
+#   DRY_RUN     — set to "true" to report without writing refs (default: false)
 #   BRANCHES    — space-separated override list (default: the four above)
 
 set -euo pipefail
@@ -25,26 +27,30 @@ set -euo pipefail
 : "${SYNC_TOKEN:?SYNC_TOKEN is required}"
 DRY_RUN="${DRY_RUN:-false}"
 
-UPSTREAM="https://github.com/kdave/btrfs-devel.git"
-TARGET="https://x-access-token:${SYNC_TOKEN}@github.com/Interested-Deving-1896/linux-merge.git"
-TARGET_DISPLAY="https://github.com/Interested-Deving-1896/linux-merge"
+UPSTREAM_REPO="kdave/btrfs-devel"
+TARGET_REPO="Interested-Deving-1896/linux-merge"
 PREFIX="btrfs-devel"
+API="https://api.github.com"
 
 DEFAULT_BRANCHES="master for-next misc-next misc-7.1"
 read -ra BRANCHES <<< "${BRANCHES:-${DEFAULT_BRANCHES}}"
 
-info()  { echo "[sync-btrfs-devel] $*"; }
-warn()  { echo "[warn] $*" >&2; }
+info() { echo "[sync-btrfs-devel] $*"; }
+warn() { echo "[warn] $*" >&2; }
 
-WORK_DIR=$(mktemp -d)
-trap 'rm -rf "${WORK_DIR}"' EXIT
-
-info "Cloning linux-merge (bare)..."
-git clone --bare "${TARGET}" "${WORK_DIR}/linux-merge.git" 2>&1
-cd "${WORK_DIR}/linux-merge.git"
-
-info "Fetching branches from kdave/btrfs-devel..."
-git fetch "${UPSTREAM}" "${BRANCHES[@]}" 2>&1
+gh_api() {
+  local method="$1" url="$2"; shift 2
+  local response http_code body
+  response=$(curl -s -w "\n%{http_code}" -X "$method" \
+    -H "Authorization: token ${SYNC_TOKEN}" \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "$@" "$url" 2>/dev/null)
+  http_code=$(echo "$response" | tail -1)
+  body=$(echo "$response" | sed '$d')
+  echo "$body"
+  [[ "$http_code" -ge 200 && "$http_code" -lt 300 ]]
+}
 
 ok=0
 fail=0
@@ -52,64 +58,94 @@ skipped=0
 declare -a RESULTS=()
 
 for branch in "${BRANCHES[@]}"; do
-  target_branch="${PREFIX}/${branch}"
-  info "── ${branch} → ${target_branch}"
+  target_ref="${PREFIX}/${branch}"
+  info "── ${branch} → ${target_ref}"
 
-  # Get the fetched SHA
-  fetched_sha=$(git rev-parse FETCH_HEAD 2>/dev/null || true)
-  # Re-fetch individually to get per-branch SHA
-  git fetch "${UPSTREAM}" "${branch}" 2>/dev/null
-  fetched_sha=$(git rev-parse FETCH_HEAD)
-  short_sha="${fetched_sha:0:7}"
+  # Resolve upstream SHA
+  upstream_data=$(gh_api GET "${API}/repos/${UPSTREAM_REPO}/git/ref/heads/${branch}") || {
+    warn "  could not resolve ${UPSTREAM_REPO}:${branch}"
+    RESULTS+=("| \`${target_ref}\` | ❌ upstream not found | — |")
+    (( fail++ )) || true
+    continue
+  }
+  upstream_sha=$(echo "$upstream_data" | python3 -c \
+    "import sys,json; print(json.load(sys.stdin)['object']['sha'])" 2>/dev/null) || {
+    warn "  could not parse SHA for ${branch}"
+    RESULTS+=("| \`${target_ref}\` | ❌ SHA parse error | — |")
+    (( fail++ )) || true
+    continue
+  }
+  short="${upstream_sha:0:7}"
+  info "  upstream SHA: ${short}"
 
-  # Check if target branch already exists and is up to date
-  existing_sha=$(git rev-parse "refs/heads/${target_branch}" 2>/dev/null || true)
-  if [[ "${existing_sha}" == "${fetched_sha}" ]]; then
-    info "  already up to date (${short_sha})"
-    RESULTS+=("| \`${target_branch}\` | ⏭ up to date | \`${short_sha}\` |")
+  # Check if target ref already exists
+  existing_data=$(gh_api GET "${API}/repos/${TARGET_REPO}/git/ref/heads/${target_ref}" 2>/dev/null || true)
+  existing_sha=$(echo "$existing_data" | python3 -c \
+    "import sys,json; print(json.load(sys.stdin).get('object',{}).get('sha',''))" 2>/dev/null || true)
+
+  if [[ "${existing_sha}" == "${upstream_sha}" ]]; then
+    info "  already up to date"
+    RESULTS+=("| \`${target_ref}\` | ⏭ up to date | \`${short}\` |")
     (( skipped++ )) || true
     continue
   fi
 
   if [[ "${DRY_RUN}" == "true" ]]; then
-    info "  [dry-run] would push ${short_sha} → ${TARGET_DISPLAY}:${target_branch}"
-    RESULTS+=("| \`${target_branch}\` | ⏭ dry-run | \`${short_sha}\` |")
+    if [[ -n "${existing_sha}" ]]; then
+      info "  [dry-run] would update ${existing_sha:0:7} → ${short}"
+    else
+      info "  [dry-run] would create ref at ${short}"
+    fi
+    RESULTS+=("| \`${target_ref}\` | ⏭ dry-run | \`${short}\` |")
     (( skipped++ )) || true
     continue
   fi
 
-  # Update the ref locally then push
-  git update-ref "refs/heads/${target_branch}" "${fetched_sha}"
-  if git push origin "refs/heads/${target_branch}:refs/heads/${target_branch}" --force 2>&1; then
-    info "  pushed ${short_sha}"
-    RESULTS+=("| \`${target_branch}\` | ✅ pushed | \`${short_sha}\` |")
-    (( ok++ )) || true
+  # Create or update the ref
+  if [[ -n "${existing_sha}" ]]; then
+    result=$(gh_api PATCH "${API}/repos/${TARGET_REPO}/git/refs/heads/${target_ref}" \
+      -H "Content-Type: application/json" \
+      -d "{\"sha\":\"${upstream_sha}\",\"force\":true}") || {
+      warn "  PATCH failed for ${target_ref}"
+      RESULTS+=("| \`${target_ref}\` | ❌ update failed | \`${short}\` |")
+      (( fail++ )) || true
+      continue
+    }
+    info "  updated ${existing_sha:0:7} → ${short}"
+    RESULTS+=("| \`${target_ref}\` | ✅ updated | \`${short}\` |")
   else
-    warn "  push failed for ${target_branch}"
-    RESULTS+=("| \`${target_branch}\` | ❌ push failed | \`${short_sha}\` |")
-    (( fail++ )) || true
+    result=$(gh_api POST "${API}/repos/${TARGET_REPO}/git/refs" \
+      -H "Content-Type: application/json" \
+      -d "{\"ref\":\"refs/heads/${target_ref}\",\"sha\":\"${upstream_sha}\"}") || {
+      warn "  POST failed for ${target_ref}"
+      RESULTS+=("| \`${target_ref}\` | ❌ create failed | \`${short}\` |")
+      (( fail++ )) || true
+      continue
+    }
+    info "  created at ${short}"
+    RESULTS+=("| \`${target_ref}\` | ✅ created | \`${short}\` |")
   fi
+  (( ok++ )) || true
 done
 
 echo ""
 echo "════════════════════════════════════════════"
 echo "  sync-btrfs-devel-branches complete"
-echo "  Pushed  : ${ok}"
-echo "  Skipped : ${skipped}"
-echo "  Failed  : ${fail}"
+echo "  Created/updated : ${ok}"
+echo "  Skipped         : ${skipped}"
+echo "  Failed          : ${fail}"
 echo "════════════════════════════════════════════"
 
-# Write job summary
 STATUS_ICON="✅"
 [[ "${fail}" -gt 0 ]] && STATUS_ICON="⚠️"
 [[ "${DRY_RUN}" == "true" ]] && STATUS_ICON="⏭"
 
 export SUMMARY_TITLE="Sync btrfs-devel branches ${STATUS_ICON}"
 export SUMMARY_BODY="$(cat <<MDEOF
-**Upstream:** \`kdave/btrfs-devel\` → \`Interested-Deving-1896/linux-merge\` (prefix: \`${PREFIX}/\`)
+**Upstream:** \`${UPSTREAM_REPO}\` → \`${TARGET_REPO}\` (prefix: \`${PREFIX}/\`)
 
-**Pushed:** ${ok} | **Skipped:** ${skipped} | **Failed:** ${fail}
-$([ "${DRY_RUN}" == "true" ] && echo "_Dry-run — no pushes performed._")
+**Updated:** ${ok} | **Skipped:** ${skipped} | **Failed:** ${fail}
+$([ "${DRY_RUN}" == "true" ] && echo "_Dry-run — no refs written._")
 
 | Branch | Status | SHA |
 |---|---|---|


### PR DESCRIPTION
## Problem

The original implementation bare-cloned `linux-merge` to push 4 branch refs — a ~1–2 GB transfer for a full Linux kernel repo, just to update 4 refs.

## Fix

`kdave/btrfs-devel` and `linux-merge` are in the same GitHub fork network (both rooted at `torvalds/linux`). GitHub's object store already contains every commit from `btrfs-devel`. Refs can be created/updated directly via:

- `POST /repos/{target}/git/refs` — create new branch
- `PATCH /repos/{target}/git/refs/heads/{branch}` — update existing branch

No clone, no checkout, no disk I/O. The workflow timeout drops from 30 min to 5 min.

## Spotted by

User question: "Why are we doing a bare clone of linux-merge? Couldn't we use [xanmod-unified-kernel / liquorix-unified-kernel / liqxanmod] instead?" — those repos are build-system repos, not kernel trees, so they can't host btrfs-devel branches. But the question correctly identified that the clone was unnecessary.
