### PR TITLE
fix: resolve 16 bugs from second-pass audit

### DIFF
--- a/.github/workflows/mirror-orgs-watchdog.yml
+++ b/.github/workflows/mirror-orgs-watchdog.yml
@@ -1,17 +1,19 @@
 name: Mirror Watchdog
 
-# Triggers when either mirror workflow fails.
+# Triggers when any of the three mirror workflows fail.
 # Waits 5 minutes (to allow transient GitHub API issues to clear) then
 # retries once. If the retry also fails, the failure surfaces normally
 # in the Actions tab and inbox.
 #
 # Covered workflows:
-#   Mirror Orgs          (mirror-orgs-full.yml)     — I-D-1896 → OSP + OOC daily
-#   Mirror OSP → GitLab  (mirror-osp-to-gitlab.yml) — OSP → GitLab hourly
+#   Mirror Interested-Deving-1896 → OSP  (mirror-to-osp.yml)        — hourly at :00
+#   Mirror Orgs                          (mirror-orgs-full.yml)      — daily at 02:00
+#   Mirror OSP → GitLab                  (mirror-osp-to-gitlab.yml)  — hourly at :30
 
 on:
   workflow_run:
     workflows:
+      - "Mirror Interested-Deving-1896 → OSP"
       - "Mirror Orgs"
       - "Mirror OSP → GitLab"
     types: [completed]
@@ -25,6 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'failure'
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Log failure context
         run: |
           echo "Mirror workflow failed:"
@@ -42,8 +47,9 @@ jobs:
           WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
         run: |
           case "$WORKFLOW_NAME" in
-            "Mirror Orgs")         TARGET=mirror-orgs-full.yml ;;
-            "Mirror OSP → GitLab") TARGET=mirror-osp-to-gitlab.yml ;;
+            "Mirror Interested-Deving-1896 → OSP") TARGET=mirror-to-osp.yml ;;
+            "Mirror Orgs")                         TARGET=mirror-orgs-full.yml ;;
+            "Mirror OSP → GitLab")                 TARGET=mirror-osp-to-gitlab.yml ;;
             *) echo "Unknown workflow '${WORKFLOW_NAME}' — nothing to retry"; exit 0 ;;
           esac
           echo "Retrying ${TARGET}..."

--- a/.github/workflows/resolve-failures.yml
+++ b/.github/workflows/resolve-failures.yml
@@ -18,7 +18,7 @@ on:
         description: "Space-separated orgs to scan (blank = all three)"
         required: false
         default: ""
-  workflow_call: {}    # Called by notify-poller.yml when new CI failures are detected
+  # Note: notify-poller.yml triggers this via REST workflow_dispatch, not workflow_call.
 
 permissions:
   contents: write

--- a/.github/workflows/sync-eggs-docs-to-book.yml
+++ b/.github/workflows/sync-eggs-docs-to-book.yml
@@ -28,6 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - name: Checkout fork-sync-all (for scripts/)
+        uses: actions/checkout@v6
+
       - name: Checkout penguins-eggs-book
         uses: actions/checkout@v6
         with:

--- a/config/gitlab-subgroups.yml
+++ b/config/gitlab-subgroups.yml
@@ -28,7 +28,6 @@ subgroups:
       - penguins-eggs-book
       - penguins-eggs-audit
       - penguins-powerwash
-      - penguins-immutable-framework
       - penguins-incus-platform
       - penguins-kernel-manager
       - eggs-ai

--- a/scripts/mirror-orgs.sh
+++ b/scripts/mirror-orgs.sh
@@ -50,7 +50,7 @@ api_get() {
   local url="$1"; shift
   local attempt=0
   while (( attempt < 3 )); do
-    local response http_code
+    local response http_code body
     response=$(curl --disable --silent --write-out "\n%{http_code}" "${AUTH[@]}" "$url")
     http_code=$(tail -1 <<< "$response")
     body=$(head -n -1 <<< "$response")
@@ -104,12 +104,18 @@ ensure_repo_exists() {
     if [[ "$DRY_RUN" != "true" ]]; then
       local desc
       desc=$(api_get "${API}/repos/${src_org}/${repo}" | jq -r '.description // ""')
-      curl --disable --silent -X POST "${AUTH[@]}" \
+      local create_response create_code
+      create_response=$(curl --disable --silent --write-out "\n%{http_code}" -X POST "${AUTH[@]}" \
         -H "Content-Type: application/json" \
         "${API}/orgs/${org}/repos" \
         -d "$(jq -n --arg name "$repo" --arg desc "$desc" \
-          '{"name":$name,"description":$desc,"private":false,"auto_init":false}')" \
-        > /dev/null
+          '{"name":$name,"description":$desc,"private":false,"auto_init":false}')")
+      create_code=$(tail -1 <<< "$create_response")
+      if [[ "$create_code" != "201" ]]; then
+        echo "  ERROR: failed to create ${org}/${repo} (HTTP ${create_code})" >&2
+        echo "  $(head -n -1 <<< "$create_response" | jq -r '.message // empty' 2>/dev/null)" >&2
+        return 1
+      fi
     fi
   fi
 }

--- a/scripts/mirror-osp-to-gitlab.sh
+++ b/scripts/mirror-osp-to-gitlab.sh
@@ -290,6 +290,18 @@ mirror_repo() {
   $push_ok
 }
 
+# ── Filters (from workflow_dispatch inputs) ───────────────────────────────────
+# REPO_FILTER:     substring — only process repos whose name contains this string
+# SUBGROUP_FILTER: exact subgroup name — only process repos in this subgroup
+# DRY_RUN:         'true' — print actions without pushing or creating projects
+REPO_FILTER="${REPO_FILTER:-}"
+SUBGROUP_FILTER="${SUBGROUP_FILTER:-}"
+DRY_RUN="${DRY_RUN:-false}"
+
+[[ -n "$REPO_FILTER" ]]     && info "Repo filter:     '${REPO_FILTER}'"
+[[ -n "$SUBGROUP_FILTER" ]] && info "Subgroup filter: '${SUBGROUP_FILTER}'"
+[[ "$DRY_RUN" == "true" ]]  && info "Dry run: no pushes or project creation will occur"
+
 # ── main ─────────────────────────────────────────────────────────────────────
 
 synced=0
@@ -309,14 +321,32 @@ for name in "${osp_repos[@]}"; do
     continue
   fi
 
+  # Apply repo name substring filter
+  if [[ -n "$REPO_FILTER" && "$name" != *"$REPO_FILTER"* ]]; then
+    (( skipped++ )) || true
+    continue
+  fi
+
   # Determine target subgroup from config/gitlab-subgroups.yml
   lookup=$(gl_subgroup_lookup "$name")
   namespace_id="${lookup%%|*}"
   subgroup_name="${lookup##*|}"
   ns_path="openos-project/${subgroup_name}/${name}"
 
+  # Apply subgroup filter
+  if [[ -n "$SUBGROUP_FILTER" && "$subgroup_name" != "$SUBGROUP_FILTER" ]]; then
+    (( skipped++ )) || true
+    continue
+  fi
+
   info "──────────────────────────────────────────"
   info "github.com/${OSP_ORG}/${name}  →  gitlab.com/${ns_path}"
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    info "  DRY  would mirror ${name}"
+    (( synced++ )) || true
+    continue
+  fi
 
   # Check if GitLab project exists; create if not
   gl_http_url=$(gl_project_url "$ns_path")

--- a/scripts/mirror-to-osp.sh
+++ b/scripts/mirror-to-osp.sh
@@ -17,6 +17,15 @@ set -uo pipefail
 : "${UPSTREAM_OWNER:?UPSTREAM_OWNER is required}"
 : "${OSP_ORG:?OSP_ORG is required}"
 
+# Optional filters / flags (from workflow_dispatch inputs)
+DRY_RUN="${DRY_RUN:-false}"
+REPO_FILTER="${REPO_FILTER:-}"
+FORCE="${FORCE:-false}"
+
+[[ "$DRY_RUN" == "true" ]] && echo "Dry run — no pushes will occur."
+[[ "$FORCE"   == "true" ]] && echo "Force mode — CI gate bypassed for all repos."
+[[ -n "$REPO_FILTER"    ]] && echo "Repo filter: '${REPO_FILTER}'"
+
 API="https://api.github.com"
 AUTH_HEADER="Authorization: token ${GH_TOKEN}"
 ACCEPT_HEADER="Accept: application/vnd.github+json"
@@ -158,12 +167,24 @@ for name in "${osp_repos[@]}"; do
     continue
   fi
 
+  # Apply repo name substring filter
+  if [[ -n "$REPO_FILTER" && "$name" != *"$REPO_FILTER"* ]]; then
+    (( skipped++ )) || true
+    continue
+  fi
+
   # Check if this repo exists on the upstream — if not, it's OSP-native, skip it
   upstream_info=$(api_get "${API}/repos/${UPSTREAM_OWNER}/${name}" 2>/dev/null)
   upstream_exists=$(echo "$upstream_info" | jq -r '.name // empty' 2>/dev/null)
 
   if [[ -z "$upstream_exists" ]]; then
     (( skipped++ )) || true
+    continue
+  fi
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo "DRY  would mirror ${UPSTREAM_OWNER}/${name} → ${OSP_ORG}/${name}"
+    (( synced++ )) || true
     continue
   fi
 
@@ -174,7 +195,8 @@ for name in "${osp_repos[@]}"; do
   # A repo that fails the gate is skipped this run; the next hourly run
   # will retry once the issue is resolved.
   # Repos in NO_GATE_REPOS bypass this check (private CI infrastructure).
-  if is_no_gate "$name"; then
+  # FORCE=true bypasses the gate for all repos (manual override).
+  if [[ "$FORCE" == "true" ]] || is_no_gate "$name"; then
     echo "Mirroring ${UPSTREAM_OWNER}/${name} → ${OSP_ORG}/${name} (gate bypassed)..."
     if mirror_repo "$name"; then
       (( synced++ )) || true

--- a/scripts/reconcile-org-refs.sh
+++ b/scripts/reconcile-org-refs.sh
@@ -35,6 +35,18 @@ set -euo pipefail
 # GITLAB_TOKEN is optional — GitLab pass is skipped if absent
 GITLAB_TOKEN="${GITLAB_TOKEN:-}"
 
+# ORGS_FILTER controls which passes run (from workflow_dispatch input):
+#   all          — run all three passes (default)
+#   osp-only     — org-ref + label passes only (no GitLab pass)
+#   ooc-only     — org-ref + label passes only (no GitLab pass)
+#   gitlab-only  — GitLab pass only
+ORGS_FILTER="${ORGS_FILTER:-all}"
+# REPO_FILTER: substring — only process repos whose name contains this string
+REPO_FILTER="${REPO_FILTER:-}"
+
+[[ "$ORGS_FILTER" != "all" ]] && echo "Orgs filter: ${ORGS_FILTER}"
+[[ -n "$REPO_FILTER" ]]       && echo "Repo filter: ${REPO_FILTER}"
+
 API="https://api.github.com"
 AUTH="Authorization: token ${GH_TOKEN}"
 
@@ -47,14 +59,18 @@ api_put() { curl -sf -X PUT -H "$AUTH" -H "Accept: application/vnd.github+json" 
               -H "Content-Type: application/json" "$@"; }
 
 rate_wait() {
-  local remaining reset now wait_sec
-  remaining=$(curl -sf -H "$AUTH" "$API/rate_limit" | python3 -c "import sys,json; print(json.load(sys.stdin)['resources']['core']['remaining'])")
+  local remaining reset now wait_sec rate_json
+  # Suppress errors — a transient curl/parse failure should not abort the run
+  rate_json=$(curl -sf -H "$AUTH" "$API/rate_limit" 2>/dev/null || true)
+  remaining=$(echo "$rate_json" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['resources']['core']['remaining'])" 2>/dev/null || echo "100")
   if [ "$remaining" -lt 50 ]; then
-    reset=$(curl -sf -H "$AUTH" "$API/rate_limit" | python3 -c "import sys,json; print(json.load(sys.stdin)['resources']['core']['reset'])")
+    reset=$(echo "$rate_json" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['resources']['core']['reset'])" 2>/dev/null || echo "0")
     now=$(date +%s)
     wait_sec=$(( reset - now + 5 ))
-    echo "  [rate-limit] only $remaining requests left — sleeping ${wait_sec}s"
-    sleep "$wait_sec"
+    if [ "$wait_sec" -gt 0 ]; then
+      echo "  [rate-limit] only $remaining requests left — sleeping ${wait_sec}s"
+      sleep "$wait_sec"
+    fi
   fi
 }
 
@@ -226,18 +242,51 @@ repo_exists() {
 # ---------------------------------------------------------------------------
 # Main loop — iterate over OSP repos, process only those also in UPSTREAM
 # ---------------------------------------------------------------------------
+if [[ "$ORGS_FILTER" == "gitlab-only" ]]; then
+  echo "Skipping org-ref and label passes (orgs filter: gitlab-only)."
+  OSP_REPOS=""
+else
+
 echo ""
 echo "Fetching OSP repo list..."
-OSP_REPOS=$(api_get "$API/orgs/$OSP_ORG/repos?per_page=100&type=all" | \
-  python3 -c "import sys,json; [print(r['name']) for r in json.load(sys.stdin)]" 2>/dev/null || true)
+OSP_REPOS=""
+_page=1
+while true; do
+  _batch=$(api_get "$API/orgs/$OSP_ORG/repos?per_page=100&page=${_page}&type=all" | \
+    python3 -c "import sys,json; repos=json.load(sys.stdin); [print(r['name']) for r in repos]; print('__COUNT__'+str(len(repos)),end='')" \
+    2>/dev/null || true)
+  _count=$(echo "$_batch" | grep -o '__COUNT__[0-9]*' | grep -o '[0-9]*' || echo 0)
+  _names=$(echo "$_batch" | grep -v '__COUNT__')
+  OSP_REPOS="${OSP_REPOS}${_names}"$'\n'
+  [[ "$_count" -lt 100 ]] && break
+  (( _page++ ))
+done
+OSP_REPOS=$(echo "$OSP_REPOS" | grep -v '^$' || true)
 
 if [ -z "$OSP_REPOS" ]; then
-  # Fallback: GraphQL (handles user accounts too)
-  OSP_REPOS=$(curl -sf -H "Authorization: bearer $GH_TOKEN" \
-    -H "Content-Type: application/json" \
-    -X POST "$API/graphql" \
-    -d '{"query":"{ organization(login: \"'"$OSP_ORG"'\") { repositories(first: 100) { nodes { name } } } }"}' | \
-    python3 -c "import sys,json; d=json.load(sys.stdin); [print(n['name']) for n in d['data']['organization']['repositories']['nodes']]")
+  # Fallback: GraphQL with pagination (handles user accounts too)
+  _cursor=""
+  while true; do
+    _after=$( [[ -n "$_cursor" ]] && echo ", after: \"${_cursor}\"" || echo "" )
+    _gql_result=$(curl -sf -H "Authorization: bearer $GH_TOKEN" \
+      -H "Content-Type: application/json" \
+      -X POST "$API/graphql" \
+      -d "{\"query\":\"{ organization(login: \\\"${OSP_ORG}\\\") { repositories(first: 100${_after}) { nodes { name } pageInfo { hasNextPage endCursor } } } }\"}" \
+      2>/dev/null || true)
+    _batch_names=$(echo "$_gql_result" | python3 -c \
+      "import sys,json; d=json.load(sys.stdin); [print(n['name']) for n in d['data']['organization']['repositories']['nodes']]" \
+      2>/dev/null || true)
+    OSP_REPOS="${OSP_REPOS}${_batch_names}"$'\n'
+    _has_next=$(echo "$_gql_result" | python3 -c \
+      "import sys,json; d=json.load(sys.stdin); print(d['data']['organization']['repositories']['pageInfo']['hasNextPage'])" \
+      2>/dev/null || echo "False")
+    [[ "$_has_next" != "True" ]] && break
+    _cursor=$(echo "$_gql_result" | python3 -c \
+      "import sys,json; d=json.load(sys.stdin); print(d['data']['organization']['repositories']['pageInfo']['endCursor'])" \
+      2>/dev/null || true)
+    [[ -z "$_cursor" ]] && break
+  done
+  OSP_REPOS=$(echo "$OSP_REPOS" | grep -v '^$' || true)
 fi
 
 echo "OSP repos found: $(echo "$OSP_REPOS" | wc -l)"
@@ -246,6 +295,11 @@ echo ""
 for REPO in $OSP_REPOS; do
   # Skip fork-sync-all itself to avoid self-modification loops
   [ "$REPO" = "fork-sync-all" ] && continue
+
+  # Apply repo name substring filter
+  if [[ -n "$REPO_FILTER" && "$REPO" != *"$REPO_FILTER"* ]]; then
+    continue
+  fi
 
   # Only process repos that also exist in Interested-Deving-1896
   if ! repo_exists "$UPSTREAM_OWNER" "$REPO"; then
@@ -457,6 +511,7 @@ echo ""
 
 for REPO in $OSP_REPOS; do
   [ "$REPO" = "fork-sync-all" ] && continue
+  [[ -n "$REPO_FILTER" && "$REPO" != *"$REPO_FILTER"* ]] && continue
   ! repo_exists "$UPSTREAM_OWNER" "$REPO" && continue
 
   echo "=== $REPO (label conversion) ==="
@@ -467,6 +522,8 @@ for REPO in $OSP_REPOS; do
 done
 
 rm -f "$BUILD_PATCHER"
+
+fi  # end: [[ "$ORGS_FILTER" != "gitlab-only" ]]
 
 # ---------------------------------------------------------------------------
 # GitLab pass — rewrite GitHub org URLs to their gitlab.com equivalents
@@ -487,6 +544,13 @@ rm -f "$BUILD_PATCHER"
 # If GITLAB_TOKEN is absent the pass is skipped non-fatally (same pattern
 # as mirror-osp-to-gitlab.sh).
 # ---------------------------------------------------------------------------
+
+if [[ "$ORGS_FILTER" == "osp-only" || "$ORGS_FILTER" == "ooc-only" ]]; then
+  echo ""
+  echo "Skipping GitLab pass (orgs filter: ${ORGS_FILTER})."
+  echo "Done."
+  exit 0
+fi
 
 if [ -z "${GITLAB_TOKEN:-}" ]; then
   echo ""
@@ -682,6 +746,7 @@ echo ""
 
 for REPO in $OSP_REPOS; do
   [ "$REPO" = "fork-sync-all" ] && continue
+  [[ -n "$REPO_FILTER" && "$REPO" != *"$REPO_FILTER"* ]] && continue
 
   # Only process repos that exist in I-D-1896 (same filter as GitHub passes)
   if ! repo_exists "$UPSTREAM_OWNER" "$REPO"; then

--- a/scripts/sync-all-forks.sh
+++ b/scripts/sync-all-forks.sh
@@ -8,6 +8,17 @@ set -uo pipefail
 : "${GH_TOKEN:?GH_TOKEN is required}"
 : "${GITHUB_OWNER:?GITHUB_OWNER is required}"
 
+# Optional filters / flags (from workflow_dispatch inputs)
+DRY_RUN="${DRY_RUN:-false}"
+REPO_FILTER="${REPO_FILTER:-}"
+FORCE="${FORCE:-false}"
+BRANCH_FILTER="${BRANCH_FILTER:-}"
+
+[[ "$DRY_RUN"   == "true" ]] && echo "Dry run — no changes will be made."
+[[ "$FORCE"     == "true" ]] && echo "Force mode — diverged branches will be reset to upstream."
+[[ -n "$REPO_FILTER"      ]] && echo "Repo filter:   '${REPO_FILTER}'"
+[[ -n "$BRANCH_FILTER"    ]] && echo "Branch filter: '${BRANCH_FILTER}'"
+
 API="https://api.github.com"
 PER_PAGE=100
 HEADER_FILE=$(mktemp)
@@ -250,6 +261,13 @@ for line in "${fork_lines[@]}"; do
 
   [[ -z "$fork" ]] && continue
 
+  # Apply repo name substring filter
+  repo_name="${fork##*/}"
+  if [[ -n "$REPO_FILTER" && "$repo_name" != *"$REPO_FILTER"* ]]; then
+    (( skipped++ ))
+    continue
+  fi
+
   echo "[${current}/${total}] Syncing ${fork}..."
 
   if [[ -z "$upstream" || "$upstream" == "null" ]]; then
@@ -264,6 +282,19 @@ for line in "${fork_lines[@]}"; do
     continue
   fi
 
+  # Apply branch filter — skip if this repo's default branch doesn't match
+  if [[ -n "$BRANCH_FILTER" && "$default_branch" != "$BRANCH_FILTER" ]]; then
+    echo "  Branch '${default_branch}' does not match filter '${BRANCH_FILTER}' — skipping."
+    (( skipped++ ))
+    continue
+  fi
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo "  DRY  would sync ${fork}:${default_branch} from ${upstream}"
+    (( synced++ ))
+    continue
+  fi
+
   # Sync default branch via merge-upstream (single API call)
   rc=0
   sync_default_branch "$fork" "$default_branch" || rc=$?
@@ -271,6 +302,27 @@ for line in "${fork_lines[@]}"; do
   if [[ "$rc" -eq 0 ]]; then
     (( synced++ ))
     echo "  done."
+  elif [[ "$FORCE" == "true" ]]; then
+    # Force-reset: get upstream SHA and PATCH the ref directly
+    echo "  Merge failed — force-resetting to upstream HEAD..."
+    upstream_sha=$(gh_api GET "${API}/repos/${upstream}/git/ref/heads/${default_branch}" \
+      | jq -r '.object.sha // empty' 2>/dev/null || true)
+    if [[ -n "$upstream_sha" ]]; then
+      force_result=$(gh_api PATCH "${API}/repos/${fork}/git/refs/heads/${default_branch}" \
+        -H "Content-Type: application/json" \
+        -d "{\"sha\":\"${upstream_sha}\",\"force\":true}") || true
+      force_sha=$(echo "$force_result" | jq -r '.object.sha // empty' 2>/dev/null || true)
+      if [[ "$force_sha" == "$upstream_sha" ]]; then
+        echo "  Force-reset to ${upstream_sha:0:8} — done."
+        (( synced++ ))
+      else
+        echo "  Force-reset failed."
+        (( failed++ ))
+      fi
+    else
+      echo "  Could not get upstream SHA for force-reset."
+      (( failed++ ))
+    fi
   else
     (( failed++ ))
   fi

--- a/scripts/sync-btrfs-devel-branches.sh
+++ b/scripts/sync-btrfs-devel-branches.sh
@@ -57,11 +57,12 @@ list_source_branches() {
   done
 }
 
-# Get SHA of a branch in a repo; returns empty string if not found
+# Get SHA of a branch in a repo; returns empty string if not found.
+# curl --fail exits 22 on 404; suppress that so set -e doesn't abort the caller.
 get_branch_sha() {
   local repo="$1" branch="$2"
   api_get "${API}/repos/${repo}/git/ref/heads/${branch}" 2>/dev/null \
-    | jq -r '.object.sha // empty'
+    | jq -r '.object.sha // empty' || true
 }
 
 synced=0

--- a/scripts/sync-from-gitlab.sh
+++ b/scripts/sync-from-gitlab.sh
@@ -28,13 +28,33 @@ GL_API="https://gitlab.com/api/v4"
 GH_API="https://api.github.com"
 
 # Subgroup IDs to scan (all openos-project subgroups that hold OSP-equivalent repos)
-SUBGROUP_IDS=(
-  130516402   # penguins-eggs_deving
-  130516465   # immutable-filesystem_deving
-  130516536   # incus_deving
-  130516188   # linux-kernel_filesystem_deving
-  130734009   # ops
+declare -A SUBGROUP_NAME_TO_ID=(
+  [penguins-eggs_deving]=130516402
+  [immutable-filesystem_deving]=130516465
+  [incus_deving]=130516536
+  [linux-kernel_filesystem_deving]=130516188
+  [ops]=130734009
 )
+
+# SUBGROUP_FILTER: if set, only scan the named subgroup (from workflow_dispatch input)
+SUBGROUP_FILTER="${SUBGROUP_FILTER:-}"
+
+if [[ -n "$SUBGROUP_FILTER" ]]; then
+  if [[ -z "${SUBGROUP_NAME_TO_ID[$SUBGROUP_FILTER]+x}" ]]; then
+    echo "ERROR: Unknown subgroup filter '${SUBGROUP_FILTER}'. Valid values: ${!SUBGROUP_NAME_TO_ID[*]}" >&2
+    exit 1
+  fi
+  SUBGROUP_IDS=( "${SUBGROUP_NAME_TO_ID[$SUBGROUP_FILTER]}" )
+  info "Subgroup filter: ${SUBGROUP_FILTER} (id=${SUBGROUP_IDS[0]})"
+else
+  SUBGROUP_IDS=(
+    130516402   # penguins-eggs_deving
+    130516465   # immutable-filesystem_deving
+    130516536   # incus_deving
+    130516188   # linux-kernel_filesystem_deving
+    130734009   # ops
+  )
+fi
 
 # Repos to never push to GitHub (GitLab-native infra, no GitHub counterpart intended)
 EXCLUDED_REPOS=(

--- a/scripts/sync-upstream-sources.sh
+++ b/scripts/sync-upstream-sources.sh
@@ -65,27 +65,52 @@ gh_api() {
 }
 
 # ── OSP-bound repo list ───────────────────────────────────────────────────────
-# Repos mirrored from I-D-1896 to OpenOS-Project-OSP (from sync-to-gitlab.sh).
-OSP_REPOS=(
-  btrfs-dwarfs-framework
-  eggs-ai
-  eggs-gui
-  immutable-linux-framework
-  liquorix-unified-kernel
-  liqxanmod
-  lkf
-  lkm
-  oa-tools
-  penguins-eggs
-  penguins-eggs-audit
-  penguins-eggs-book
-  penguins-incus-platform
-  penguins-kernel-manager
-  penguins-powerwash
-  penguins-recovery
-  ukm
-  xanmod-unified-kernel
-)
+# Derived from config/gitlab-subgroups.yml — the single source of truth for
+# which repos are mirrored to GitLab. Falls back to a hardcoded list if the
+# config file is not found (e.g. when running outside the repo root).
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_SUBGROUP_CONFIG="${_SCRIPT_DIR}/../config/gitlab-subgroups.yml"
+
+if [[ -f "$_SUBGROUP_CONFIG" ]]; then
+  mapfile -t OSP_REPOS < <(python3 - "$_SUBGROUP_CONFIG" <<'PYEOF'
+import sys, re
+config_path = sys.argv[1]
+with open(config_path) as f:
+    content = f.read()
+in_subgroups = False
+for line in content.splitlines():
+    if re.match(r'^subgroups:', line):
+        in_subgroups = True
+        continue
+    if not in_subgroups:
+        continue
+    m = re.match(r'^      - (.+)', line)
+    if m:
+        print(m.group(1).strip())
+PYEOF
+  )
+else
+  OSP_REPOS=(
+    btrfs-dwarfs-framework
+    eggs-ai
+    eggs-gui
+    immutable-linux-framework
+    liquorix-unified-kernel
+    liqxanmod
+    lkf
+    lkm
+    oa-tools
+    penguins-eggs
+    penguins-eggs-audit
+    penguins-eggs-book
+    penguins-incus-platform
+    penguins-kernel-manager
+    penguins-powerwash
+    penguins-recovery
+    ukm
+    xanmod-unified-kernel
+  )
+fi
 
 # ── README fetch and Origins parsing ─────────────────────────────────────────
 

--- a/scripts/upstream-prs.sh
+++ b/scripts/upstream-prs.sh
@@ -93,25 +93,23 @@ push_branch() {
   local mirror_org="$1" repo="$2" branch="$3"
   local tmpdir
   tmpdir=$(mktemp -d)
+  # Guarantee cleanup on any exit path, including a failed cd
+  # shellcheck disable=SC2064
+  trap "cd /; rm -rf '${tmpdir}'" RETURN
   local clone_url="https://x-access-token:${GH_TOKEN}@github.com/${mirror_org}/${repo}.git"
   local upstream_url="https://x-access-token:${GH_TOKEN}@github.com/${UPSTREAM_OWNER}/${repo}.git"
 
   if ! git clone --bare --branch "$branch" --single-branch "$clone_url" "${tmpdir}/${repo}.git" \
       2>&1 | sanitize; then
-    rm -rf "$tmpdir"
     return 1
   fi
 
   cd "${tmpdir}/${repo}.git" || return 1
   if ! git push "$upstream_url" "refs/heads/${branch}:refs/heads/${branch}" --force \
       2>&1 | sanitize; then
-    cd /
-    rm -rf "$tmpdir"
     return 1
   fi
 
-  cd /
-  rm -rf "$tmpdir"
   return 0
 }
 


### PR DESCRIPTION
16 bugs identified in a second-pass audit across workflows, scripts, and config.

## Critical — visible failures on every run

**`sync-eggs-docs-to-book.yml`**
Both checkout steps used `path:`, so `scripts/` was never at the workspace root. `write-summary` failed on every run with "file not found". Added a bare `actions/checkout` for `fork-sync-all` first.

**`mirror-orgs-watchdog.yml`**
No `actions/checkout` step at all. `write-summary` always failed. Added checkout.

**`scripts/sync-btrfs-devel-branches.sh`**
`get_branch_sha` piped `curl --fail` into `jq`. A 404 (branch not found) exits non-zero, which `set -eo pipefail` turned into a full script abort. Added `|| true` to absorb the expected non-zero exit.

**`scripts/reconcile-org-refs.sh` — `rate_wait`**
`curl` output was piped directly into `python3`. A transient network blip produced empty input, causing a `JSONDecodeError` that aborted the entire reconcile run. Now caches the response first; parse errors default to "100 remaining" so the run continues.

## Workflow dispatch inputs now functional

Five scripts were receiving filter/flag inputs from their workflows but never reading them:

| Script | Inputs now implemented |
|---|---|
| `mirror-osp-to-gitlab.sh` | `REPO_FILTER`, `SUBGROUP_FILTER`, `DRY_RUN` |
| `reconcile-org-refs.sh` | `ORGS_FILTER` (all/osp-only/ooc-only/gitlab-only), `REPO_FILTER` |
| `sync-all-forks.sh` | `REPO_FILTER`, `BRANCH_FILTER`, `FORCE`, `DRY_RUN` |
| `mirror-to-osp.sh` | `REPO_FILTER`, `DRY_RUN`, `FORCE` |
| `sync-from-gitlab.sh` | `SUBGROUP_FILTER` |

Notable: `FORCE` in `sync-all-forks` uses `PATCH /git/refs` with `force:true` to reset diverged branches. `FORCE` in `mirror-to-osp` bypasses the CI gate. `SUBGROUP_FILTER` in `sync-from-gitlab` validates against known names and exits 1 on an unknown value.

## Correctness / reliability

**`reconcile-org-refs.sh` — pagination**
Repo list fetch was capped at 100 with no loop. Orgs with >100 repos silently dropped overflow. Now fully paginated for both the REST path and the GraphQL fallback.

**`config/gitlab-subgroups.yml`**
`penguins-immutable-framework` was listed under `penguins-eggs_deving` — a wrong/duplicate name. Every script references `immutable-linux-framework`, which is already correctly listed under `immutable-filesystem_deving`. Removed the stale entry (30 repos → 30 repos, no net change to the correct set).

**`scripts/mirror-orgs.sh`**
Repo creation `curl` discarded the response entirely. A 422/403 would silently proceed to a confusing push failure. Now captures HTTP status and returns 1 with a logged error on non-201. Also added `local` to `body` in `api_get` to prevent variable leak.

**`scripts/upstream-prs.sh`**
`push_branch` leaked `$tmpdir` if `cd` failed. Replaced manual `rm -rf` calls with `trap RETURN` to guarantee cleanup on all exit paths.

**`scripts/sync-upstream-sources.sh`**
Hardcoded 18-repo `OSP_REPOS` array diverged from the 30 repos in `config/gitlab-subgroups.yml`. 12 repos were silently excluded from upstream origin syncing. Now reads the config dynamically with a hardcoded fallback for local runs outside the repo.

**`mirror-orgs-watchdog.yml` — coverage**
`Mirror Interested-Deving-1896 → OSP` (the most critical hourly workflow) had no watchdog coverage. Added to both the `workflow_run` trigger list and the `case` statement.

**`resolve-failures.yml`**
Dead `workflow_call: {}` trigger removed. `notify-poller.yml` triggers this workflow via REST `workflow_dispatch`, not `workflow_call`.