### PR TITLE
fix: fourth-pass audit — DRY_RUN/REPO_FILTER, mirror-artifacts delegation, cron stagger

### DIFF
--- a/.github/workflows/mirror-artifacts.yml
+++ b/.github/workflows/mirror-artifacts.yml
@@ -9,7 +9,7 @@ name: Mirror Artifacts
 
 on:
   schedule:
-    - cron: "0 * * * *"
+    - cron: "10 * * * *"  # Hourly at :10 — offset from mirror-releases (:00)
   workflow_dispatch:
     inputs:
       upstream_repo:
@@ -44,6 +44,10 @@ permissions:
 #   Docker daemon push errors are not retried — re-run the workflow manually.
 # PyPI: no rate limit on uploads; trusted publishing (OIDC) is used.
 # Flatpak/RPM repos: no API rate limits — written to gh-pages via git push.
+
+concurrency:
+  group: mirror-artifacts
+  cancel-in-progress: false
 
 jobs:
   mirror:

--- a/.github/workflows/mirror-releases.yml
+++ b/.github/workflows/mirror-releases.yml
@@ -37,6 +37,10 @@ permissions:
 #   X-RateLimit-Reset sleep. Asset downloads/uploads are not counted against
 #   the REST API quota but are subject to bandwidth limits.
 
+concurrency:
+  group: mirror-releases
+  cancel-in-progress: false
+
 jobs:
   mirror:
     runs-on: ubuntu-latest

--- a/.github/workflows/reconcile-org-refs.yml
+++ b/.github/workflows/reconcile-org-refs.yml
@@ -71,7 +71,6 @@ jobs:
 
       - name: Rewrite org references in OSP + OOC mirrors + GitLab
         env:
-          SYNC_TOKEN: ${{ secrets.SYNC_TOKEN }}
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
           GITLAB_TOKEN: ${{ secrets.GITLAB_SYNC_TOKEN }}
           UPSTREAM_OWNER: Interested-Deving-1896

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ All schedules are UTC. The hourly chain runs in this order each hour:
 
 ```
 :00  mirror-to-osp          Interested-Deving-1896 → OSP
+:00  mirror-releases        GitHub Releases → OSP + OOC
+:10  mirror-artifacts       Release assets + GHCR images → OSP + OOC
 :05  sync-pieroproietti      pieroproietti forks fast-path
 :15  mirror-osp-to-ooc       OSP → OOC (per-repo, injected by setup-osp-mirrors)
 :30  upstream-prs            OSP/OOC PRs → Interested-Deving-1896
@@ -314,6 +316,8 @@ Per-repo push triggers (so a commit to e.g. `penguins-eggs` on GitLab fires the 
 
 ```
 :00  mirror-to-osp.yml        Interested-Deving-1896 → OSP
+:00  mirror-releases.yml      GitHub Releases → OSP + OOC
+:10  mirror-artifacts.yml     Release assets + GHCR images → OSP + OOC
 :05  sync-pieroproietti        pieroproietti forks fast-path
 :15  mirror-osp-to-ooc.yaml   OSP → OOC  (per-repo, injected by setup-osp-mirrors)
 :30  upstream-prs.yml          OOC/OSP PRs → Interested-Deving-1896

--- a/scripts/create-readmes.sh
+++ b/scripts/create-readmes.sh
@@ -26,6 +26,9 @@ set -uo pipefail
 : "${GH_TOKEN:?GH_TOKEN is required}"
 : "${GITHUB_OWNER:=Interested-Deving-1896}"
 
+DRY_RUN="${DRY_RUN:-false}"
+REPO_FILTER="${REPO_FILTER:-}"
+
 GH_API="https://api.github.com"
 MODELS_API="https://models.github.ai/inference"
 MODEL="openai/gpt-4o"
@@ -97,6 +100,10 @@ readme_exists() {
 
 commit_file() {
   local owner="$1" repo="$2" path="$3" message="$4" content_b64="$5"
+  if [[ "$DRY_RUN" == "true" ]]; then
+    info "  [DRY_RUN] would commit ${path} to ${owner}/${repo}"
+    return 0
+  fi
   local payload
   payload=$(jq -n --arg m "$message" --arg c "$content_b64" '{message:$m,content:$c}')
   curl -sf -X PUT \
@@ -282,6 +289,8 @@ created=0
 skipped=0
 
 for repo in $repos; do
+  [[ -n "$REPO_FILTER" && "$repo" != "$REPO_FILTER" ]] && continue
+
   if readme_exists "$GITHUB_OWNER" "$repo"; then
     (( skipped++ )) || true
     continue

--- a/scripts/mirror-artifacts.sh
+++ b/scripts/mirror-artifacts.sh
@@ -22,13 +22,45 @@ set -uo pipefail
 
 UPSTREAM_REPO="${UPSTREAM_REPO:-}"
 RELEASE_TAG="${RELEASE_TAG:-}"
+DRY_RUN="${DRY_RUN:-false}"
+REPO_FILTER="${REPO_FILTER:-}"
+FORCE="${FORCE:-false}"
+
+[[ "$DRY_RUN" == "true" ]] && echo "Dry run — no writes will occur."
+[[ "$FORCE"   == "true" ]] && echo "Force mode — existing releases will be re-mirrored."
+[[ -n "$REPO_FILTER"    ]] && echo "Repo filter: '${REPO_FILTER}'"
+[[ -n "$RELEASE_TAG"    ]] && echo "Release tag: '${RELEASE_TAG}'"
 
 API="https://api.github.com"
 AUTH=(-H "Authorization: token ${GH_TOKEN}" -H "Accept: application/vnd.github+json")
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXCLUDED_REPOS=("fork-sync-all" "org-mirror")
 
-api_get() { curl --disable --silent "${AUTH[@]}" "$@"; }
+api_get() {
+  local url="$1"
+  local attempt=0
+  while (( attempt < 3 )); do
+    local response http_code body
+    response=$(curl --disable --silent --write-out "\n%{http_code}" "${AUTH[@]}" "$url")
+    http_code=$(tail -1 <<< "$response")
+    body=$(head -n -1 <<< "$response")
+    if [[ "$http_code" == "200" ]]; then
+      echo "$body"; return 0
+    elif [[ "$http_code" == "403" || "$http_code" == "429" ]]; then
+      local reset now sleep_sec
+      reset=$(curl --disable --silent --head "${AUTH[@]}" "$url" \
+        | grep -i x-ratelimit-reset | awk '{print $2}' | tr -d '\r')
+      now=$(date +%s)
+      sleep_sec=$(( reset > now ? reset - now + 2 : 30 ))
+      echo "Rate limited — sleeping ${sleep_sec}s" >&2
+      sleep "$sleep_sec"
+      (( attempt++ ))
+    else
+      echo "HTTP ${http_code} for ${url}" >&2; return 1
+    fi
+  done
+  return 1
+}
 
 is_excluded() {
   local r="$1"
@@ -55,83 +87,35 @@ has_workflow() {
   echo "$result" | jq -e '.sha' > /dev/null 2>&1
 }
 
-# Mirror GitHub Releases for a single repo to a single org
-mirror_releases_for_repo() {
+# Mirror Flatpak/RPM packages for releases of a single repo to a single org.
+# GitHub Releases themselves are handled by mirror-releases.sh (called in main).
+mirror_packages_for_repo() {
   local src_repo="$1" dst_org="$2"
-  export GH_TOKEN UPSTREAM_OWNER OSP_ORG OOC_ORG
 
-  # Get upstream releases (or just the specific one if RELEASE_TAG is set)
+  # Fetch releases to check for Flatpak/RPM assets
   local releases
   if [[ -n "$RELEASE_TAG" ]]; then
-    releases=$(api_get "${API}/repos/${UPSTREAM_OWNER}/${src_repo}/releases/tags/${RELEASE_TAG}")
-    releases="[$releases]"
+    local r
+    r=$(api_get "${API}/repos/${UPSTREAM_OWNER}/${src_repo}/releases/tags/${RELEASE_TAG}" 2>/dev/null || true)
+    releases="[$r]"
   else
-    releases=$(api_get "${API}/repos/${UPSTREAM_OWNER}/${src_repo}/releases?per_page=100")
+    releases=$(api_get "${API}/repos/${UPSTREAM_OWNER}/${src_repo}/releases?per_page=100" 2>/dev/null || true)
   fi
 
   local count
   count=$(echo "$releases" | jq 'length' 2>/dev/null || echo 0)
-  [[ "$count" == "0" ]] && return
-
-  # Get existing tags in mirror
-  local existing_tags
-  existing_tags=$(api_get "${API}/repos/${dst_org}/${src_repo}/releases?per_page=100" | \
-    jq -r '.[].tag_name' 2>/dev/null || echo "")
-
-  local tmpdir
-  tmpdir=$(mktemp -d)
-  trap "rm -rf '$tmpdir'" RETURN
+  [[ "$count" == "0" || "$count" == "null" ]] && return
 
   while IFS= read -r release; do
-    local tag name body prerelease draft
+    local tag draft
     tag=$(echo "$release" | jq -r '.tag_name')
-    name=$(echo "$release" | jq -r '.name // .tag_name')
-    body=$(echo "$release" | jq -r '.body // ""')
-    prerelease=$(echo "$release" | jq -r '.prerelease')
     draft=$(echo "$release" | jq -r '.draft')
-
     [[ "$draft" == "true" ]] && continue
-    echo "$existing_tags" | grep -qxF "$tag" && continue
 
-    echo "    [releases] ${dst_org}/${src_repo}: creating $tag"
-
-    local mirror_body
-    mirror_body="${body}
-
----
-*Mirrored from [${UPSTREAM_OWNER}/${src_repo}](https://github.com/${UPSTREAM_OWNER}/${src_repo}/releases/tag/${tag})*"
-
-    local payload
-    payload=$(jq -n \
-      --arg tag "$tag" --arg name "$name" --arg body "$mirror_body" \
-      --argjson prerelease "$prerelease" \
-      '{tag_name:$tag,name:$name,body:$body,prerelease:$prerelease,draft:false}')
-
-    local new_release
-    new_release=$(curl --disable --silent -X POST \
-      "${AUTH[@]}" -H "Content-Type: application/json" \
-      "${API}/repos/${dst_org}/${src_repo}/releases" -d "$payload")
-
-    local upload_url
-    upload_url=$(echo "$new_release" | jq -r '.upload_url // empty' | sed 's/{?name,label}//')
-    [[ -z "$upload_url" ]] && { echo "    FAILED: $(echo "$new_release" | jq -r '.message')"; continue; }
-
-    # Upload assets
-    while IFS= read -r asset_line; do
-      [[ -z "$asset_line" ]] && continue
-      local aname atype aurl
-      aname=$(echo "$asset_line" | jq -r '.name')
-      atype=$(echo "$asset_line" | jq -r '.content_type')
-      aurl=$(echo "$asset_line" | jq -r '.browser_download_url')
-      local afile="${tmpdir}/${aname}"
-      curl --disable --silent -L -H "Authorization: token ${GH_TOKEN}" -o "$afile" "$aurl"
-      local http
-      http=$(curl --disable --silent -o /dev/null -w "%{http_code}" -X POST \
-        -H "Authorization: token ${GH_TOKEN}" -H "Content-Type: ${atype}" \
-        "${upload_url}?name=${aname}" --data-binary "@${afile}")
-      echo "      asset: $aname (HTTP $http)"
-      rm -f "$afile"
-    done < <(echo "$release" | jq -c '.assets[]')
+    if [[ "$DRY_RUN" == "true" ]]; then
+      echo "    DRY  would mirror packages for ${dst_org}/${src_repo}:${tag}"
+      continue
+    fi
 
     # Mirror Flatpak if .flatpak asset present
     if echo "$release" | jq -e '.assets[] | select(.name | endswith(".flatpak"))' > /dev/null 2>&1; then
@@ -146,7 +130,6 @@ mirror_releases_for_repo() {
       UPSTREAM_REPO="$src_repo" TARGET_ORG="$dst_org" RELEASE_TAG="$tag" \
         bash "${SCRIPT_DIR}/mirror-rpm.sh" || echo "    rpm mirror failed (non-fatal)"
     fi
-
   done < <(echo "$releases" | jq -c '.[]')
 }
 
@@ -181,11 +164,25 @@ for org in "$OSP_ORG" "$OOC_ORG"; do
   while IFS= read -r repo; do
     [[ -z "$repo" ]] && continue
     is_excluded "$repo" && continue
+
+    # Apply repo name substring filter
+    if [[ -n "$REPO_FILTER" && "$repo" != *"$REPO_FILTER"* ]]; then
+      continue
+    fi
+
     upstream_name=$(api_get "${API}/repos/${UPSTREAM_OWNER}/${repo}" | jq -r '.name // empty')
     [[ -z "$upstream_name" ]] && continue
 
     echo "  --- ${org}/${repo} ---"
-    mirror_releases_for_repo "$repo" "$org"
+
+    # Delegate GitHub Releases mirroring to mirror-releases.sh to avoid
+    # duplication and race conditions when both workflows fire simultaneously.
+    REPO_FILTER="$repo" RELEASE_TAG="$RELEASE_TAG" DRY_RUN="$DRY_RUN" FORCE="$FORCE" \
+      bash "${SCRIPT_DIR}/mirror-releases.sh" || echo "  releases mirror failed (non-fatal)"
+
+    # Mirror Flatpak/RPM packages (not handled by mirror-releases.sh)
+    mirror_packages_for_repo "$repo" "$org"
+
     echo ""
   done <<< "$repos"
 done

--- a/scripts/reconcile-org-refs.sh
+++ b/scripts/reconcile-org-refs.sh
@@ -43,9 +43,12 @@ GITLAB_TOKEN="${GITLAB_TOKEN:-}"
 ORGS_FILTER="${ORGS_FILTER:-all}"
 # REPO_FILTER: substring — only process repos whose name contains this string
 REPO_FILTER="${REPO_FILTER:-}"
+# DRY_RUN: print what would change without writing anything
+DRY_RUN="${DRY_RUN:-false}"
 
 [[ "$ORGS_FILTER" != "all" ]] && echo "Orgs filter: ${ORGS_FILTER}"
 [[ -n "$REPO_FILTER" ]]       && echo "Repo filter: ${REPO_FILTER}"
+[[ "$DRY_RUN" == "true" ]]    && echo "Dry run:     no changes will be written"
 
 API="https://api.github.com"
 AUTH="Authorization: token ${GH_TOKEN}"
@@ -194,9 +197,13 @@ print(json.dumps({
 }))
 " "$tmp_patched" "$sha" "$src" "$dst" > "$tmp_payload"
 
-  api_put "$API/repos/$owner/$repo/contents/$fpath" -d "@$tmp_payload" > /dev/null \
-    && echo "    patched: $fpath" \
-    || echo "    WARN: failed to patch $fpath"
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo "    DRY  would patch: $fpath (${src} → ${dst})"
+  else
+    api_put "$API/repos/$owner/$repo/contents/$fpath" -d "@$tmp_payload" > /dev/null \
+      && echo "    patched: $fpath" \
+      || echo "    WARN: failed to patch $fpath"
+  fi
 
   rm -f "$tmp_meta" "$tmp_decoded" "$tmp_patched" "$tmp_payload"
 }
@@ -465,9 +472,13 @@ print(json.dumps({
 }))
 " "$tmp_patched" "$sha" > "$tmp_payload"
 
-  api_put "$API/repos/$owner/$repo/contents/$fpath" -d "@$tmp_payload" > /dev/null \
-    && echo "    patched (build): $fpath" \
-    || echo "    WARN: failed to patch $fpath"
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo "    DRY  would patch (build): $fpath"
+  else
+    api_put "$API/repos/$owner/$repo/contents/$fpath" -d "@$tmp_payload" > /dev/null \
+      && echo "    patched (build): $fpath" \
+      || echo "    WARN: failed to patch $fpath"
+  fi
 
   rm -f "$tmp_meta" "$tmp_decoded" "$tmp_patched" "$tmp_payload"
 }
@@ -699,11 +710,15 @@ print(json.dumps({
 }))
 " "$tmp_patched" "$branch" "$src" "$dst" > "$tmp_payload"
 
-  gl_api_put \
-    "${GL_API}/projects/${project_id}/repository/files/${encoded_path}" \
-    -d "@$tmp_payload" > /dev/null \
-    && echo "    gl patched: $fpath" \
-    || echo "    WARN: failed to gl patch $fpath"
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo "    DRY  would gl patch: $fpath (${src} → ${dst})"
+  else
+    gl_api_put \
+      "${GL_API}/projects/${project_id}/repository/files/${encoded_path}" \
+      -d "@$tmp_payload" > /dev/null \
+      && echo "    gl patched: $fpath" \
+      || echo "    WARN: failed to gl patch $fpath"
+  fi
 
   rm -f "$tmp_meta" "$tmp_decoded" "$tmp_patched" "$tmp_payload"
 }

--- a/scripts/resolve-failures.sh
+++ b/scripts/resolve-failures.sh
@@ -12,6 +12,9 @@ set -o pipefail
 : "${GH_TOKEN:?GH_TOKEN is required}"
 : "${SCAN_OWNERS:?SCAN_OWNERS is required}"
 
+DRY_RUN="${DRY_RUN:-false}"
+REPO_FILTER="${REPO_FILTER:-}"
+
 API="https://api.github.com"
 
 # Repos the resolver must never commit to directly. These are repos where
@@ -398,6 +401,13 @@ Analyze the failure and provide a fix if possible."
     fi
 
     echo "    AI fix: ${explanation}"
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+      echo "    [DRY_RUN] would apply fix to ${repo}:${workflow_path}"
+      total_fixed=$(( total_fixed + 1 ))
+      return 0
+    fi
+
     echo "    Applying fix..."
 
     # Append co-author
@@ -572,6 +582,12 @@ resolve_notifications() {
         continue
       fi
 
+      repo_short="${repo_full##*/}"
+      if [[ -n "$REPO_FILTER" && "$repo_short" != "$REPO_FILTER" ]]; then
+        dismiss_notification "$thread_id"
+        continue
+      fi
+
       echo "    Workflow: ${run_name} (${workflow_path})"
       echo "    Branch:   ${branch}"
 
@@ -630,6 +646,9 @@ for owner in $SCAN_OWNERS; do
       echo "  Skipping excluded repo: ${repo}"
       continue
     fi
+
+    repo_short="${repo##*/}"
+    [[ -n "$REPO_FILTER" && "$repo_short" != "$REPO_FILTER" ]] && continue
 
     total_scanned=$(( total_scanned + 1 ))
 

--- a/scripts/setup-osp-mirrors.sh
+++ b/scripts/setup-osp-mirrors.sh
@@ -16,6 +16,9 @@ set -uo pipefail
 : "${OSP_ORG:?OSP_ORG is required}"
 : "${OOC_ORG:?OOC_ORG is required}"
 
+DRY_RUN="${DRY_RUN:-false}"
+REPO_FILTER="${REPO_FILTER:-}"
+
 API="https://api.github.com"
 AUTH_HEADER="Authorization: token ${GH_TOKEN}"
 ACCEPT_HEADER="Accept: application/vnd.github+json"
@@ -261,6 +264,7 @@ skipped=0
 
 for repo in "${osp_repos[@]}"; do
   [[ -z "$repo" ]] && continue
+  [[ -n "$REPO_FILTER" && "$repo" != "$REPO_FILTER" ]] && continue
 
   if is_excluded "$repo"; then
     (( skipped++ )) || true
@@ -279,6 +283,12 @@ for repo in "${osp_repos[@]}"; do
   default_branch=$(echo "$upstream_info" | jq -r '.default_branch // "main"')
 
   echo "Setting up mirrors for: ${repo} (branch: ${default_branch})"
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo "  [DRY_RUN] would run setup_repo for ${repo}"
+    (( processed++ )) || true
+    echo ""
+    continue
+  fi
   setup_repo "$repo" "$default_branch"
   (( processed++ )) || true
   echo ""

--- a/scripts/sync-from-gitlab.sh
+++ b/scripts/sync-from-gitlab.sh
@@ -18,6 +18,12 @@ set -uo pipefail
 
 : "${GITLAB_TOKEN:?GITLAB_TOKEN is required}"
 : "${GH_TOKEN:?GH_TOKEN is required}"
+
+DRY_RUN="${DRY_RUN:-false}"
+REPO_FILTER="${REPO_FILTER:-}"
+
+[[ "$DRY_RUN" == "true" ]] && info "Dry run — no pushes will occur."
+[[ -n "$REPO_FILTER"    ]] && info "Repo filter: '${REPO_FILTER}'"
 : "${GITHUB_OWNER:=Interested-Deving-1896}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -228,6 +234,12 @@ for group_id in "${SUBGROUP_IDS[@]}"; do
       continue
     fi
 
+    # Apply repo name substring filter
+    if [[ -n "$REPO_FILTER" && "$gl_name" != *"$REPO_FILTER"* ]]; then
+      (( skipped++ )) || true
+      continue
+    fi
+
     # Only sync if a GitHub repo with the same name exists
     if ! github_repo_exists "$gl_name"; then
       (( skipped++ )) || true
@@ -236,6 +248,12 @@ for group_id in "${SUBGROUP_IDS[@]}"; do
 
     info "──────────────────────────────────────────"
     info "gitlab.com/${gl_path}  →  github.com/${GITHUB_OWNER}/${gl_name}"
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+      info "  DRY  would sync ${gl_name}"
+      (( synced++ )) || true
+      continue
+    fi
 
     if sync_repo "$gl_path" "$gl_name"; then
       info "✅ ${gl_name} done"

--- a/scripts/sync-pieroproietti-forks.sh
+++ b/scripts/sync-pieroproietti-forks.sh
@@ -14,6 +14,9 @@ set -uo pipefail
 : "${GITHUB_OWNER:?GITHUB_OWNER is required}"
 : "${UPSTREAM_USER:=pieroproietti}"
 
+DRY_RUN="${DRY_RUN:-false}"
+REPO_FILTER="${REPO_FILTER:-}"
+
 API="https://api.github.com"
 PER_PAGE=100
 HEADER_FILE=$(mktemp)
@@ -193,6 +196,8 @@ for line in "${fork_lines[@]}"; do
   upstream=$(echo "$line"        | awk '{print $3}')
 
   [[ -z "$fork" ]] && continue
+  repo_name="${fork##*/}"
+  [[ -n "$REPO_FILTER" && "$repo_name" != "$REPO_FILTER" ]] && continue
 
   echo "[${current}/${total}] ${fork}  (upstream: ${upstream}, branch: ${upstream_branch})"
 
@@ -205,6 +210,12 @@ for line in "${fork_lines[@]}"; do
   if [[ -z "$upstream_branch" || "$upstream_branch" == "null" ]]; then
     echo "  No upstream default branch found, skipping."
     (( skipped++ ))
+    continue
+  fi
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo "  [DRY_RUN] would sync ${fork} branch ${upstream_branch} from ${upstream}"
+    (( synced++ ))
     continue
   fi
 

--- a/scripts/sync-registered-imports.sh
+++ b/scripts/sync-registered-imports.sh
@@ -28,6 +28,10 @@ set -uo pipefail
 : "${GH_TOKEN:?GH_TOKEN is required}"
 : "${GITHUB_OWNER:=Interested-Deving-1896}"
 
+DRY_RUN="${DRY_RUN:-false}"
+REPO_FILTER="${REPO_FILTER:-}"
+SOURCE_FILTER="${SOURCE_FILTER:-}"
+
 IMPORTS_FILE="registered-imports.json"
 
 info() { echo "[sync-registered-imports] $*"; }
@@ -120,6 +124,13 @@ sync_entry() {
   local gh_url="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_OWNER}/${target_name}.git"
   local push_ok=true
 
+  if [[ "$DRY_RUN" == "true" ]]; then
+    info "  [DRY_RUN] would push ${source_url} → ${GITHUB_OWNER}/${target_name}"
+    cd /
+    rm -rf "$work_dir"
+    return 0
+  fi
+
   # Push branches (no prune — preserves GitHub-only branches)
   git_push_retry "$gh_url" '+refs/heads/*:refs/heads/*' || push_ok=false
 
@@ -163,6 +174,8 @@ failed=0
 # Iterate entries via python3 to handle JSON safely
 while IFS='|' read -r source_url target_name platform; do
   [ -z "$source_url" ] && continue
+  [[ -n "$REPO_FILTER"    && "$target_name" != "$REPO_FILTER"    ]] && continue
+  [[ -n "$SOURCE_FILTER"  && "$platform"    != "$SOURCE_FILTER"  ]] && continue
   if sync_entry "$source_url" "$target_name" "$platform"; then
     synced=$((synced + 1))
   else

--- a/scripts/sync-to-gitlab.sh
+++ b/scripts/sync-to-gitlab.sh
@@ -25,6 +25,14 @@ set -uo pipefail
 : "${GITLAB_TOKEN:?GITLAB_TOKEN is required}"
 : "${GITHUB_OWNER:=Interested-Deving-1896}"
 
+DRY_RUN="${DRY_RUN:-false}"
+REPO_FILTER="${REPO_FILTER:-}"
+FORCE="${FORCE:-false}"   # re-push even if GitLab project already up-to-date
+
+[[ "$DRY_RUN" == "true" ]] && info "Dry run — no pushes will occur."
+[[ "$FORCE"   == "true" ]] && info "Force mode — all repos will be re-pushed."
+[[ -n "$REPO_FILTER"    ]] && info "Repo filter: '${REPO_FILTER}'"
+
 GL_HOST="https://gitlab.com"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -100,8 +108,19 @@ for entry in "${REPOS[@]}"; do
   gh_repo="${entry%%|*}"
   gl_path="${entry##*|}"
 
+  # Apply repo name substring filter
+  if [[ -n "$REPO_FILTER" && "$gh_repo" != *"$REPO_FILTER"* ]]; then
+    continue
+  fi
+
   info "──────────────────────────────────────────"
   info "${GITHUB_OWNER}/${gh_repo}  →  gitlab.com/${gl_path}"
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    info "  DRY  would push ${gh_repo}"
+    (( synced++ )) || true
+    continue
+  fi
 
   gh_url="https://${GH_TOKEN}@github.com/${GITHUB_OWNER}/${gh_repo}.git"
   gl_url="${GL_HOST/https:\/\//https://oauth2:${GITLAB_TOKEN}@}/${gl_path}.git"

--- a/scripts/update-readmes.sh
+++ b/scripts/update-readmes.sh
@@ -26,6 +26,9 @@ set -uo pipefail
 : "${GH_TOKEN:?GH_TOKEN is required}"
 : "${GITHUB_OWNER:=Interested-Deving-1896}"
 
+DRY_RUN="${DRY_RUN:-false}"
+REPO_FILTER="${REPO_FILTER:-}"
+
 # When true, strip <!-- AI:skip --> before processing so statically-written
 # READMEs are migrated to the marker template on this run.
 FORCE_REWRITE="${FORCE_REWRITE:-false}"
@@ -114,6 +117,10 @@ get_file_sha() {
 
 commit_file() {
   local owner="$1" repo="$2" path="$3" message="$4" content_b64="$5" sha="$6"
+  if [[ "$DRY_RUN" == "true" ]]; then
+    info "  [DRY_RUN] would commit ${path} to ${owner}/${repo}"
+    return 0
+  fi
   local payload
   if [ -n "$sha" ]; then
     payload=$(jq -n --arg m "$message" --arg c "$content_b64" --arg s "$sha" \
@@ -997,6 +1004,7 @@ NEW_REPO="${NEW_REPO:-}"
 if [ -n "${CHANGED_REPOS:-}" ]; then
   info "Push trigger mode — processing: ${CHANGED_REPOS}"
   for repo in $CHANGED_REPOS; do
+    [[ -n "$REPO_FILTER" && "$repo" != "$REPO_FILTER" ]] && continue
     process_repo "$GITHUB_OWNER" "$repo"
   done
 
@@ -1015,6 +1023,7 @@ else
   if [[ "$PRIORITY_ONLY" == "true" ]]; then
     info "Priority-only mode — skipping secondary repos."
     for repo in $priority_repos; do
+      [[ -n "$REPO_FILTER" && "$repo" != "$REPO_FILTER" ]] && continue
       process_repo "$GITHUB_OWNER" "$repo"
       sleep 2
     done
@@ -1033,6 +1042,7 @@ else
     # Process priority repos first.
     info "--- Priority pass (OSP-mirrored repos) ---"
     for repo in $priority_repos; do
+      [[ -n "$REPO_FILTER" && "$repo" != "$REPO_FILTER" ]] && continue
       process_repo "$GITHUB_OWNER" "$repo"
       sleep 2
     done
@@ -1041,6 +1051,7 @@ else
     info "--- Secondary pass (remaining repos) ---"
     for repo in $all_repos; do
       echo "$priority_repos" | grep -qx "$repo" && continue
+      [[ -n "$REPO_FILTER" && "$repo" != "$REPO_FILTER" ]] && continue
       process_repo "$GITHUB_OWNER" "$repo"
       sleep 2
     done

--- a/scripts/upstream-commits.sh
+++ b/scripts/upstream-commits.sh
@@ -30,6 +30,12 @@ set -uo pipefail
 : "${UPSTREAM_OWNER:?UPSTREAM_OWNER is required}"
 : "${MIRROR_ORGS:?MIRROR_ORGS is required}"
 
+DRY_RUN="${DRY_RUN:-false}"
+REPO_FILTER="${REPO_FILTER:-}"
+
+[[ "$DRY_RUN" == "true" ]] && echo "Dry run — no PRs will be opened."
+[[ -n "$REPO_FILTER"    ]] && echo "Repo filter: '${REPO_FILTER}'"
+
 API="https://api.github.com"
 AUTH=(-H "Authorization: token ${GH_TOKEN}" -H "Accept: application/vnd.github+json")
 PER_PAGE=100
@@ -210,6 +216,11 @@ for mirror_org in $MIRROR_ORGS; do
     while IFS= read -r repo; do
       [[ -z "$repo" ]] && continue
 
+      # Apply repo name substring filter
+      if [[ -n "$REPO_FILTER" && "$repo" != *"$REPO_FILTER"* ]]; then
+        continue
+      fi
+
       # Skip repos with no upstream counterpart
       if ! upstream_exists "$repo"; then
         continue
@@ -285,6 +296,12 @@ for mirror_org in $MIRROR_ORGS; do
       if upstream_branch_exists "$repo" "$branch" || upstream_pr_exists "$repo" "$branch"; then
         echo "  → branch or PR already exists for ${branch}, skipping"
         (( skipped++ )) || true
+        continue
+      fi
+
+      if [[ "$DRY_RUN" == "true" ]]; then
+        echo "  → DRY  would push branch '${branch}' and open PR in ${UPSTREAM_OWNER}/${repo}"
+        (( opened++ )) || true
         continue
       fi
 

--- a/scripts/upstream-prs.sh
+++ b/scripts/upstream-prs.sh
@@ -27,6 +27,9 @@ set -uo pipefail
 : "${UPSTREAM_OWNER:?UPSTREAM_OWNER is required}"
 : "${MIRROR_ORGS:?MIRROR_ORGS is required}"
 
+DRY_RUN="${DRY_RUN:-false}"
+REPO_FILTER="${REPO_FILTER:-}"
+
 API="https://api.github.com"
 AUTH=(-H "Authorization: token ${GH_TOKEN}" -H "Accept: application/vnd.github+json")
 PER_PAGE=100
@@ -168,6 +171,7 @@ for mirror_org in $MIRROR_ORGS; do
 
     while IFS= read -r repo; do
       [[ -z "$repo" ]] && continue
+      [[ -n "$REPO_FILTER" && "$repo" != "$REPO_FILTER" ]] && continue
 
       # Skip if no upstream counterpart
       if ! upstream_exists "$repo"; then
@@ -199,7 +203,9 @@ for mirror_org in $MIRROR_ORGS; do
 
         # Push branch upstream
         echo "  → pushing branch to ${UPSTREAM_OWNER}/${repo}..."
-        if ! push_branch "$mirror_org" "$repo" "$pr_branch" 2>&1 | sanitize; then
+        if [[ "$DRY_RUN" == "true" ]]; then
+          echo "  → [DRY_RUN] would push branch ${pr_branch}"
+        elif ! push_branch "$mirror_org" "$repo" "$pr_branch" 2>&1 | sanitize; then
           echo "  → ERROR: failed to push branch"
           (( failed++ )) || true
           continue
@@ -220,6 +226,12 @@ for mirror_org in $MIRROR_ORGS; do
 
         # Build upstream PR body
         upstream_body="$(printf 'Upstreamed from %s#%s.\n\n---\n\n%s' "$mirror_org/${repo}" "$pr_number" "$pr_body")"
+
+        if [[ "$DRY_RUN" == "true" ]]; then
+          echo "  → [DRY_RUN] would open PR '${pr_title}' in ${UPSTREAM_OWNER}/${repo}"
+          (( opened++ )) || true
+          continue
+        fi
 
         # Open upstream PR
         echo "  → opening PR in ${UPSTREAM_OWNER}/${repo}..."


### PR DESCRIPTION
## Summary

Fourth-pass audit fixes covering two themes: **safe-run controls** (DRY_RUN/REPO_FILTER) across all remaining scripts, and **mirror-artifacts race condition** elimination.

## Changes

### DRY_RUN / REPO_FILTER / SOURCE_FILTER

All matching workflows already passed these env vars via `workflow_dispatch` inputs. The scripts were missing the variable declarations and enforcement logic.

| Script | DRY_RUN gate | Filter vars |
|---|---|---|
| `upstream-prs.sh` | Before branch push + PR open | `REPO_FILTER` |
| `sync-pieroproietti-forks.sh` | Before `sync_default_branch` | `REPO_FILTER` |
| `resolve-failures.sh` | Before `apply_fix` commit | `REPO_FILTER` (notifications pass + main scan) |
| `create-readmes.sh` | Inside `commit_file()` | `REPO_FILTER` |
| `update-readmes.sh` | Inside `commit_file()` | `REPO_FILTER` (all 4 loop paths) |
| `setup-osp-mirrors.sh` | At `setup_repo` call site | `REPO_FILTER` |
| `sync-registered-imports.sh` | Inside `sync_entry()` before push | `REPO_FILTER`, `SOURCE_FILTER` |
| `sync-to-gitlab.sh` | Before `git push --mirror` | `REPO_FILTER`, `FORCE` |
| `sync-from-gitlab.sh` | Before `git push` | `REPO_FILTER` |
| `upstream-commits.sh` | Before push + PR creation | `REPO_FILTER` |
| `reconcile-org-refs.sh` | Gates all `api_put`/`gl_api_put` calls | — |

### mirror-artifacts race condition

`mirror-artifacts.yml` and `mirror-releases.yml` both ran at `:00`, independently creating the same GitHub releases and hitting 422 errors. Fix:

- `mirror-artifacts.sh` now delegates release mirroring to `mirror-releases.sh` (via `bash scripts/mirror-releases.sh`) and handles only Flatpak/RPM packages itself.
- `mirror-artifacts.yml` cron staggered from `:00` → `:10`.
- Concurrency groups added to both `mirror-artifacts.yml` and `mirror-releases.yml`.

### Other

- `reconcile-org-refs.yml`: removed dead `SYNC_TOKEN` env var (secret no longer exists under that name).
- Stale branches deleted: `feat/sync-pieroproietti-hourly`, `feat/update-infra-deps` (`feat/sync-btrfs-devel-branches` was already gone).
