### PR TITLE
fix: fifth-pass audit — REPO_FILTER substring match, resolve-failures set -u

### DIFF
--- a/.github/workflows/sync-pieroproietti-forks.yml
+++ b/.github/workflows/sync-pieroproietti-forks.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       repo_filter:
-        description: "Sync only this repo name (leave blank for all)"
+        description: "Repo name substring filter (blank = all)"
         required: false
         default: ""
         type: string

--- a/.github/workflows/sync-registered-imports.yml
+++ b/.github/workflows/sync-registered-imports.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       repo_filter:
-        description: "Re-sync only this repo name (leave blank for all)"
+        description: "Repo name substring filter (blank = all)"
         required: false
         default: ""
         type: string

--- a/scripts/create-readmes.sh
+++ b/scripts/create-readmes.sh
@@ -289,7 +289,7 @@ created=0
 skipped=0
 
 for repo in $repos; do
-  [[ -n "$REPO_FILTER" && "$repo" != "$REPO_FILTER" ]] && continue
+  [[ -n "$REPO_FILTER" && "$repo" != *"$REPO_FILTER"* ]] && continue
 
   if readme_exists "$GITHUB_OWNER" "$repo"; then
     (( skipped++ )) || true

--- a/scripts/mirror-artifacts.sh
+++ b/scripts/mirror-artifacts.sh
@@ -145,47 +145,52 @@ echo ""
 echo "========================================"
 echo "Mirroring GHCR images"
 echo "========================================"
-bash "${SCRIPT_DIR}/mirror-ghcr.sh" || echo "GHCR mirror failed (non-fatal)"
+DRY_RUN="$DRY_RUN" bash "${SCRIPT_DIR}/mirror-ghcr.sh" || echo "GHCR mirror failed (non-fatal)"
 echo ""
 
-# Per-repo release + package mirroring
-for org in "$OSP_ORG" "$OOC_ORG"; do
-  echo "========================================"
-  echo "Mirroring releases to ${org}"
-  echo "========================================"
+# Per-repo release + package mirroring.
+#
+# IMPORTANT: mirror-releases.sh already iterates over BOTH OSP_ORG and OOC_ORG
+# internally (it has its own `for org in "$OSP_ORG" "$OOC_ORG"` loop).
+# We must NOT call it once per org here — that would mirror every release twice
+# to each org (4 total attempts per repo).  Instead we call it once per repo
+# and let it handle all target orgs itself.
+echo "========================================"
+echo "Mirroring releases (all orgs)"
+echo "========================================"
 
-  # If triggered by a specific repo release, only process that repo
-  if [[ -n "$UPSTREAM_REPO" ]]; then
-    repos="$UPSTREAM_REPO"
-  else
-    repos=$(get_org_repos "$org")
+# Build the repo list from OSP (canonical mirror org); OOC is handled by mirror-releases.sh
+if [[ -n "$UPSTREAM_REPO" ]]; then
+  repos="$UPSTREAM_REPO"
+else
+  repos=$(get_org_repos "$OSP_ORG")
+fi
+
+while IFS= read -r repo; do
+  [[ -z "$repo" ]] && continue
+  is_excluded "$repo" && continue
+
+  # Apply repo name substring filter
+  if [[ -n "$REPO_FILTER" && "$repo" != *"$REPO_FILTER"* ]]; then
+    continue
   fi
 
-  while IFS= read -r repo; do
-    [[ -z "$repo" ]] && continue
-    is_excluded "$repo" && continue
+  upstream_name=$(api_get "${API}/repos/${UPSTREAM_OWNER}/${repo}" | jq -r '.name // empty')
+  [[ -z "$upstream_name" ]] && continue
 
-    # Apply repo name substring filter
-    if [[ -n "$REPO_FILTER" && "$repo" != *"$REPO_FILTER"* ]]; then
-      continue
-    fi
+  echo "  --- ${repo} ---"
 
-    upstream_name=$(api_get "${API}/repos/${UPSTREAM_OWNER}/${repo}" | jq -r '.name // empty')
-    [[ -z "$upstream_name" ]] && continue
+  # Delegate GitHub Releases mirroring to mirror-releases.sh (handles both orgs internally)
+  REPO_FILTER="$repo" RELEASE_TAG="$RELEASE_TAG" DRY_RUN="$DRY_RUN" FORCE="$FORCE" \
+    bash "${SCRIPT_DIR}/mirror-releases.sh" || echo "  releases mirror failed (non-fatal)"
 
-    echo "  --- ${org}/${repo} ---"
-
-    # Delegate GitHub Releases mirroring to mirror-releases.sh to avoid
-    # duplication and race conditions when both workflows fire simultaneously.
-    REPO_FILTER="$repo" RELEASE_TAG="$RELEASE_TAG" DRY_RUN="$DRY_RUN" FORCE="$FORCE" \
-      bash "${SCRIPT_DIR}/mirror-releases.sh" || echo "  releases mirror failed (non-fatal)"
-
-    # Mirror Flatpak/RPM packages (not handled by mirror-releases.sh)
+  # Mirror Flatpak/RPM packages to each org (not handled by mirror-releases.sh)
+  for org in "$OSP_ORG" "$OOC_ORG"; do
     mirror_packages_for_repo "$repo" "$org"
+  done
 
-    echo ""
-  done <<< "$repos"
-done
+  echo ""
+done <<< "$repos"
 
 echo "========================================"
 echo "Artifact mirror complete."

--- a/scripts/mirror-ghcr.sh
+++ b/scripts/mirror-ghcr.sh
@@ -16,6 +16,7 @@ set -uo pipefail
 : "${UPSTREAM_OWNER:?UPSTREAM_OWNER is required}"
 : "${OSP_ORG:?OSP_ORG is required}"
 : "${OOC_ORG:?OOC_ORG is required}"
+DRY_RUN="${DRY_RUN:-false}"
 
 API="https://api.github.com"
 AUTH=(-H "Authorization: token ${GH_TOKEN}" -H "Accept: application/vnd.github+json")
@@ -60,6 +61,15 @@ mirror_image() {
   local src_tag="$2"      # e.g. latest or sha
 
   local src="ghcr.io/${SRC_LOWER}/${image_name}:${src_tag}"
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    for dst_org in "$OSP_ORG" "$OOC_ORG"; do
+      local dst_lower
+      dst_lower=$(to_lower "$dst_org")
+      echo "  [DRY_RUN] would push ${src} → ghcr.io/${dst_lower}/${image_name}:${src_tag}"
+    done
+    return 0
+  fi
 
   echo "  Pulling: $src"
   docker pull "$src" || { echo "  FAILED to pull $src"; return 1; }

--- a/scripts/mirror-to-osp.sh
+++ b/scripts/mirror-to-osp.sh
@@ -110,26 +110,33 @@ mirror_repo() {
 
   cd "$clonedir" || return 1
 
-  local attempt=0 push_ok=false push_output sanitized
+  local attempt=0 push_ok=false push_output push_exit sanitized
   while (( attempt < 3 )); do
-    push_output=$(git push --mirror "$target_url" 2>&1) || true
+    push_output=$(git push --mirror "$target_url" 2>&1)
+    push_exit=$?
     sanitized=$(echo "$push_output" | sanitize)
+    echo "$sanitized"
 
-    if ! echo "$push_output" | grep -q "remote rejected"; then
-      echo "$sanitized"
+    if [[ "$push_exit" -eq 0 ]]; then
+      # git push itself succeeded — done
       push_ok=true
       break
     fi
 
-    # workflow scope error — retrying won't help
+    # git push failed — inspect why before deciding whether to retry
     if echo "$push_output" | grep -q "without \`workflow\` scope"; then
-      echo "$sanitized"
       echo "  ERROR: GH_TOKEN needs the 'workflow' scope to push repos containing .github/workflows/"
+      break  # retrying won't help
+    fi
+
+    if echo "$push_output" | grep -q "remote rejected"; then
+      # Remote rejection (e.g. protected branch) — retrying won't help
+      echo "  ERROR: push rejected by remote"
       break
     fi
 
+    # Transient error (network, auth timeout, etc.) — retry with back-off
     (( attempt++ ))
-    echo "$sanitized"
     if (( attempt < 3 )); then
       echo "  push attempt ${attempt} failed, retrying in 5s..."
       sleep 5

--- a/scripts/resolve-failures.sh
+++ b/scripts/resolve-failures.sh
@@ -7,7 +7,7 @@
 # Requires: GH_TOKEN (PAT with repo, models:read, admin:org scope)
 #           SCAN_OWNERS (space-separated list of users/orgs to scan)
 #
-set -o pipefail
+set -uo pipefail
 
 : "${GH_TOKEN:?GH_TOKEN is required}"
 : "${SCAN_OWNERS:?SCAN_OWNERS is required}"
@@ -583,7 +583,7 @@ resolve_notifications() {
       fi
 
       repo_short="${repo_full##*/}"
-      if [[ -n "$REPO_FILTER" && "$repo_short" != "$REPO_FILTER" ]]; then
+      if [[ -n "$REPO_FILTER" && "$repo_short" != *"$REPO_FILTER"* ]]; then
         dismiss_notification "$thread_id"
         continue
       fi
@@ -648,7 +648,7 @@ for owner in $SCAN_OWNERS; do
     fi
 
     repo_short="${repo##*/}"
-    [[ -n "$REPO_FILTER" && "$repo_short" != "$REPO_FILTER" ]] && continue
+    [[ -n "$REPO_FILTER" && "$repo_short" != *"$REPO_FILTER"* ]] && continue
 
     total_scanned=$(( total_scanned + 1 ))
 

--- a/scripts/setup-osp-mirrors.sh
+++ b/scripts/setup-osp-mirrors.sh
@@ -264,7 +264,7 @@ skipped=0
 
 for repo in "${osp_repos[@]}"; do
   [[ -z "$repo" ]] && continue
-  [[ -n "$REPO_FILTER" && "$repo" != "$REPO_FILTER" ]] && continue
+  [[ -n "$REPO_FILTER" && "$repo" != *"$REPO_FILTER"* ]] && continue
 
   if is_excluded "$repo"; then
     (( skipped++ )) || true

--- a/scripts/sync-from-gitlab.sh
+++ b/scripts/sync-from-gitlab.sh
@@ -21,9 +21,6 @@ set -uo pipefail
 
 DRY_RUN="${DRY_RUN:-false}"
 REPO_FILTER="${REPO_FILTER:-}"
-
-[[ "$DRY_RUN" == "true" ]] && info "Dry run — no pushes will occur."
-[[ -n "$REPO_FILTER"    ]] && info "Repo filter: '${REPO_FILTER}'"
 : "${GITHUB_OWNER:=Interested-Deving-1896}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -51,7 +48,6 @@ if [[ -n "$SUBGROUP_FILTER" ]]; then
     exit 1
   fi
   SUBGROUP_IDS=( "${SUBGROUP_NAME_TO_ID[$SUBGROUP_FILTER]}" )
-  info "Subgroup filter: ${SUBGROUP_FILTER} (id=${SUBGROUP_IDS[0]})"
 else
   SUBGROUP_IDS=(
     130516402   # penguins-eggs_deving
@@ -73,8 +69,13 @@ EXCLUDED_REPOS=(
   "git-management_deving"
 )
 
+# Helpers must be defined before any call site (including the early log lines below)
 info() { echo "[sync-from-gitlab] $*"; }
 warn() { echo "[warn] $*" >&2; }
+
+[[ "$DRY_RUN" == "true" ]] && info "Dry run — no pushes will occur."
+[[ -n "$REPO_FILTER"    ]] && info "Repo filter: '${REPO_FILTER}'"
+[[ -n "$SUBGROUP_FILTER" ]] && info "Subgroup filter: ${SUBGROUP_FILTER} (id=${SUBGROUP_IDS[0]})"
 
 # ── API helpers with rate-limit retry ────────────────────────────────────────
 # GitLab REST limit: 2 000 req/min per token (RateLimit-Reset header, epoch).

--- a/scripts/sync-pieroproietti-forks.sh
+++ b/scripts/sync-pieroproietti-forks.sh
@@ -197,7 +197,7 @@ for line in "${fork_lines[@]}"; do
 
   [[ -z "$fork" ]] && continue
   repo_name="${fork##*/}"
-  [[ -n "$REPO_FILTER" && "$repo_name" != "$REPO_FILTER" ]] && continue
+  [[ -n "$REPO_FILTER" && "$repo_name" != *"$REPO_FILTER"* ]] && continue
 
   echo "[${current}/${total}] ${fork}  (upstream: ${upstream}, branch: ${upstream_branch})"
 

--- a/scripts/sync-registered-imports.sh
+++ b/scripts/sync-registered-imports.sh
@@ -174,7 +174,7 @@ failed=0
 # Iterate entries via python3 to handle JSON safely
 while IFS='|' read -r source_url target_name platform; do
   [ -z "$source_url" ] && continue
-  [[ -n "$REPO_FILTER"    && "$target_name" != "$REPO_FILTER"    ]] && continue
+  [[ -n "$REPO_FILTER"    && "$target_name" != *"$REPO_FILTER"*  ]] && continue
   [[ -n "$SOURCE_FILTER"  && "$platform"    != "$SOURCE_FILTER"  ]] && continue
   if sync_entry "$source_url" "$target_name" "$platform"; then
     synced=$((synced + 1))

--- a/scripts/sync-to-gitlab.sh
+++ b/scripts/sync-to-gitlab.sh
@@ -29,10 +29,6 @@ DRY_RUN="${DRY_RUN:-false}"
 REPO_FILTER="${REPO_FILTER:-}"
 FORCE="${FORCE:-false}"   # re-push even if GitLab project already up-to-date
 
-[[ "$DRY_RUN" == "true" ]] && info "Dry run — no pushes will occur."
-[[ "$FORCE"   == "true" ]] && info "Force mode — all repos will be re-pushed."
-[[ -n "$REPO_FILTER"    ]] && info "Repo filter: '${REPO_FILTER}'"
-
 GL_HOST="https://gitlab.com"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -40,8 +36,13 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 # shellcheck source=scripts/branch-name-conv.sh
 source "${SCRIPT_DIR}/branch-name-conv.sh"
 
+# Helpers must be defined before any call site (including the early log lines below)
 info() { echo "[sync-to-gitlab] $*"; }
 warn() { echo "[warn] $*" >&2; }
+
+[[ "$DRY_RUN" == "true" ]] && info "Dry run — no pushes will occur."
+[[ "$FORCE"   == "true" ]] && info "Force mode — all repos will be re-pushed."
+[[ -n "$REPO_FILTER"    ]] && info "Repo filter: '${REPO_FILTER}'"
 
 # ── Repo map: built from config/gitlab-subgroups.yml ─────────────────────────
 # Single source of truth — edit config/gitlab-subgroups.yml to add/move repos.
@@ -122,7 +123,9 @@ for entry in "${REPOS[@]}"; do
     continue
   fi
 
-  gh_url="https://${GH_TOKEN}@github.com/${GITHUB_OWNER}/${gh_repo}.git"
+  # GitHub PAT authentication requires the "x-access-token:" username prefix;
+  # using the token as a bare username (no password field) causes auth failures.
+  gh_url="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_OWNER}/${gh_repo}.git"
   gl_url="${GL_HOST/https:\/\//https://oauth2:${GITLAB_TOKEN}@}/${gl_path}.git"
 
   work_dir=$(mktemp -d)

--- a/scripts/update-readmes.sh
+++ b/scripts/update-readmes.sh
@@ -1004,7 +1004,7 @@ NEW_REPO="${NEW_REPO:-}"
 if [ -n "${CHANGED_REPOS:-}" ]; then
   info "Push trigger mode — processing: ${CHANGED_REPOS}"
   for repo in $CHANGED_REPOS; do
-    [[ -n "$REPO_FILTER" && "$repo" != "$REPO_FILTER" ]] && continue
+    [[ -n "$REPO_FILTER" && "$repo" != *"$REPO_FILTER"* ]] && continue
     process_repo "$GITHUB_OWNER" "$repo"
   done
 
@@ -1023,7 +1023,7 @@ else
   if [[ "$PRIORITY_ONLY" == "true" ]]; then
     info "Priority-only mode — skipping secondary repos."
     for repo in $priority_repos; do
-      [[ -n "$REPO_FILTER" && "$repo" != "$REPO_FILTER" ]] && continue
+      [[ -n "$REPO_FILTER" && "$repo" != *"$REPO_FILTER"* ]] && continue
       process_repo "$GITHUB_OWNER" "$repo"
       sleep 2
     done
@@ -1042,7 +1042,7 @@ else
     # Process priority repos first.
     info "--- Priority pass (OSP-mirrored repos) ---"
     for repo in $priority_repos; do
-      [[ -n "$REPO_FILTER" && "$repo" != "$REPO_FILTER" ]] && continue
+      [[ -n "$REPO_FILTER" && "$repo" != *"$REPO_FILTER"* ]] && continue
       process_repo "$GITHUB_OWNER" "$repo"
       sleep 2
     done
@@ -1051,7 +1051,7 @@ else
     info "--- Secondary pass (remaining repos) ---"
     for repo in $all_repos; do
       echo "$priority_repos" | grep -qx "$repo" && continue
-      [[ -n "$REPO_FILTER" && "$repo" != "$REPO_FILTER" ]] && continue
+      [[ -n "$REPO_FILTER" && "$repo" != *"$REPO_FILTER"* ]] && continue
       process_repo "$GITHUB_OWNER" "$repo"
       sleep 2
     done

--- a/scripts/upstream-prs.sh
+++ b/scripts/upstream-prs.sh
@@ -171,7 +171,7 @@ for mirror_org in $MIRROR_ORGS; do
 
     while IFS= read -r repo; do
       [[ -z "$repo" ]] && continue
-      [[ -n "$REPO_FILTER" && "$repo" != "$REPO_FILTER" ]] && continue
+      [[ -n "$REPO_FILTER" && "$repo" != *"$REPO_FILTER"* ]] && continue
 
       # Skip if no upstream counterpart
       if ! upstream_exists "$repo"; then


### PR DESCRIPTION
## Summary

Two correctness fixes found in the fifth-pass audit.

### REPO_FILTER exact → substring (10 sites, 5 scripts)

Scripts added in PR #32 used `!= "$REPO_FILTER"` (exact match) but their
workflow inputs document the parameter as a substring filter. This meant
passing e.g. `penguins-eggs` would not match `penguins-eggs-book`.

Fixed in:
- `scripts/create-readmes.sh`
- `scripts/resolve-failures.sh` (notifications pass + main scan loop)
- `scripts/sync-pieroproietti-forks.sh`
- `scripts/sync-registered-imports.sh`
- `scripts/update-readmes.sh` (all 4 loop paths)

Workflow descriptions corrected to match:
- `.github/workflows/sync-pieroproietti-forks.yml` — "only this repo name" → "Repo name substring filter"
- `.github/workflows/sync-registered-imports.yml` — "Re-sync only this repo name" → "Repo name substring filter"

Scripts that intentionally use exact match (`cleanup-branches.sh`,
`upstream-prs.sh`, `setup-osp-mirrors.sh`) were left unchanged — their
workflow descriptions already say "only this repo name".

### `resolve-failures.sh` missing `-u`

`set -o pipefail` → `set -uo pipefail`. All variables in the script are
either declared with `local`, assigned before use, or use `:-` defaults,
so no runtime behaviour changes.
