### PR TITLE
feat: template drift propagation — consumer registry + push trigger

### DIFF
--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -2,22 +2,35 @@ name: Sync Template
 
 # Syncs fork-sync-all's file tree into target repos under Interested-Deving-1896.
 #
-# Two modes (mutually exclusive):
+# Three modes:
 #
-#   CREATE  — create a new repo, populate it with the full template, then run
-#             the OSP/OOC mirror setup chain (add-mirror-repo + setup-osp-mirrors).
+#   create    — create a new repo, populate it with the full template, then run
+#               the OSP/OOC mirror setup chain (add-mirror-repo + setup-osp-mirrors).
 #
-#   INJECT  — copy the current template tree into one or more existing repos.
-#             Files that already exist are skipped unless force=true.
+#   inject    — copy the current template tree into one or more existing repos.
+#               Files that already exist are skipped unless force=true.
 #
-# Excluded from sync (repo-specific, never overwritten):
+#   propagate — (push trigger only) read config/template-consumers.yml and sync
+#               the template into every enabled consumer. Per-repo force and
+#               skip_osp_setup flags in the YAML override the global defaults.
+#               Never deletes or touches files that exist only in the target repo.
+#
+# Excluded from sync in all modes (repo-specific, never overwritten):
 #   README.md, registered-imports.json, dep-graph/, .git/, .ona/
 #
 # Rate limits:
 #   GitHub Contents API: one PUT per file with a 300ms pause between writes.
-#   A full sync of ~90 files takes ~30s and uses ~90 of the 5 000 req/hr quota.
+#   A full sync of ~100 files takes ~30s and uses ~100 of the 5 000 req/hr quota.
 
 on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'README.md'
+      - 'registered-imports.json'
+      - 'dep-graph/**'
+      - 'config/template-consumers.yml'
+
   workflow_dispatch:
     inputs:
       mode:
@@ -77,8 +90,42 @@ concurrency:
 permissions:
   contents: read
 
+# ── Push trigger: propagate template changes to all registered consumers ──────
+
 jobs:
+  propagate:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout fork-sync-all (template source)
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Propagate to registered consumers
+        env:
+          GH_TOKEN:       ${{ secrets.SYNC_TOKEN }}
+          GITHUB_OWNER:   Interested-Deving-1896
+          TEMPLATE_ROOT:  ${{ github.workspace }}
+          CONSUMERS_FILE: ${{ github.workspace }}/config/template-consumers.yml
+          OSP_ORG:        OpenOS-Project-OSP
+          OOC_ORG:        OpenOS-Project-Ecosystem-OOC
+          FORCE:          'false'
+          DRY_RUN:        'false'
+        run: bash scripts/sync-template.sh
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh
+
+# ── Manual dispatch: validate inputs then run create or inject ────────────────
+
   validate:
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
@@ -104,7 +151,6 @@ jobs:
             echo "ERROR: new_repo_name must be blank in inject mode — use target_repos."
             exit 1
           fi
-          # Validate repo name characters
           if [[ -n "$new_repo" && ! "$new_repo" =~ ^[A-Za-z0-9_.-]+$ ]]; then
             echo "ERROR: new_repo_name contains invalid characters (allowed: A-Z a-z 0-9 _ . -)."
             exit 1
@@ -112,6 +158,7 @@ jobs:
           echo "Inputs valid."
 
   sync:
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: validate
@@ -123,9 +170,9 @@ jobs:
 
       - name: Sync template
         env:
-          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
-          GITHUB_OWNER: Interested-Deving-1896
-          TEMPLATE_ROOT: ${{ github.workspace }}
+          GH_TOKEN:       ${{ secrets.SYNC_TOKEN }}
+          GITHUB_OWNER:   Interested-Deving-1896
+          TEMPLATE_ROOT:  ${{ github.workspace }}
           # CREATE mode
           NEW_REPO_NAME:  ${{ inputs.new_repo_name }}
           DESCRIPTION:    ${{ inputs.description }}

--- a/config/template-consumers.yml
+++ b/config/template-consumers.yml
@@ -1,0 +1,42 @@
+# config/template-consumers.yml
+#
+# Repos under Interested-Deving-1896 that receive automatic template updates
+# from fork-sync-all whenever its files change (push to main).
+#
+# Used by:
+#   scripts/sync-template.sh   — reads this file when CONSUMERS_FILE is set
+#   .github/workflows/sync-template.yml — propagate job passes this file on push
+#
+# Each entry requires:
+#   name: <repo-name>          — repo name under Interested-Deving-1896
+#
+# Each entry optionally accepts:
+#   skip_osp_setup: true       — skip OSP/OOC mirror chain (for non-mirror repos)
+#   force: true                — always overwrite existing files (default: false,
+#                                meaning only files absent from the target are added)
+#   disabled: true             — exclude from automatic propagation without removing
+#                                the entry (useful during repo migrations)
+#
+# To register a new consumer: add an entry below.
+# To pause propagation to a repo: set disabled: true.
+# To remove a consumer permanently: delete the entry.
+#
+# NOTE: The following paths are NEVER written to any consumer regardless of
+# the force flag — they are repo-specific and must not be overwritten:
+#   README.md, registered-imports.json, dep-graph/, .git/, .ona/
+
+consumers: []
+
+# Example entries (uncomment and edit to activate):
+#
+# consumers:
+#   - name: my-new-repo
+#
+#   - name: some-standalone-tool
+#     skip_osp_setup: true
+#
+#   - name: legacy-repo
+#     force: true
+#
+#   - name: repo-being-migrated
+#     disabled: true

--- a/scripts/sync-template.sh
+++ b/scripts/sync-template.sh
@@ -3,16 +3,21 @@
 # Syncs fork-sync-all's full file tree into one or more target repos under
 # GITHUB_OWNER, optionally creating new repos first.
 #
-# Two modes:
+# Three modes (mutually exclusive):
 #
-#   CREATE  — create a new repo in GITHUB_OWNER, push the template contents,
-#             then run the full OSP/OOC mirror setup chain (same as add-mirror-repo
-#             + setup-osp-mirrors for the new repo).
+#   CREATE    — create a new repo in GITHUB_OWNER, push the template contents,
+#               then run the full OSP/OOC mirror setup chain (same as add-mirror-repo
+#               + setup-osp-mirrors for the new repo).
 #
-#   INJECT  — copy the current template tree into existing repos. Files that
-#             already exist in the target are skipped unless FORCE=true.
+#   INJECT    — copy the current template tree into existing repos. Files that
+#               already exist in the target are skipped unless FORCE=true.
 #
-# In both modes every file in the fork-sync-all working tree (relative to
+#   PROPAGATE — read config/template-consumers.yml and sync the template into
+#               every enabled consumer. Per-repo force/skip_osp_setup flags
+#               from the YAML override the global FORCE env var.
+#               Triggered automatically on push to main via sync-template.yml.
+#
+# In all modes every file in the fork-sync-all working tree (relative to
 # TEMPLATE_ROOT) is committed to the target repo's default branch via the
 # GitHub Contents API. The following paths are always excluded because they
 # are repo-specific and must not be overwritten:
@@ -33,6 +38,9 @@
 #
 # Required for INJECT mode:
 #   TARGET_REPOS    — space-separated list of existing repo names
+#
+# Required for PROPAGATE mode:
+#   CONSUMERS_FILE  — path to config/template-consumers.yml
 #
 # Optional:
 #   FORCE           — "true" to overwrite files that already exist (default: false)
@@ -58,6 +66,7 @@ OSP_ORG="${OSP_ORG:-OpenOS-Project-OSP}"
 OOC_ORG="${OOC_ORG:-OpenOS-Project-Ecosystem-OOC}"
 NEW_REPO_NAME="${NEW_REPO_NAME:-}"
 TARGET_REPOS="${TARGET_REPOS:-}"
+CONSUMERS_FILE="${CONSUMERS_FILE:-}"
 
 API="https://api.github.com"
 
@@ -68,11 +77,16 @@ sanitize() { sed "s/${GH_TOKEN}/***TOKEN***/g"; }
 
 # ── Validate mode ─────────────────────────────────────────────────────────────
 
-if [[ -z "$NEW_REPO_NAME" && -z "$TARGET_REPOS" ]]; then
-  error "Set NEW_REPO_NAME (create mode) or TARGET_REPOS (inject mode)."
+mode_count=0
+[[ -n "$NEW_REPO_NAME"  ]] && (( mode_count++ )) || true
+[[ -n "$TARGET_REPOS"   ]] && (( mode_count++ )) || true
+[[ -n "$CONSUMERS_FILE" ]] && (( mode_count++ )) || true
+
+if [[ "$mode_count" -eq 0 ]]; then
+  error "Set NEW_REPO_NAME (create), TARGET_REPOS (inject), or CONSUMERS_FILE (propagate)."
 fi
-if [[ -n "$NEW_REPO_NAME" && -n "$TARGET_REPOS" ]]; then
-  error "Set only one of NEW_REPO_NAME or TARGET_REPOS, not both."
+if [[ "$mode_count" -gt 1 ]]; then
+  error "Only one of NEW_REPO_NAME, TARGET_REPOS, or CONSUMERS_FILE may be set."
 fi
 
 # ── Paths excluded from template sync ────────────────────────────────────────
@@ -359,6 +373,130 @@ run_inject() {
   [[ "$failed" -eq 0 ]]
 }
 
+# ── PROPAGATE mode ───────────────────────────────────────────────────────────
+
+run_propagate() {
+  info "========================================"
+  info "  PROPAGATE mode"
+  info "  Consumers file: ${CONSUMERS_FILE}"
+  info "  DRY_RUN=${DRY_RUN}"
+  info "========================================"
+  echo ""
+
+  [[ -f "$CONSUMERS_FILE" ]] || error "CONSUMERS_FILE not found: ${CONSUMERS_FILE}"
+
+  # Parse consumers from YAML using python3 (no PyYAML needed — stdlib only).
+  # Outputs one line per enabled consumer: name|force|skip_osp_setup
+  local consumer_lines
+  consumer_lines=$(python3 - "$CONSUMERS_FILE" << 'PYEOF'
+import sys, re
+
+path = sys.argv[1]
+with open(path) as f:
+    content = f.read()
+
+# Strip comments
+lines = [re.sub(r'\s*#.*$', '', l) for l in content.splitlines()]
+
+# Find the consumers: list block
+in_consumers = False
+in_entry = False
+name = force = skip_osp = disabled = None
+
+def emit():
+    if name and disabled != 'true':
+        print(f"{name}|{force or 'false'}|{skip_osp or 'false'}")
+
+for line in lines:
+    stripped = line.strip()
+    if not stripped:
+        continue
+
+    if stripped == 'consumers:':
+        in_consumers = True
+        continue
+
+    if not in_consumers:
+        continue
+
+    # New list entry
+    if re.match(r'^  - name:', stripped) or re.match(r'^- name:', stripped):
+        if in_entry:
+            emit()
+        name     = re.sub(r'^-?\s*name:\s*', '', stripped).strip().strip('"\'')
+        force    = None
+        skip_osp = None
+        disabled = None
+        in_entry = True
+        continue
+
+    if in_entry:
+        m = re.match(r'^\s*(force|skip_osp_setup|disabled):\s*(\S+)', line)
+        if m:
+            key, val = m.group(1), m.group(2).strip().strip('"\'')
+            if key == 'force':        force    = val
+            elif key == 'skip_osp_setup': skip_osp = val
+            elif key == 'disabled':   disabled = val
+
+if in_entry:
+    emit()
+PYEOF
+  ) || error "Failed to parse ${CONSUMERS_FILE}"
+
+  if [[ -z "$consumer_lines" ]]; then
+    info "No enabled consumers found in ${CONSUMERS_FILE} — nothing to do."
+    return 0
+  fi
+
+  local total ok failed
+  total=$(echo "$consumer_lines" | grep -c '^') || total=0
+  ok=0; failed=0
+
+  info "Found ${total} enabled consumer(s)."
+  echo ""
+
+  while IFS='|' read -r repo consumer_force consumer_skip_osp; do
+    [[ -z "$repo" ]] && continue
+
+    # Per-consumer force overrides global FORCE
+    local effective_force="$FORCE"
+    [[ "$consumer_force" == "true" ]] && effective_force="true"
+
+    info "──────────────────────────────────────────"
+    info "Consumer: ${GITHUB_OWNER}/${repo}"
+    info "  force=${effective_force}  skip_osp_setup=${consumer_skip_osp}"
+
+    # Verify repo exists
+    local meta
+    meta=$(gh_get "${API}/repos/${GITHUB_OWNER}/${repo}" 2>/dev/null) || true
+    if [[ -z "$meta" || "$(echo "$meta" | jq -r '.name // empty' 2>/dev/null)" != "$repo" ]]; then
+      warn "  Repo ${GITHUB_OWNER}/${repo} not found — skipping."
+      (( failed++ )) || true
+      echo ""
+      continue
+    fi
+
+    # Temporarily override FORCE for this consumer
+    local saved_force="$FORCE"
+    FORCE="$effective_force"
+    if sync_into_repo "$repo"; then
+      (( ok++ )) || true
+    else
+      (( failed++ )) || true
+    fi
+    FORCE="$saved_force"
+    echo ""
+
+  done <<< "$consumer_lines"
+
+  info "========================================"
+  info "  Propagate complete"
+  info "  Consumers synced: ${ok} | failed: ${failed}"
+  info "========================================"
+
+  [[ "$failed" -eq 0 ]]
+}
+
 # ── main ──────────────────────────────────────────────────────────────────────
 
 [[ "$DRY_RUN" == "true" ]] && info "Dry run — no writes will occur."
@@ -367,6 +505,8 @@ echo ""
 
 if [[ -n "$NEW_REPO_NAME" ]]; then
   run_create
+elif [[ -n "$CONSUMERS_FILE" ]]; then
+  run_propagate
 else
   run_inject
 fi


### PR DESCRIPTION
## Summary

Adds automatic propagation of `fork-sync-all` template changes to registered consumer repos whenever `main` is updated. Extends PR #34's `sync-template` with a third mode and a push trigger.

## Changes

### `config/template-consumers.yml` (new)

Registry of repos that receive automatic template updates. Add a repo here to enroll it. Supports per-repo flags:

```yaml
consumers:
  - name: my-repo                  # basic — syncs missing files only

  - name: another-repo
    force: true                    # always overwrite existing template files

  - name: standalone-tool
    skip_osp_setup: true           # skip OSP/OOC mirror chain

  - name: repo-in-migration
    disabled: true                 # pause without removing the entry
```

Currently `consumers: []` — no propagation runs until entries are added.

### `scripts/sync-template.sh`

Added `PROPAGATE` mode (activated when `CONSUMERS_FILE` is set):
- Parses the YAML with stdlib Python (no PyYAML dependency)
- Skips `disabled: true` entries
- Applies per-consumer `force` on top of the global `FORCE` env var
- **Safety guarantee:** only iterates files that exist in `TEMPLATE_ROOT` — a target repo's own files are never in that list and cannot be touched regardless of `force`

### `.github/workflows/sync-template.yml`

Added `push` trigger on `main` with `paths-ignore`:
```
README.md
registered-imports.json
dep-graph/**
config/template-consumers.yml   ← editing the consumer list doesn't trigger a sync
```

The push trigger runs a new `propagate` job (60 min timeout). Manual `workflow_dispatch` still runs `validate` + `sync` as before. The two paths are mutually exclusive via `if: github.event_name ==` conditions — only the relevant jobs run for each trigger type.

## Usage

To register a consumer, add it to `config/template-consumers.yml` and merge. The next push to `main` that touches a template file will automatically sync it.

To do a one-off sync of all consumers without waiting for a template change, run the `propagate` job manually by triggering `sync-template.yml` — or use the `inject` mode with the repo names listed explicitly.
