### PR TITLE
fix: resolve 8 bugs found in audit

### DIFF
--- a/.github/workflows/mirror-orgs-full.yml
+++ b/.github/workflows/mirror-orgs-full.yml
@@ -57,8 +57,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
           UPSTREAM_OWNER: Interested-Deving-1896
-          OSP_ORG: ${{ inputs.target_orgs == 'ooc-only' && '' || 'OpenOS-Project-OSP' }}
-          OOC_ORG: ${{ inputs.target_orgs == 'osp-only' && '' || 'OpenOS-Project-Ecosystem-OOC' }}
+          OSP_ORG: ${{ inputs.target_orgs == 'ooc-only' && 'SKIP' || 'OpenOS-Project-OSP' }}
+          OOC_ORG: ${{ inputs.target_orgs == 'osp-only' && 'SKIP' || 'OpenOS-Project-Ecosystem-OOC' }}
           REPO_FILTER: ${{ inputs.repo_filter || '' }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
           MAX_REPO_SIZE_MB: ${{ inputs.max_repo_size_mb || '500' }}

--- a/.github/workflows/mirror-orgs-watchdog.yml
+++ b/.github/workflows/mirror-orgs-watchdog.yml
@@ -1,6 +1,6 @@
 name: Mirror Watchdog
 
-# Triggers when any of the three mirror workflows fail.
+# Triggers when either mirror workflow fails.
 # Waits 5 minutes (to allow transient GitHub API issues to clear) then
 # retries once. If the retry also fails, the failure surfaces normally
 # in the Actions tab and inbox.
@@ -8,14 +8,12 @@ name: Mirror Watchdog
 # Covered workflows:
 #   Mirror Orgs          (mirror-orgs-full.yml)     — I-D-1896 → OSP + OOC daily
 #   Mirror OSP → GitLab  (mirror-osp-to-gitlab.yml) — OSP → GitLab hourly
-#   Mirror OSP → OOC     (org-mirror)               — legacy per-org mirror
 
 on:
   workflow_run:
     workflows:
       - "Mirror Orgs"
       - "Mirror OSP → GitLab"
-      - "Mirror OSP → OOC"
     types: [completed]
 
 permissions:
@@ -44,8 +42,9 @@ jobs:
           WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
         run: |
           case "$WORKFLOW_NAME" in
+            "Mirror Orgs")         TARGET=mirror-orgs-full.yml ;;
             "Mirror OSP → GitLab") TARGET=mirror-osp-to-gitlab.yml ;;
-            *)                     TARGET=mirror-orgs-full.yml ;;
+            *) echo "Unknown workflow '${WORKFLOW_NAME}' — nothing to retry"; exit 0 ;;
           esac
           echo "Retrying ${TARGET}..."
           gh workflow run "$TARGET" \

--- a/.github/workflows/notify-poller.yml
+++ b/.github/workflows/notify-poller.yml
@@ -58,7 +58,7 @@ jobs:
             -X POST \
             -H "Authorization: token ${GH_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/Interested-Deving-1896/fork-sync-all/actions/workflows/resolve-failures.yml/dispatches" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/workflows/resolve-failures.yml/dispatches" \
             -d '{"ref":"main"}' \
             && echo "Resolver triggered." \
             || echo "Failed to trigger resolver — will retry on next poll."

--- a/.github/workflows/resolve-failures.yml
+++ b/.github/workflows/resolve-failures.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Scan and resolve failures
         env:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+          WATCHDOG_REPO: ${{ github.repository }}
           SCAN_OWNERS: >-
             ${{
               inputs.scan_owners != '' && inputs.scan_owners ||

--- a/.github/workflows/rotate-token.yml
+++ b/.github/workflows/rotate-token.yml
@@ -60,7 +60,7 @@ jobs:
           SECRET_NAME: ${{ inputs.secret_name }}
           TOKEN_VALUE: ${{ inputs.token_value }}
           VALIDATE: ${{ inputs.validate }}
-          REPO: Interested-Deving-1896/fork-sync-all
+          REPO: ${{ github.repository }}
         run: bash scripts/rotate-token.sh
       - name: Write summary
         if: always()

--- a/.github/workflows/setup-osp-mirrors.yml
+++ b/.github/workflows/setup-osp-mirrors.yml
@@ -57,21 +57,6 @@ jobs:
           fi
           bash scripts/setup-osp-mirrors.sh
 
-      - name: Rewrite org references in OSP + OOC mirrors
-        env:
-          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
-          GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
-          UPSTREAM_OWNER: Interested-Deving-1896
-          OSP_ORG: OpenOS-Project-OSP
-          OOC_ORG: OpenOS-Project-Ecosystem-OOC
-          REPO_FILTER: ${{ inputs.repo_filter || '' }}
-          DRY_RUN: ${{ inputs.dry_run || 'false' }}
-        run: |
-          if [[ -z "${GH_TOKEN}" ]]; then
-            echo "SYNC_TOKEN not configured — skipping."
-            exit 0
-          fi
-          bash scripts/reconcile-org-refs.sh
       - name: Write summary
         if: always()
         env:

--- a/.github/workflows/token-health.yml
+++ b/.github/workflows/token-health.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
           GITLAB_TOKEN: ${{ secrets.GITLAB_SYNC_TOKEN }}
-          REPO: Interested-Deving-1896/fork-sync-all
+          REPO: ${{ github.repository }}
           WARN_DAYS: ${{ inputs.warn_days || '30' }}
           STALE_DAYS: ${{ inputs.stale_days || '90' }}
         run: |
@@ -47,7 +47,7 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           existing=$(gh issue list \
-            --repo Interested-Deving-1896/fork-sync-all \
+            --repo "${{ github.repository }}" \
             --label "token-monitor" \
             --state open \
             --json number \
@@ -60,7 +60,7 @@ jobs:
 
           **Quick links:**
           - [View/manage PATs](https://github.com/settings/tokens)
-          - [Rotate Secret Token workflow](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/rotate-token.yml)
+          - [Rotate Secret Token workflow](https://github.com/${{ github.repository }}/actions/workflows/rotate-token.yml)
           - [GitLab PATs](https://gitlab.com/-/user_settings/personal_access_tokens)
 
           _This issue is managed automatically by the Token Monitor workflow. It will be closed when all tokens are healthy._
@@ -72,12 +72,12 @@ jobs:
 
           if [[ -n "$existing" ]]; then
             gh issue comment "$existing" \
-              --repo Interested-Deving-1896/fork-sync-all \
+              --repo "${{ github.repository }}" \
               --body "**Updated $(date -u +%Y-%m-%d):** Token health check re-run. See [run summary](${RUN_URL}) for current status."
             echo "Updated existing issue #${existing}"
           else
             gh issue create \
-              --repo Interested-Deving-1896/fork-sync-all \
+              --repo "${{ github.repository }}" \
               --title "Token Monitor: action required" \
               --body "$body" \
               --label "token-monitor"
@@ -90,7 +90,7 @@ jobs:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
         run: |
           existing=$(gh issue list \
-            --repo Interested-Deving-1896/fork-sync-all \
+            --repo "${{ github.repository }}" \
             --label "token-monitor" \
             --state open \
             --json number \
@@ -98,7 +98,7 @@ jobs:
 
           if [[ -n "$existing" ]]; then
             gh issue close "$existing" \
-              --repo Interested-Deving-1896/fork-sync-all \
+              --repo "${{ github.repository }}" \
               --comment "All tokens are healthy as of $(date -u +%Y-%m-%d). Closing."
             echo "Closed issue #${existing}"
           else

--- a/.github/workflows/update-readmes.yml
+++ b/.github/workflows/update-readmes.yml
@@ -98,7 +98,7 @@ jobs:
             if [[ "$triggering" == "Add Mirror Repo" ]]; then
               # Extract the repo name from the triggering run's inputs via API.
               run_id="${{ github.event.workflow_run.id }}"
-              new_repo=$(gh api "repos/Interested-Deving-1896/fork-sync-all/actions/runs/${run_id}" \
+              new_repo=$(gh api "repos/${{ github.repository }}/actions/runs/${run_id}" \
                 | jq -r '.inputs.repo_url // empty' \
                 | sed 's|.*/||')
               echo "new_repo=${new_repo}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/upstream-prs.yml
+++ b/.github/workflows/upstream-prs.yml
@@ -33,7 +33,7 @@ permissions:
 # ── Rate limits ──────────────────────────────────────────────────────────────
 # GitHub REST API (SYNC_TOKEN): 5 000 req/hr primary limit.
 #   upstream-prs.sh retries HTTP 403/429 up to 3 times with reset-aware sleep.
-#   Runs hourly at :23 — offset from other hourly workflows to spread usage.
+#   Runs hourly at :30 — offset from other hourly workflows to spread usage.
 
 jobs:
   upstream-prs:

--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Validate config/gitlab-subgroups.yml
         env:
           CONFIG_FILE: ${{ inputs.config_file || 'config/gitlab-subgroups.yml' }}
-        run: python3 scripts/validate-gitlab-subgroups.py
+        run: python3 scripts/validate-gitlab-subgroups.py "$CONFIG_FILE"
       - name: Write summary
         if: always()
         env:

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ All schedules are UTC. The hourly chain runs in this order each hour:
 :45  upstream-commits        Direct OSP/OOC commits → PRs in Interested-Deving-1896
 :45  setup-osp-mirrors       Ensure OSP mirror workflows are configured
 :50  reconcile-org-refs      Rewrite org references in OSP + OOC + GitLab
-:50  sync-registered-imports External platform imports re-sync
+:50  sync-registered-imports Re-sync repos registered via import-repo.yml
 ```
 
 Daily jobs run at:
@@ -320,5 +320,5 @@ Per-repo push triggers (so a commit to e.g. `penguins-eggs` on GitLab fires the 
 :30  mirror-osp-to-gitlab.yml  OSP → GitLab openos-project
 :45  upstream-commits.yml      Direct OSP/OOC commits → PRs in Interested-Deving-1896
 :50  reconcile-org-refs.yml    Rewrite org references in OSP + OOC + GitLab
-:50  sync-registered-imports   External platform imports re-sync
+:50  sync-registered-imports   Re-sync repos registered via import-repo.yml
 ```

--- a/scripts/import-repo.sh
+++ b/scripts/import-repo.sh
@@ -100,7 +100,7 @@ echo ""
 # Detect early whether a required token is missing and print the exact
 # command to fix it — before attempting the clone and failing mid-way.
 
-REPO_SLUG="Interested-Deving-1896/fork-sync-all"
+REPO_SLUG="${GITHUB_REPOSITORY:-Interested-Deving-1896/fork-sync-all}"
 
 token_missing_hint() {
   local secret_name="$1" platform_label="$2"

--- a/scripts/mirror-orgs.sh
+++ b/scripts/mirror-orgs.sh
@@ -24,6 +24,10 @@ set -uo pipefail
 UPSTREAM_OWNER="${UPSTREAM_OWNER:-Interested-Deving-1896}"
 OSP_ORG="${OSP_ORG:-OpenOS-Project-OSP}"
 OOC_ORG="${OOC_ORG:-OpenOS-Project-Ecosystem-OOC}"
+# 'SKIP' is the sentinel passed by mirror-orgs-full.yml when osp-only or
+# ooc-only is selected. An empty string can't be used because GHA ternary
+# expressions treat '' as falsy and always evaluate to the else branch.
+# The loop below skips any org set to SKIP.
 REPO_FILTER="${REPO_FILTER:-}"
 DRY_RUN="${DRY_RUN:-false}"
 EXCLUDED_REPOS="${EXCLUDED_REPOS:-org-mirror}"
@@ -176,6 +180,7 @@ for repo in "${repos[@]}"; do
 
   echo "Processing: ${repo}"
   for dst_org in "$OSP_ORG" "$OOC_ORG"; do
+    [[ "$dst_org" == "SKIP" ]] && continue
     ensure_repo_exists "$dst_org" "$repo" "$UPSTREAM_OWNER"
     if mirror_repo "$UPSTREAM_OWNER" "$repo" "$dst_org"; then
       (( synced++ ))

--- a/scripts/sync-to-gitlab.sh
+++ b/scripts/sync-to-gitlab.sh
@@ -28,6 +28,7 @@ set -uo pipefail
 GL_HOST="https://gitlab.com"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 # shellcheck source=scripts/branch-name-conv.sh
 source "${SCRIPT_DIR}/branch-name-conv.sh"
 
@@ -124,7 +125,8 @@ for entry in "${REPOS[@]}"; do
   # GitLab-only branches (all-features, feat/*, lts, openos/ci, etc.) are
   # untouched because we never push a delete instruction for them.
   push_ok=true
-  local attempt=0 max_retries=3
+  attempt=0
+  max_retries=3
   while true; do
     if push_branches_encoded "$gl_url" 2>&1 \
         | sed "s/${GITLAB_TOKEN}/***TOKEN***/g" \
@@ -137,7 +139,7 @@ for entry in "${REPOS[@]}"; do
       push_ok=false
       break
     fi
-    local wait=$(( attempt * 15 ))
+    wait=$(( attempt * 15 ))
     warn "[push-retry] attempt ${attempt}/${max_retries} failed — retrying in ${wait}s"
     sleep "$wait"
   done


### PR DESCRIPTION
Eight bugs identified in a post-merge audit, ranging from hard crashes to silent wrong-behavior.

## Changes

### P1 — Hard crashes

**`scripts/sync-to-gitlab.sh`**
- `REPO_ROOT` was never defined. With `set -uo pipefail` active, bash exited immediately on the first reference — the script has never successfully run since the refactor.
- `local attempt=0` and `local wait=...` appeared in the top-level `for` loop body, not inside a function. Bash rejects `local` outside functions and exits; the retry logic was unreachable.

### P2 — Wrong behavior

**`setup-osp-mirrors.yml`**
- Secret name was `secrets.GITLAB_TOKEN`; the actual secret is `secrets.GITLAB_SYNC_TOKEN` (used correctly in every other workflow). The GitLab URL-rewrite pass in `reconcile-org-refs.sh` has been silently skipped on every run.
- Removed the redundant reconcile step entirely — `reconcile-org-refs.yml` runs the same script at `:50`; running it again at `:45` doubled expensive API calls for no benefit.

**`mirror-orgs-full.yml` + `scripts/mirror-orgs.sh`**
- GHA ternary expressions treat `''` as falsy, so `condition && '' || 'fallback'` always evaluates to `'fallback'`. The `osp-only` and `ooc-only` inputs had no effect — both orgs were always mirrored.
- The script's `:-` fallback compounded this: even if the workflow had passed `''`, the script would have replaced it with the default org name.
- Fixed by using `SKIP` as the sentinel (non-empty, so GHA expressions work) and adding `[[ "$dst_org" == "SKIP" ]] && continue` in the loop.

**`mirror-orgs-watchdog.yml`**
- `"Mirror OSP → OOC"` in the `workflow_run` trigger references a workflow that doesn't exist in this repo. The trigger entry never fired.
- The `case` default (`*`) silently retried `mirror-orgs-full.yml` for any unrecognized name. Made each case explicit; unknown names now `exit 0`.

**`validate-config.yml`**
- `CONFIG_FILE` was set as an env var but `validate-gitlab-subgroups.py` reads `sys.argv[1]`, not `os.environ`. The custom `config_file` input was always ignored; the script always validated the default path.
- Fixed by passing `"$CONFIG_FILE"` as an argument in the `run:` command.

### P3 — Cosmetic / resource waste

**Hardcoded `Interested-Deving-1896/fork-sync-all` references**
- Replaced with `${{ github.repository }}` in `update-readmes.yml`, `notify-poller.yml`, `rotate-token.yml`, `token-health.yml`.
- Added `WATCHDOG_REPO: ${{ github.repository }}` to `resolve-failures.yml` (script already uses `${WATCHDOG_REPO:-...}` fallback for local runs).
- `import-repo.sh`: `REPO_SLUG` now reads `${GITHUB_REPOSITORY:-Interested-Deving-1896/fork-sync-all}`.

**`upstream-prs.yml`**
- Internal comment said `:23` but the cron fires at `:30`. Corrected.