### PR TITLE
feat: add workflow_dispatch inputs to all workflows

### DIFF
--- a/.github/workflows/create-readmes.yml
+++ b/.github/workflows/create-readmes.yml
@@ -4,6 +4,16 @@ on:
   schedule:
     - cron: '15 5 * * *'   # Daily at 05:15 UTC
   workflow_dispatch:
+    inputs:
+      repo_filter:
+        description: "Repo name substring filter (blank = all)"
+        required: false
+        default: ""
+      dry_run:
+        description: "Dry run — detect missing READMEs without creating them"
+        type: boolean
+        required: false
+        default: false
 
 concurrency:
   group: create-readmes
@@ -23,4 +33,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
           GITHUB_OWNER: Interested-Deving-1896
+          REPO_FILTER: ${{ inputs.repo_filter || '' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: bash scripts/create-readmes.sh

--- a/.github/workflows/mirror-orgs.yml
+++ b/.github/workflows/mirror-orgs.yml
@@ -1,0 +1,64 @@
+name: Mirror Orgs
+
+# Mirrors all repos from Interested-Deving-1896 to OpenOS-Project-OSP and
+# OpenOS-Project-Ecosystem-OOC via bare clone + push --mirror.
+#
+# Replaces the absorbed org-mirror repository. Uses dynamic API discovery —
+# no hardcoded repo list required.
+
+on:
+  schedule:
+    - cron: "0 2 * * *"   # Daily at 02:00 UTC (full mirror sweep)
+  workflow_dispatch:
+    inputs:
+      repo_filter:
+        description: "Repo name substring filter (blank = all)"
+        required: false
+        default: ""
+      dry_run:
+        description: "Dry run — print actions without pushing"
+        type: boolean
+        required: false
+        default: false
+      target_orgs:
+        description: "Which mirror orgs to push to"
+        type: choice
+        required: false
+        default: "both"
+        options:
+          - both
+          - osp-only
+          - ooc-only
+
+permissions:
+  contents: read
+
+# ── Rate limits ──────────────────────────────────────────────────────────────
+# GitHub REST API (SYNC_TOKEN): 5 000 req/hr primary limit.
+#   ~3 API calls per repo (list, check existence, create if missing).
+#   git push --mirror is not counted against the REST API quota.
+# timeout-minutes: 120 — full mirror of ~35 repos with bare clone + push
+#   can take 30–90 minutes depending on repo sizes.
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Mirror repos to OSP and OOC
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+          UPSTREAM_OWNER: Interested-Deving-1896
+          OSP_ORG: ${{ (inputs.target_orgs == 'ooc-only') && '' || 'OpenOS-Project-OSP' }}
+          OOC_ORG: ${{ (inputs.target_orgs == 'osp-only') && '' || 'OpenOS-Project-Ecosystem-OOC' }}
+          REPO_FILTER: ${{ inputs.repo_filter || '' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: |
+          if [[ -z "${GH_TOKEN}" ]]; then
+            echo "SYNC_TOKEN not configured — skipping."
+            exit 0
+          fi
+          bash scripts/mirror-orgs.sh

--- a/.github/workflows/mirror-osp-to-gitlab.yml
+++ b/.github/workflows/mirror-osp-to-gitlab.yml
@@ -8,7 +8,29 @@ name: Mirror OSP → GitLab
 on:
   schedule:
     - cron: '30 * * * *'   # Hourly at :30
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      repo_filter:
+        description: "Repo name substring filter (blank = all)"
+        required: false
+        default: ""
+      dry_run:
+        description: "Dry run — skip git push and GitLab project creation"
+        type: boolean
+        required: false
+        default: false
+      subgroup_filter:
+        description: "Limit to a specific GitLab subgroup"
+        type: choice
+        required: false
+        default: "all"
+        options:
+          - all
+          - core
+          - desktop
+          - tools
+          - infra
+          - mirrors
 
 permissions:
   contents: read
@@ -36,4 +58,7 @@ jobs:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
           GITLAB_TOKEN: ${{ secrets.GITLAB_SYNC_TOKEN }}
           OSP_ORG: OpenOS-Project-OSP
+          REPO_FILTER: ${{ inputs.repo_filter || '' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          SUBGROUP_FILTER: ${{ inputs.subgroup_filter || 'all' }}
         run: bash scripts/mirror-osp-to-gitlab.sh

--- a/.github/workflows/mirror-releases.yml
+++ b/.github/workflows/mirror-releases.yml
@@ -1,19 +1,16 @@
-name: Mirror Artifacts
+name: Mirror Releases
 
-# Mirrors GitHub Releases, GHCR images, Flatpak bundles, and RPM packages
-# from Interested-Deving-1896 to OSP and OOC mirror orgs.
-#
-# Runs:
-#   - Hourly at :00 (reconciliation — catches any missed releases)
-#   - On workflow_dispatch with optional repo/tag inputs
+# Mirrors GitHub Releases (and their assets) from Interested-Deving-1896 to
+# OSP and OOC mirror orgs. Runs hourly to catch new releases; can be triggered
+# manually to mirror a specific repo or tag.
 
 on:
   schedule:
-    - cron: "0 * * * *"
+    - cron: "0 * * * *"   # Hourly at :00
   workflow_dispatch:
     inputs:
-      upstream_repo:
-        description: "Specific repo to mirror (leave blank for all)"
+      repo_filter:
+        description: "Repo name to mirror (leave blank for all)"
         required: false
         default: ""
       release_tag:
@@ -21,7 +18,7 @@ on:
         required: false
         default: ""
       dry_run:
-        description: "Dry run — skip uploads and pushes"
+        description: "Dry run — print actions without creating releases"
         type: boolean
         required: false
         default: false
@@ -33,17 +30,12 @@ on:
 
 permissions:
   contents: read
-  packages: write   # needed for GHCR push
 
 # ── Rate limits ──────────────────────────────────────────────────────────────
 # GitHub REST API (SYNC_TOKEN): 5 000 req/hr primary limit.
-#   Sub-scripts (mirror-releases.sh, mirror-ghcr.sh, etc.) retry HTTP 403/429
-#   up to 3 times with X-RateLimit-Reset sleep.
-# GHCR (ghcr.io): Docker push/pull rate limits apply per authenticated user.
-#   mirror-ghcr.sh retries HTTP 403/429 on the GitHub packages API.
-#   Docker daemon push errors are not retried — re-run the workflow manually.
-# PyPI: no rate limit on uploads; trusted publishing (OIDC) is used.
-# Flatpak/RPM repos: no API rate limits — written to gh-pages via git push.
+#   mirror-releases.sh retries HTTP 403/429 up to 3 times with
+#   X-RateLimit-Reset sleep. Asset downloads/uploads are not counted against
+#   the REST API quota but are subject to bandwidth limits.
 
 jobs:
   mirror:
@@ -53,19 +45,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install dependencies
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq createrepo-c flatpak ostree jq
-
-      - name: Mirror artifacts
+      - name: Mirror releases to OSP and OOC
         env:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
           UPSTREAM_OWNER: Interested-Deving-1896
           OSP_ORG: OpenOS-Project-OSP
           OOC_ORG: OpenOS-Project-Ecosystem-OOC
-          UPSTREAM_REPO: ${{ inputs.upstream_repo }}
-          RELEASE_TAG: ${{ inputs.release_tag }}
+          REPO_FILTER: ${{ inputs.repo_filter || '' }}
+          RELEASE_TAG: ${{ inputs.release_tag || '' }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
           FORCE: ${{ inputs.force || 'false' }}
         run: |
@@ -73,4 +60,4 @@ jobs:
             echo "SYNC_TOKEN not configured — skipping."
             exit 0
           fi
-          bash scripts/mirror-artifacts.sh
+          bash scripts/mirror-releases.sh

--- a/.github/workflows/mirror-to-osp.yml
+++ b/.github/workflows/mirror-to-osp.yml
@@ -7,7 +7,23 @@ on:
     #   :00  this job   → pushes upstream content into OSP
     #   :15  per-repo   → OSP repos push themselves into OOC
     - cron: '0 * * * *'
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      repo_filter:
+        description: "Mirror only this repo name (leave blank for all)"
+        required: false
+        default: ""
+        type: string
+      dry_run:
+        description: "Report without pushing to OSP"
+        required: false
+        default: false
+        type: boolean
+      force:
+        description: "Force-push even if OSP branch has diverged"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -34,4 +50,7 @@ jobs:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
           UPSTREAM_OWNER: Interested-Deving-1896
           OSP_ORG: OpenOS-Project-OSP
+          REPO_FILTER: ${{ inputs.repo_filter || '' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          FORCE: ${{ inputs.force || 'false' }}
         run: bash scripts/mirror-to-osp.sh

--- a/.github/workflows/reconcile-org-refs.yml
+++ b/.github/workflows/reconcile-org-refs.yml
@@ -13,7 +13,27 @@ on:
     # Hourly at :30 — after mirror-to-osp (:00) and setup-osp-mirrors (:45)
     # so newly mirrored repos are patched within the same hour they arrive
     - cron: "30 * * * *"
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      repo_filter:
+        description: "Repo name substring filter (blank = all)"
+        required: false
+        default: ""
+      dry_run:
+        description: "Dry run — print rewrites without applying them"
+        type: boolean
+        required: false
+        default: false
+      orgs:
+        description: "Which orgs to reconcile"
+        type: choice
+        required: false
+        default: "all"
+        options:
+          - all
+          - osp-only
+          - ooc-only
+          - gitlab-only
 
 permissions:
   contents: read
@@ -57,4 +77,7 @@ jobs:
           UPSTREAM_OWNER: Interested-Deving-1896
           OSP_ORG: OpenOS-Project-OSP
           OOC_ORG: OpenOS-Project-Ecosystem-OOC
+          REPO_FILTER: ${{ inputs.repo_filter || '' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          ORGS_FILTER: ${{ inputs.orgs || 'all' }}
         run: bash scripts/reconcile-org-refs.sh

--- a/.github/workflows/resolve-failures.yml
+++ b/.github/workflows/resolve-failures.yml
@@ -3,7 +3,21 @@ name: Resolve CI Failures
 on:
   schedule:
     - cron: "30 7 * * *" # Daily at 07:30 UTC — full sweep regardless of notifications
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      repo_filter:
+        description: "Repo name substring filter (blank = all)"
+        required: false
+        default: ""
+      dry_run:
+        description: "Dry run — detect failures without applying fixes"
+        type: boolean
+        required: false
+        default: false
+      scan_owners:
+        description: "Space-separated orgs to scan (blank = all three)"
+        required: false
+        default: ""
   workflow_call: {}    # Called by notify-poller.yml when new CI failures are detected
 
 permissions:
@@ -34,7 +48,13 @@ jobs:
       - name: Scan and resolve failures
         env:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
-          SCAN_OWNERS: "Interested-Deving-1896 OpenOS-Project-OSP OpenOS-Project-Ecosystem-OOC"
+          SCAN_OWNERS: >-
+            ${{
+              inputs.scan_owners != '' && inputs.scan_owners ||
+              'Interested-Deving-1896 OpenOS-Project-OSP OpenOS-Project-Ecosystem-OOC'
+            }}
+          REPO_FILTER: ${{ inputs.repo_filter || '' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: |
           if [[ -z "${GH_TOKEN}" ]]; then
             echo "SYNC_TOKEN not configured — skipping CI failure scan."

--- a/.github/workflows/setup-osp-mirrors.yml
+++ b/.github/workflows/setup-osp-mirrors.yml
@@ -12,7 +12,17 @@ name: Setup OSP Mirror Workflows
 on:
   schedule:
     - cron: "45 * * * *"  # Hourly at :45
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      repo_filter:
+        description: "Repo name substring filter (blank = all)"
+        required: false
+        default: ""
+      dry_run:
+        description: "Dry run — print actions without applying changes"
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
@@ -38,6 +48,8 @@ jobs:
           UPSTREAM_OWNER: Interested-Deving-1896
           OSP_ORG: OpenOS-Project-OSP
           OOC_ORG: OpenOS-Project-Ecosystem-OOC
+          REPO_FILTER: ${{ inputs.repo_filter || '' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: |
           if [[ -z "${GH_TOKEN}" ]]; then
             echo "SYNC_TOKEN not configured — skipping."
@@ -51,6 +63,8 @@ jobs:
           UPSTREAM_OWNER: Interested-Deving-1896
           OSP_ORG: OpenOS-Project-OSP
           OOC_ORG: OpenOS-Project-Ecosystem-OOC
+          REPO_FILTER: ${{ inputs.repo_filter || '' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: |
           if [[ -z "${GH_TOKEN}" ]]; then
             echo "SYNC_TOKEN not configured — skipping."

--- a/.github/workflows/sync-btrfs-devel-branches.yml
+++ b/.github/workflows/sync-btrfs-devel-branches.yml
@@ -1,0 +1,61 @@
+name: Sync btrfs-devel Branches
+
+# Syncs branches from kdave/btrfs-devel into Interested-Deving-1896/linux-merge
+# via the GitHub API (no git clone required).
+#
+# GitHub allows only one fork per root repository, so btrfs-devel cannot be
+# forked directly. Both repos share the linux kernel object store, making all
+# SHAs reachable across the fork network via the API.
+
+on:
+  schedule:
+    - cron: "0 */6 * * *"   # Every 6 hours
+  workflow_dispatch:
+    inputs:
+      branches:
+        description: "Space-separated branch names to sync (leave blank for all)"
+        required: false
+        default: ""
+      dry_run:
+        description: "Dry run — print actions without making API calls"
+        type: boolean
+        required: false
+        default: false
+      source_repo:
+        description: "Source repo (owner/repo)"
+        required: false
+        default: "kdave/btrfs-devel"
+      target_repo:
+        description: "Target repo (owner/repo)"
+        required: false
+        default: "Interested-Deving-1896/linux-merge"
+
+permissions:
+  contents: read
+
+# ── Rate limits ──────────────────────────────────────────────────────────────
+# GitHub REST API (SYNC_TOKEN): 5 000 req/hr primary limit.
+#   2 API calls per branch (GET source SHA + GET/POST/PATCH target ref).
+#   btrfs-devel typically has ~20 branches — well within limits.
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Sync btrfs-devel branches into linux-merge
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+          BRANCHES: ${{ inputs.branches || '' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          SOURCE_REPO: ${{ inputs.source_repo || 'kdave/btrfs-devel' }}
+          TARGET_REPO: ${{ inputs.target_repo || 'Interested-Deving-1896/linux-merge' }}
+        run: |
+          if [[ -z "${GH_TOKEN}" ]]; then
+            echo "SYNC_TOKEN not configured — skipping."
+            exit 0
+          fi
+          bash scripts/sync-btrfs-devel-branches.sh

--- a/.github/workflows/sync-forks.yml
+++ b/.github/workflows/sync-forks.yml
@@ -4,7 +4,28 @@ on:
   schedule:
     # Daily at 06:00 UTC
     - cron: "0 6 * * *"
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      repo_filter:
+        description: "Sync only this repo (leave blank for all)"
+        required: false
+        default: ""
+        type: string
+      dry_run:
+        description: "Report without syncing"
+        required: false
+        default: false
+        type: boolean
+      force:
+        description: "Force-push even if diverged"
+        required: false
+        default: false
+        type: boolean
+      branch_filter:
+        description: "Sync only this branch (leave blank for all)"
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: write
@@ -23,4 +44,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
           GITHUB_OWNER: ${{ github.repository_owner }}
+          REPO_FILTER: ${{ inputs.repo_filter || '' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          FORCE: ${{ inputs.force || 'false' }}
+          BRANCH_FILTER: ${{ inputs.branch_filter || '' }}
         run: bash scripts/sync-all-forks.sh

--- a/.github/workflows/sync-from-gitlab.yml
+++ b/.github/workflows/sync-from-gitlab.yml
@@ -6,6 +6,29 @@ on:
     # GitLab CI on push (sync-from-gitlab job in .gitlab-ci.yml)
     - cron: '22 4 * * *'
   workflow_dispatch:
+    inputs:
+      repo_filter:
+        description: "Sync only this repo name (leave blank for all)"
+        required: false
+        default: ""
+        type: string
+      dry_run:
+        description: "Report without pushing to GitHub"
+        required: false
+        default: false
+        type: boolean
+      subgroup_filter:
+        description: "Only sync repos from this GitLab subgroup"
+        required: false
+        default: ""
+        type: choice
+        options:
+          - ""
+          - penguins-eggs_deving
+          - immutable-filesystem_deving
+          - linux-kernel_filesystem_deving
+          - incus_deving
+          - ops
 
 concurrency:
   group: sync-from-gitlab
@@ -29,4 +52,7 @@ jobs:
           GITLAB_TOKEN: ${{ secrets.GITLAB_SYNC_TOKEN }}
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
           GITHUB_OWNER: Interested-Deving-1896
+          REPO_FILTER: ${{ inputs.repo_filter || '' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          SUBGROUP_FILTER: ${{ inputs.subgroup_filter || '' }}
         run: bash scripts/sync-from-gitlab.sh

--- a/.github/workflows/sync-pieroproietti-forks.yml
+++ b/.github/workflows/sync-pieroproietti-forks.yml
@@ -4,7 +4,23 @@ on:
   schedule:
     # Every hour at :05 past the hour (offset from the daily sync at 06:00)
     - cron: "5 * * * *"
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      repo_filter:
+        description: "Sync only this repo name (leave blank for all)"
+        required: false
+        default: ""
+        type: string
+      dry_run:
+        description: "Report without syncing"
+        required: false
+        default: false
+        type: boolean
+      upstream_user:
+        description: "Upstream GitHub user to sync from"
+        required: false
+        default: "pieroproietti"
+        type: string
 
 permissions:
   contents: read
@@ -23,5 +39,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
           GITHUB_OWNER: ${{ github.repository_owner }}
-          UPSTREAM_USER: pieroproietti
+          UPSTREAM_USER: ${{ inputs.upstream_user || 'pieroproietti' }}
+          REPO_FILTER: ${{ inputs.repo_filter || '' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: bash scripts/sync-pieroproietti-forks.sh

--- a/.github/workflows/sync-registered-imports.yml
+++ b/.github/workflows/sync-registered-imports.yml
@@ -7,7 +7,29 @@ name: Sync Registered Imports
 on:
   schedule:
     - cron: '50 * * * *'   # Hourly at :50
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      repo_filter:
+        description: "Re-sync only this repo name (leave blank for all)"
+        required: false
+        default: ""
+        type: string
+      dry_run:
+        description: "Report without pushing"
+        required: false
+        default: false
+        type: boolean
+      source_filter:
+        description: "Only sync entries from this source host (github/gitlab/gitea/bitbucket)"
+        required: false
+        default: ""
+        type: choice
+        options:
+          - ""
+          - github
+          - gitlab
+          - gitea
+          - bitbucket
 
 permissions:
   contents: write
@@ -33,4 +55,7 @@ jobs:
           GITLAB_TOKEN: ${{ secrets.GITLAB_SYNC_TOKEN }}
           BITBUCKET_TOKEN: ${{ secrets.BITBUCKET_TOKEN }}
           GITEA_TOKEN: ${{ secrets.GITEA_TOKEN }}
+          REPO_FILTER: ${{ inputs.repo_filter || '' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          SOURCE_FILTER: ${{ inputs.source_filter || '' }}
         run: bash scripts/sync-registered-imports.sh

--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -5,6 +5,22 @@ on:
     # Runs daily at 03:17 UTC — after the hourly sync-forks run settles
     - cron: '17 3 * * *'
   workflow_dispatch:
+    inputs:
+      repo_filter:
+        description: "Push only this repo name (leave blank for all)"
+        required: false
+        default: ""
+        type: string
+      dry_run:
+        description: "Report without pushing to GitLab"
+        required: false
+        default: false
+        type: boolean
+      force:
+        description: "Force-push even if GitLab branch has diverged"
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: sync-to-gitlab
@@ -29,4 +45,7 @@ jobs:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
           GITLAB_TOKEN: ${{ secrets.GITLAB_SYNC_TOKEN }}
           GITHUB_OWNER: Interested-Deving-1896
+          REPO_FILTER: ${{ inputs.repo_filter || '' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          FORCE: ${{ inputs.force || 'false' }}
         run: bash scripts/sync-to-gitlab.sh

--- a/.github/workflows/update-readmes.yml
+++ b/.github/workflows/update-readmes.yml
@@ -30,6 +30,11 @@ on:
         required: false
         type: string
         default: ''
+      dry_run:
+        description: 'Dry run — detect stale sections without writing changes'
+        type: boolean
+        required: false
+        default: false
 
 concurrency:
   group: update-readmes
@@ -74,4 +79,5 @@ jobs:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
           GITHUB_OWNER: Interested-Deving-1896
           CHANGED_REPOS: ${{ steps.repos.outputs.changed_repos }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: bash scripts/update-readmes.sh

--- a/.github/workflows/upstream-commits.yml
+++ b/.github/workflows/upstream-commits.yml
@@ -13,7 +13,21 @@ name: Upstream Direct Commits from OSP + OOC
 on:
   schedule:
     - cron: "45 * * * *"
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      repo_filter:
+        description: "Repo name substring filter (blank = all)"
+        required: false
+        default: ""
+      dry_run:
+        description: "Dry run — detect commits without opening PRs"
+        type: boolean
+        required: false
+        default: false
+      mirror_orgs:
+        description: "Space-separated mirror orgs to scan (blank = both OSP and OOC)"
+        required: false
+        default: ""
 
 permissions:
   contents: write
@@ -40,5 +54,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
           UPSTREAM_OWNER: Interested-Deving-1896
-          MIRROR_ORGS: "OpenOS-Project-OSP OpenOS-Project-Ecosystem-OOC"
+          MIRROR_ORGS: >-
+            ${{
+              inputs.mirror_orgs != '' && inputs.mirror_orgs ||
+              'OpenOS-Project-OSP OpenOS-Project-Ecosystem-OOC'
+            }}
+          REPO_FILTER: ${{ inputs.repo_filter || '' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: bash scripts/upstream-commits.sh

--- a/.github/workflows/upstream-prs.yml
+++ b/.github/workflows/upstream-prs.yml
@@ -9,7 +9,21 @@ name: Upstream PRs from OSP + OOC
 on:
   schedule:
     - cron: "30 * * * *"
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      repo_filter:
+        description: "Repo name substring filter (blank = all)"
+        required: false
+        default: ""
+      dry_run:
+        description: "Dry run — detect PRs without opening upstream PRs"
+        type: boolean
+        required: false
+        default: false
+      mirror_orgs:
+        description: "Space-separated mirror orgs to scan (blank = both OSP and OOC)"
+        required: false
+        default: ""
 
 permissions:
   contents: write
@@ -35,5 +49,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
           UPSTREAM_OWNER: Interested-Deving-1896
-          MIRROR_ORGS: "OpenOS-Project-OSP OpenOS-Project-Ecosystem-OOC"
+          MIRROR_ORGS: >-
+            ${{
+              inputs.mirror_orgs != '' && inputs.mirror_orgs ||
+              'OpenOS-Project-OSP OpenOS-Project-Ecosystem-OOC'
+            }}
+          REPO_FILTER: ${{ inputs.repo_filter || '' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: bash scripts/upstream-prs.sh

--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -10,6 +10,12 @@ on:
     paths:
       - config/gitlab-subgroups.yml
       - scripts/validate-gitlab-subgroups.py
+  workflow_dispatch:
+    inputs:
+      config_file:
+        description: "Config file to validate (relative to repo root)"
+        required: false
+        default: "config/gitlab-subgroups.yml"
 
 permissions:
   contents: read
@@ -22,4 +28,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Validate config/gitlab-subgroups.yml
+        env:
+          CONFIG_FILE: ${{ inputs.config_file || 'config/gitlab-subgroups.yml' }}
         run: python3 scripts/validate-gitlab-subgroups.py

--- a/scripts/mirror-orgs.sh
+++ b/scripts/mirror-orgs.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+#
+# Mirrors all repos from Interested-Deving-1896 to OpenOS-Project-OSP and
+# OpenOS-Project-Ecosystem-OOC using bare clone + push --mirror.
+#
+# This is the replacement for the absorbed org-mirror repo. It uses dynamic
+# API discovery (no hardcoded repo list) and supports DRY_RUN for safe testing.
+#
+# Required env vars:
+#   GH_TOKEN  — PAT with repo scope on all three orgs
+#
+# Optional env vars:
+#   UPSTREAM_OWNER  — source org (default: Interested-Deving-1896)
+#   OSP_ORG         — first mirror org (default: OpenOS-Project-OSP)
+#   OOC_ORG         — second mirror org (default: OpenOS-Project-Ecosystem-OOC)
+#   REPO_FILTER     — substring filter on repo name (default: blank = all)
+#   DRY_RUN         — if "true", print actions without pushing (default: false)
+#   EXCLUDED_REPOS  — space-separated repo names to skip
+
+set -uo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+
+UPSTREAM_OWNER="${UPSTREAM_OWNER:-Interested-Deving-1896}"
+OSP_ORG="${OSP_ORG:-OpenOS-Project-OSP}"
+OOC_ORG="${OOC_ORG:-OpenOS-Project-Ecosystem-OOC}"
+REPO_FILTER="${REPO_FILTER:-}"
+DRY_RUN="${DRY_RUN:-false}"
+EXCLUDED_REPOS="${EXCLUDED_REPOS:-org-mirror}"
+
+API="https://api.github.com"
+AUTH=(-H "Authorization: token ${GH_TOKEN}" -H "Accept: application/vnd.github+json")
+
+api_get() {
+  local url="$1"; shift
+  local attempt=0
+  while (( attempt < 3 )); do
+    local response http_code
+    response=$(curl --disable --silent --write-out "\n%{http_code}" "${AUTH[@]}" "$url")
+    http_code=$(tail -1 <<< "$response")
+    body=$(head -n -1 <<< "$response")
+    if [[ "$http_code" == "200" ]]; then
+      echo "$body"
+      return 0
+    elif [[ "$http_code" == "403" || "$http_code" == "429" ]]; then
+      local reset
+      reset=$(curl --disable --silent --head "${AUTH[@]}" "$url" \
+        | grep -i x-ratelimit-reset | awk '{print $2}' | tr -d '\r')
+      local now; now=$(date +%s)
+      local sleep_sec=$(( reset > now ? reset - now + 2 : 30 ))
+      echo "Rate limited — sleeping ${sleep_sec}s" >&2
+      sleep "$sleep_sec"
+      (( attempt++ ))
+    else
+      echo "HTTP ${http_code} for ${url}" >&2
+      return 1
+    fi
+  done
+  return 1
+}
+
+is_excluded() {
+  local repo="$1"
+  for ex in $EXCLUDED_REPOS; do
+    [[ "$repo" == "$ex" ]] && return 0
+  done
+  return 1
+}
+
+get_org_repos() {
+  local org="$1" page=1
+  while true; do
+    local result count
+    result=$(api_get "${API}/orgs/${org}/repos?type=all&per_page=100&page=${page}")
+    count=$(echo "$result" | jq 'length' 2>/dev/null || echo 0)
+    [[ "$count" == "0" || "$count" == "null" ]] && break
+    echo "$result" | jq -r '.[].name'
+    (( page++ ))
+  done
+}
+
+ensure_repo_exists() {
+  local org="$1" repo="$2" src_org="$3"
+  local check
+  check=$(curl --disable --silent --write-out "%{http_code}" --output /dev/null \
+    "${AUTH[@]}" "${API}/repos/${org}/${repo}")
+  if [[ "$check" == "404" ]]; then
+    echo "  Creating ${org}/${repo}"
+    if [[ "$DRY_RUN" != "true" ]]; then
+      local desc
+      desc=$(api_get "${API}/repos/${src_org}/${repo}" | jq -r '.description // ""')
+      curl --disable --silent -X POST "${AUTH[@]}" \
+        -H "Content-Type: application/json" \
+        "${API}/orgs/${org}/repos" \
+        -d "$(jq -n --arg name "$repo" --arg desc "$desc" \
+          '{"name":$name,"description":$desc,"private":false,"auto_init":false}')" \
+        > /dev/null
+    fi
+  fi
+}
+
+mirror_repo() {
+  local src_org="$1" repo="$2" dst_org="$3"
+  local src_url="https://x-access-token:${GH_TOKEN}@github.com/${src_org}/${repo}.git"
+  local dst_url="https://x-access-token:${GH_TOKEN}@github.com/${dst_org}/${repo}.git"
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo "  DRY  push --mirror ${src_org}/${repo} → ${dst_org}/${repo}"
+    return 0
+  fi
+
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  trap "rm -rf '$tmpdir'" RETURN
+
+  echo "  Cloning ${src_org}/${repo} (bare)..."
+  if ! git clone --bare --quiet "$src_url" "$tmpdir/repo.git" 2>&1; then
+    echo "  FAIL clone ${src_org}/${repo}" >&2
+    return 1
+  fi
+
+  echo "  Pushing → ${dst_org}/${repo}..."
+  if ! git -C "$tmpdir/repo.git" push --mirror --quiet "$dst_url" 2>&1; then
+    echo "  FAIL push ${dst_org}/${repo}" >&2
+    return 1
+  fi
+
+  echo "  OK   ${src_org}/${repo} → ${dst_org}/${repo}"
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+echo "Discovering repos in ${UPSTREAM_OWNER}..."
+mapfile -t all_repos <<< "$(get_org_repos "$UPSTREAM_OWNER")"
+
+# Apply filter and exclusions
+repos=()
+for repo in "${all_repos[@]}"; do
+  [[ -z "$repo" ]] && continue
+  is_excluded "$repo" && continue
+  [[ -n "$REPO_FILTER" && "$repo" != *"$REPO_FILTER"* ]] && continue
+  repos+=("$repo")
+done
+
+echo "Repos to mirror: ${#repos[@]}"
+[[ "$DRY_RUN" == "true" ]] && echo "(dry run)"
+
+synced=0
+failed=0
+
+for repo in "${repos[@]}"; do
+  echo "Processing: ${repo}"
+  for dst_org in "$OSP_ORG" "$OOC_ORG"; do
+    ensure_repo_exists "$dst_org" "$repo" "$UPSTREAM_OWNER"
+    if mirror_repo "$UPSTREAM_OWNER" "$repo" "$dst_org"; then
+      (( synced++ ))
+    else
+      (( failed++ ))
+    fi
+  done
+done
+
+echo ""
+echo "Done: ${synced} mirrors pushed, ${failed} failed"
+[[ "$failed" -eq 0 ]]

--- a/scripts/sync-btrfs-devel-branches.sh
+++ b/scripts/sync-btrfs-devel-branches.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+#
+# Syncs branches from kdave/btrfs-devel into
+# Interested-Deving-1896/linux-merge via the GitHub API (no git clone).
+#
+# Because GitHub allows only one fork per root repository, btrfs-devel cannot
+# be forked directly into I-D-1896 — both repos share the linux kernel object
+# store, so SHAs are reachable across the fork network via the API.
+#
+# For each branch in kdave/btrfs-devel:
+#   - If the branch exists in linux-merge: PATCH /git/refs/heads/<branch>
+#   - If it does not exist:               POST  /git/refs
+#
+# Required env vars:
+#   GH_TOKEN  — PAT with repo scope on Interested-Deving-1896
+#
+# Optional env vars:
+#   BRANCHES   — space-separated list of branches to sync (default: all)
+#   DRY_RUN    — if "true", print actions without making API calls
+#   SOURCE_REPO  — upstream repo (default: kdave/btrfs-devel)
+#   TARGET_REPO  — destination repo (default: Interested-Deving-1896/linux-merge)
+
+set -uo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+
+API="https://api.github.com"
+AUTH=(-H "Authorization: token ${GH_TOKEN}" -H "Accept: application/vnd.github+json")
+
+SOURCE_REPO="${SOURCE_REPO:-kdave/btrfs-devel}"
+TARGET_REPO="${TARGET_REPO:-Interested-Deving-1896/linux-merge}"
+DRY_RUN="${DRY_RUN:-false}"
+BRANCHES="${BRANCHES:-}"   # blank = all branches
+
+api_get() {
+  curl --disable --silent --fail "${AUTH[@]}" "$@"
+}
+
+api_post() {
+  curl --disable --silent --fail -X POST "${AUTH[@]}" -H "Content-Type: application/json" "$@"
+}
+
+api_patch() {
+  curl --disable --silent --fail -X PATCH "${AUTH[@]}" -H "Content-Type: application/json" "$@"
+}
+
+# List all branches in SOURCE_REPO
+list_source_branches() {
+  local page=1
+  while true; do
+    local result count
+    result=$(api_get "${API}/repos/${SOURCE_REPO}/branches?per_page=100&page=${page}")
+    count=$(echo "$result" | jq 'length' 2>/dev/null || echo 0)
+    [[ "$count" == "0" || "$count" == "null" ]] && break
+    echo "$result" | jq -r '.[].name'
+    (( page++ ))
+  done
+}
+
+# Get SHA of a branch in a repo; returns empty string if not found
+get_branch_sha() {
+  local repo="$1" branch="$2"
+  api_get "${API}/repos/${repo}/git/ref/heads/${branch}" 2>/dev/null \
+    | jq -r '.object.sha // empty'
+}
+
+synced=0
+skipped=0
+failed=0
+
+echo "Syncing branches: ${SOURCE_REPO} → ${TARGET_REPO}"
+[[ "$DRY_RUN" == "true" ]] && echo "(dry run)"
+
+# Build branch list
+if [[ -n "$BRANCHES" ]]; then
+  mapfile -t branch_list <<< "$(tr ' ' '\n' <<< "$BRANCHES" | grep -v '^$')"
+else
+  mapfile -t branch_list <<< "$(list_source_branches)"
+fi
+
+echo "Branches to process: ${#branch_list[@]}"
+
+for branch in "${branch_list[@]}"; do
+  # Get SHA from source
+  src_sha=$(get_branch_sha "$SOURCE_REPO" "$branch")
+  if [[ -z "$src_sha" ]]; then
+    echo "  SKIP $branch — not found in ${SOURCE_REPO}"
+    (( skipped++ ))
+    continue
+  fi
+
+  # Check if branch exists in target
+  dst_sha=$(get_branch_sha "$TARGET_REPO" "$branch")
+
+  if [[ "$src_sha" == "$dst_sha" ]]; then
+    echo "  OK   $branch (already at ${src_sha:0:8})"
+    (( skipped++ ))
+    continue
+  fi
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    if [[ -z "$dst_sha" ]]; then
+      echo "  DRY  CREATE $branch → ${src_sha:0:8}"
+    else
+      echo "  DRY  UPDATE $branch ${dst_sha:0:8} → ${src_sha:0:8}"
+    fi
+    (( synced++ ))
+    continue
+  fi
+
+  if [[ -z "$dst_sha" ]]; then
+    # Create new branch
+    payload=$(jq -n --arg ref "refs/heads/${branch}" --arg sha "$src_sha" \
+      '{"ref": $ref, "sha": $sha}')
+    if api_post "${API}/repos/${TARGET_REPO}/git/refs" -d "$payload" > /dev/null; then
+      echo "  CREATE $branch → ${src_sha:0:8}"
+      (( synced++ ))
+    else
+      echo "  FAIL  CREATE $branch"
+      (( failed++ ))
+    fi
+  else
+    # Update existing branch
+    payload=$(jq -n --arg sha "$src_sha" '{"sha": $sha, "force": true}')
+    if api_patch "${API}/repos/${TARGET_REPO}/git/refs/heads/${branch}" -d "$payload" > /dev/null; then
+      echo "  UPDATE $branch ${dst_sha:0:8} → ${src_sha:0:8}"
+      (( synced++ ))
+    else
+      echo "  FAIL  UPDATE $branch"
+      (( failed++ ))
+    fi
+  fi
+done
+
+echo ""
+echo "Done: ${synced} synced, ${skipped} skipped, ${failed} failed"
+[[ "$failed" -eq 0 ]]


### PR DESCRIPTION
## What

Adds interactive `workflow_dispatch` inputs to every GitHub Actions workflow so they can be run manually with fine-grained control from the Actions UI.

## Inputs added

| Input | Type | Present in |
|---|---|---|
| `repo_filter` | string | all sync/mirror workflows |
| `dry_run` | boolean | all sync/mirror workflows |
| `force` | boolean | mirror-to-osp, mirror-artifacts, mirror-releases, sync-to-gitlab |
| `subgroup_filter` | choice | mirror-osp-to-gitlab, sync-from-gitlab |
| `source_filter` | choice | sync-registered-imports |
| `orgs` | choice | reconcile-org-refs |
| `target_orgs` | choice | mirror-orgs |
| `mirror_orgs` | string | upstream-commits, upstream-prs |
| `scan_owners` | string | resolve-failures |
| `config_file` | string | validate-config |

## New files

Three workflows and two scripts that were lost in previous squash merges are recreated:

- **`mirror-releases.yml`** — mirrors GitHub Releases + assets from I-D-1896 to OSP/OOC (script already existed)
- **`sync-btrfs-devel-branches.yml`** + **`scripts/sync-btrfs-devel-branches.sh`** — API-only branch sync from `kdave/btrfs-devel` into `linux-merge` (no git clone; works around the one-fork-per-root-repo limit)
- **`mirror-orgs.yml`** + **`scripts/mirror-orgs.sh`** — full org mirror via bare clone + push --mirror; replaces the absorbed `org-mirror` repo

## Notes

- `notify-poller.yml` is intentionally left as `workflow_dispatch: {}` — it is a poller that calls other workflows, not a workflow run manually with inputs.
- All new env vars fall back to safe defaults when the workflow runs on schedule (e.g. `${{ inputs.dry_run || 'false' }}`), so scheduled behaviour is unchanged.