### PR TITLE
feat: profile-based template sync with per-consumer overrides

### DIFF
--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -30,6 +30,7 @@ on:
       - 'registered-imports.json'
       - 'dep-graph/**'
       - 'config/template-consumers.yml'
+      - 'config/template-manifest.yml'
 
   workflow_dispatch:
     inputs:
@@ -71,6 +72,12 @@ on:
         type: string
         default: ''
 
+      profile:
+        description: 'Template profile to apply (full | mirror | infra-core | standalone)'
+        required: false
+        type: string
+        default: 'full'
+
       force:
         description: 'Overwrite files that already exist in target repos'
         required: false
@@ -109,6 +116,7 @@ jobs:
           GITHUB_OWNER:   Interested-Deving-1896
           TEMPLATE_ROOT:  ${{ github.workspace }}
           CONSUMERS_FILE: ${{ github.workspace }}/config/template-consumers.yml
+          MANIFEST_FILE:  ${{ github.workspace }}/config/template-manifest.yml
           OSP_ORG:        OpenOS-Project-OSP
           OOC_ORG:        OpenOS-Project-Ecosystem-OOC
           FORCE:          'false'
@@ -173,6 +181,7 @@ jobs:
           GH_TOKEN:       ${{ secrets.SYNC_TOKEN }}
           GITHUB_OWNER:   Interested-Deving-1896
           TEMPLATE_ROOT:  ${{ github.workspace }}
+          MANIFEST_FILE:  ${{ github.workspace }}/config/template-manifest.yml
           # CREATE mode
           NEW_REPO_NAME:  ${{ inputs.new_repo_name }}
           DESCRIPTION:    ${{ inputs.description }}
@@ -183,6 +192,7 @@ jobs:
           # INJECT mode
           TARGET_REPOS:   ${{ inputs.target_repos }}
           # Shared
+          PROFILE: ${{ inputs.profile || 'full' }}
           FORCE:   ${{ inputs.force }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: bash scripts/sync-template.sh

--- a/README.md
+++ b/README.md
@@ -142,6 +142,56 @@ Daily jobs run at:
 
 ---
 
+## Template Sync
+
+`sync-template.yml` propagates fork-sync-all's file tree into registered consumer repos. It supports three modes (`create`, `inject`, `propagate`) and a profile system that controls which files each consumer receives.
+
+### Profiles
+
+Profiles are defined in [`config/template-manifest.yml`](config/template-manifest.yml). Each profile is a named set of include/exclude glob patterns applied to the template tree before syncing.
+
+| Profile | What it syncs |
+|---|---|
+| `full` | Everything (default) |
+| `mirror` | Full mirror/sync suite; excludes fork-sync-all-only files (`sync-template.yml`, `validate-config.yml`, `generate-dep-graph.yml`, and their scripts/config) |
+| `infra-core` | CI hygiene only: PR automation, token rotation, branch cleanup, failure resolution, dep updates |
+| `standalone` | Minimal: PR automation + token rotation only |
+
+### Registering a consumer
+
+Add an entry to [`config/template-consumers.yml`](config/template-consumers.yml):
+
+```yaml
+consumers:
+  - name: my-repo
+    profile: infra-core        # which profile to apply
+    skip_osp_setup: true       # omit for mirror-chain repos
+    exclude_paths:             # additional per-consumer exclusions
+      - .github/workflows/pr-automation.yml
+    include_paths:             # re-include specific files excluded by the profile
+      - .github/workflows/sync-forks.yml
+```
+
+**Filter resolution order:**
+1. Profile `include` whitelist — if defined, only listed paths pass through
+2. Profile `exclude` patterns — matched paths are dropped
+3. Consumer `exclude_paths` — additional drops on top of the profile
+4. Consumer `include_paths` — re-includes paths dropped by steps 2–3
+
+The following paths are never written to any consumer regardless of profile or overrides: `README.md`, `registered-imports.json`, `dep-graph/`, `.git/`, `.ona/`
+
+### Manual inject with a profile
+
+```
+Actions → Sync Template → Run workflow
+  mode: inject
+  target_repos: my-repo another-repo
+  profile: infra-core
+  dry_run: true   ← always verify first
+```
+
+---
+
 ## Secrets
 
 | Secret | Used by | Notes |

--- a/config/template-consumers.yml
+++ b/config/template-consumers.yml
@@ -7,36 +7,97 @@
 #   scripts/sync-template.sh   — reads this file when CONSUMERS_FILE is set
 #   .github/workflows/sync-template.yml — propagate job passes this file on push
 #
-# Each entry requires:
-#   name: <repo-name>          — repo name under Interested-Deving-1896
+# ── Required fields ──────────────────────────────────────────────────────────
 #
-# Each entry optionally accepts:
-#   skip_osp_setup: true       — skip OSP/OOC mirror chain (for non-mirror repos)
-#   force: true                — always overwrite existing files (default: false,
-#                                meaning only files absent from the target are added)
-#   disabled: true             — exclude from automatic propagation without removing
-#                                the entry (useful during repo migrations)
+#   name: <repo-name>
+#     Repo name under Interested-Deving-1896.
 #
-# To register a new consumer: add an entry below.
+# ── Optional fields ──────────────────────────────────────────────────────────
+#
+#   profile: <profile-name>
+#     Which template profile to apply. Profiles are defined in
+#     config/template-manifest.yml. Defaults to `full` if omitted.
+#     Built-in profiles:
+#       full         — all template files (default)
+#       mirror       — mirror/sync suite + infra tooling; excludes
+#                      fork-sync-all-only files (sync-template, validate-config…)
+#       infra-core   — CI hygiene only (PR automation, token rotation,
+#                      branch cleanup, failure resolution, dep updates)
+#       standalone   — minimal: PR automation + token rotation only
+#
+#   exclude_paths: [...]
+#     Additional glob patterns to exclude on top of the profile's own excludes.
+#     Matched against paths relative to the repo root.
+#     Example: exclude_paths: [".github/workflows/update-readmes.yml"]
+#
+#   include_paths: [...]
+#     Glob patterns to re-include after the profile's excludes have been applied.
+#     Useful for pulling in a specific file from an otherwise-excluded directory.
+#     Example: include_paths: [".github/workflows/rotate-token.yml"]
+#
+#   force: true
+#     Overwrite files that already exist in the target repo (default: false,
+#     meaning only files absent from the target are added).
+#
+#   skip_osp_setup: true
+#     Skip OSP/OOC mirror chain setup. Set for non-mirror repos.
+#
+#   disabled: true
+#     Exclude from automatic propagation without removing the entry.
+#     Useful during repo migrations or when temporarily pausing updates.
+#
+# ── Global exclusions ────────────────────────────────────────────────────────
+#
+# The following paths are NEVER written to any consumer regardless of profile,
+# force, or include_paths — they are repo-specific and must not be overwritten:
+#   README.md, registered-imports.json, dep-graph/, .git/, .ona/
+#
+# ── Adding a consumer ────────────────────────────────────────────────────────
+#
+# 1. Choose the profile that best fits the repo's role (see above).
+# 2. Add exclude_paths for any profile files the repo manages itself.
+# 3. Set skip_osp_setup: true for repos not in the mirror chain.
+# 4. Leave force: false (default) unless the repo has never diverged.
+#
 # To pause propagation to a repo: set disabled: true.
 # To remove a consumer permanently: delete the entry.
-#
-# NOTE: The following paths are NEVER written to any consumer regardless of
-# the force flag — they are repo-specific and must not be overwritten:
-#   README.md, registered-imports.json, dep-graph/, .git/, .ona/
 
 consumers: []
 
 # Example entries (uncomment and edit to activate):
 #
 # consumers:
-#   - name: my-new-repo
 #
-#   - name: some-standalone-tool
+#   # Standard mirror-chain repo — receives the full template.
+#   - name: my-mirror-repo
+#
+#   # Repo in the mirror chain but not fork-sync-all itself — use mirror profile
+#   # to exclude sync-template.yml and validate-config.yml.
+#   - name: my-other-mirror-repo
+#     profile: mirror
 #     skip_osp_setup: true
 #
-#   - name: legacy-repo
-#     force: true
+#   # Self-contained repo that only wants CI hygiene, no mirror workflows.
+#   - name: my-tool-repo
+#     profile: infra-core
+#     skip_osp_setup: true
 #
+#   # Repo that diverged — use infra-core and exclude a workflow it owns itself.
+#   - name: diverged-repo
+#     profile: infra-core
+#     skip_osp_setup: true
+#     exclude_paths:
+#       - .github/workflows/pr-automation.yml
+#
+#   # Repo that wants infra-core but also needs one mirror workflow pulled in.
+#   - name: partial-mirror-repo
+#     profile: infra-core
+#     skip_osp_setup: true
+#     include_paths:
+#       - .github/workflows/sync-forks.yml
+#       - scripts/sync-forks.sh
+#
+#   # Repo being migrated — temporarily paused.
 #   - name: repo-being-migrated
+#     profile: mirror
 #     disabled: true

--- a/config/template-manifest.yml
+++ b/config/template-manifest.yml
@@ -1,0 +1,107 @@
+# config/template-manifest.yml
+#
+# Defines named profiles that control which files are propagated from
+# fork-sync-all to consumer repos.
+#
+# Used by:
+#   scripts/sync-template.sh  — loaded when MANIFEST_FILE is set
+#
+# A profile is a named set of include/exclude glob patterns applied to the
+# fork-sync-all file tree before syncing. Patterns are matched against paths
+# relative to the repo root (e.g. ".github/workflows/pr-automation.yml").
+#
+# Pattern rules:
+#   - Patterns are evaluated in order: includes first, then excludes.
+#   - A path is included if it matches at least one include pattern (or if
+#     no include patterns are defined, all paths are included by default).
+#   - A path is excluded if it matches any exclude pattern, regardless of
+#     whether it matched an include pattern.
+#   - Glob syntax: * matches within a path segment, ** matches across segments.
+#   - Patterns without a leading / are matched against the full relative path.
+#
+# The following paths are ALWAYS excluded regardless of profile or per-consumer
+# overrides (they are repo-specific and must never be overwritten):
+#   README.md, registered-imports.json, dep-graph/, .git/, .ona/
+#
+# Per-consumer overrides in template-consumers.yml:
+#   exclude_paths: [...]  — additional paths to exclude on top of the profile
+#   include_paths: [...]  — re-include paths that the profile excluded
+#   (include_paths are applied after profile excludes, so they can restore
+#    specific files from an otherwise-excluded directory)
+#
+# To add a new profile: append an entry under `profiles:` below.
+# Profile names are arbitrary strings; `full` is the implicit default when
+# no profile is specified for a consumer.
+
+profiles:
+
+  # ── full ────────────────────────────────────────────────────────────────────
+  # Everything in the template tree. Used for standard fork-sync-all consumers
+  # that participate in the full mirror/sync/readme infrastructure.
+  full:
+    description: >
+      All template files. For repos that are full participants in the
+      fork-sync-all mirror and sync infrastructure.
+    # No include/exclude — all files pass through (minus the global exclusions).
+
+  # ── mirror ──────────────────────────────────────────────────────────────────
+  # Full mirror/sync suite plus shared infra tooling. Excludes repo-management
+  # workflows that only make sense on the fork-sync-all repo itself
+  # (sync-template, validate-config, generate-dep-graph).
+  mirror:
+    description: >
+      Mirror and sync workflows plus shared infra tooling. For repos that
+      participate in the OSP/OOC mirror chain but are not fork-sync-all itself.
+    exclude:
+      - .github/workflows/sync-template.yml
+      - .github/workflows/validate-config.yml
+      - .github/workflows/generate-dep-graph.yml
+      - config/gitlab-subgroups.yml
+      - config/template-consumers.yml
+      - config/template-manifest.yml
+      - scripts/validate-gitlab-subgroups.py
+      - scripts/sync-template.sh
+
+  # ── infra-core ──────────────────────────────────────────────────────────────
+  # Shared CI hygiene tooling only. No mirror/sync workflows. Suitable for
+  # repos that are managed under Interested-Deving-1896 but have their own
+  # purpose and don't participate in the mirror chain.
+  infra-core:
+    description: >
+      Shared CI hygiene only: PR automation, token rotation, health checks,
+      branch cleanup, failure resolution, and dependency updates.
+      No mirror or sync workflows.
+    include:
+      - .github/workflows/pr-automation.yml
+      - .github/workflows/rotate-token.yml
+      - .github/workflows/token-health.yml
+      - .github/workflows/cleanup-branches.yml
+      - .github/workflows/resolve-failures.yml
+      - .github/workflows/notify-poller.yml
+      - .github/workflows/update-infra-deps.yml
+      - scripts/pr-automation.sh
+      - scripts/rotate-token.sh
+      - scripts/token-monitor.sh
+      - scripts/cleanup-branches.sh
+      - scripts/resolve-failures.sh
+      - scripts/update-infra-deps.sh
+      - scripts/write-summary.sh
+      - .gitignore
+      - LICENSE
+
+  # ── standalone ──────────────────────────────────────────────────────────────
+  # Minimal footprint: only PR automation and token rotation. For repos that
+  # are self-contained and only need basic CI hygiene without the full infra
+  # tooling suite.
+  standalone:
+    description: >
+      Minimal CI hygiene: PR automation and token rotation only.
+      For self-contained repos that don't need the broader infra suite.
+    include:
+      - .github/workflows/pr-automation.yml
+      - .github/workflows/rotate-token.yml
+      - scripts/pr-automation.sh
+      - scripts/rotate-token.sh
+      - scripts/write-summary.sh
+      - .gitignore
+      - LICENSE

--- a/scripts/sync-template.sh
+++ b/scripts/sync-template.sh
@@ -13,8 +13,9 @@
 #               already exist in the target are skipped unless FORCE=true.
 #
 #   PROPAGATE — read config/template-consumers.yml and sync the template into
-#               every enabled consumer. Per-repo force/skip_osp_setup flags
-#               from the YAML override the global FORCE env var.
+#               every enabled consumer. Per-repo profile, force, skip_osp_setup,
+#               exclude_paths, and include_paths flags from the YAML override
+#               the global defaults.
 #               Triggered automatically on push to main via sync-template.yml.
 #
 # In all modes every file in the fork-sync-all working tree (relative to
@@ -27,6 +28,13 @@
 #   dep-graph/
 #   .git/
 #   .ona/
+#
+# Profile-based filtering:
+#   When MANIFEST_FILE is set, each consumer can specify a `profile` that
+#   controls which files are included/excluded. Profiles are defined in
+#   config/template-manifest.yml. Per-consumer `exclude_paths` and
+#   `include_paths` are applied on top of the profile's own filters.
+#   If no profile is specified, `full` is assumed (all files pass through).
 #
 # Required env vars:
 #   GH_TOKEN        — PAT with repo + admin:org + workflow scopes
@@ -43,6 +51,8 @@
 #   CONSUMERS_FILE  — path to config/template-consumers.yml
 #
 # Optional:
+#   MANIFEST_FILE   — path to config/template-manifest.yml (enables profiles)
+#   PROFILE         — profile name for CREATE/INJECT modes (default: full)
 #   FORCE           — "true" to overwrite files that already exist (default: false)
 #   DRY_RUN         — "true" to report without writing (default: false)
 #   PRIVATE         — "true" to create new repos as private (default: false)
@@ -67,6 +77,8 @@ OOC_ORG="${OOC_ORG:-OpenOS-Project-Ecosystem-OOC}"
 NEW_REPO_NAME="${NEW_REPO_NAME:-}"
 TARGET_REPOS="${TARGET_REPOS:-}"
 CONSUMERS_FILE="${CONSUMERS_FILE:-}"
+MANIFEST_FILE="${MANIFEST_FILE:-}"
+PROFILE="${PROFILE:-full}"
 
 API="https://api.github.com"
 
@@ -197,15 +209,215 @@ commit_file() {
   fi
 }
 
+# ── Profile / manifest filtering ─────────────────────────────────────────────
+
+# Resolve profile filters from the manifest file.
+# Outputs two newline-separated lists to stdout, separated by a sentinel line:
+#
+#   <include patterns>
+#   ---SENTINEL---
+#   <exclude patterns>
+#
+# If MANIFEST_FILE is unset or the profile is "full" with no rules, both lists
+# are empty (meaning: include everything, exclude nothing extra).
+#
+# Args: $1 = profile name
+resolve_profile_filters() {
+  local profile_name="${1:-full}"
+
+  if [[ -z "$MANIFEST_FILE" || ! -f "$MANIFEST_FILE" ]]; then
+    echo "---SENTINEL---"
+    return 0
+  fi
+
+  python3 - "$MANIFEST_FILE" "$profile_name" << 'PYEOF'
+import sys, re
+
+manifest_path = sys.argv[1]
+profile_name  = sys.argv[2]
+
+with open(manifest_path) as f:
+    content = f.read()
+
+# Minimal YAML parser: extract the named profile's include/exclude lists.
+# Handles the indented block-sequence format used in template-manifest.yml.
+lines = content.splitlines()
+
+in_profiles   = False
+in_profile    = False
+in_include    = False
+in_exclude    = False
+includes      = []
+excludes      = []
+
+for line in lines:
+    stripped = line.strip()
+    if not stripped or stripped.startswith('#'):
+        continue
+
+    if stripped == 'profiles:':
+        in_profiles = True
+        continue
+
+    if not in_profiles:
+        continue
+
+    # Top-level profile key (2-space indent)
+    m = re.match(r'^  (\S+):$', line)
+    if m:
+        if in_profile:
+            break  # past our profile — done
+        if m.group(1) == profile_name:
+            in_profile = True
+        in_include = False
+        in_exclude = False
+        continue
+
+    if not in_profile:
+        continue
+
+    # include:/exclude: sub-keys (4-space indent)
+    if re.match(r'^    include:\s*$', line):
+        in_include = True
+        in_exclude = False
+        continue
+    if re.match(r'^    exclude:\s*$', line):
+        in_exclude = True
+        in_include = False
+        continue
+
+    # List items under include/exclude (6-space indent)
+    m = re.match(r'^      - (.+)$', line)
+    if m:
+        val = m.group(1).strip().strip('"\'')
+        if in_include:
+            includes.append(val)
+        elif in_exclude:
+            excludes.append(val)
+        continue
+
+    # Any other 4-space key resets include/exclude context
+    if re.match(r'^    \S', line):
+        in_include = False
+        in_exclude = False
+
+print('\n'.join(includes))
+print('---SENTINEL---')
+print('\n'.join(excludes))
+PYEOF
+}
+
+# Test whether a relative path matches a glob pattern.
+# Uses bash's extglob-free fnmatch via Python for portability.
+# Returns 0 (match) or 1 (no match).
+path_matches_pattern() {
+  local path="$1" pattern="$2"
+  python3 -c "
+import fnmatch, sys
+path    = sys.argv[1]
+pattern = sys.argv[2]
+# Match the full path or any suffix (for directory-prefix patterns like 'scripts/**')
+if fnmatch.fnmatch(path, pattern):
+    sys.exit(0)
+# Also match if pattern ends with /** and path starts with the prefix
+if pattern.endswith('/**'):
+    prefix = pattern[:-3]
+    if path == prefix or path.startswith(prefix + '/'):
+        sys.exit(0)
+# Match basename alone for simple filename patterns
+import os
+if fnmatch.fnmatch(os.path.basename(path), pattern):
+    sys.exit(0)
+sys.exit(1)
+" "$path" "$pattern" 2>/dev/null
+}
+
+# Determine whether a relative path passes the combined profile + per-consumer
+# filter set.
+#
+# Filter resolution order:
+#   1. If profile has include patterns: path must match at least one → included.
+#      If profile has no include patterns: path is included by default.
+#   2. If path matches any profile exclude pattern → excluded.
+#   3. If path matches any consumer exclude_paths pattern → excluded.
+#   4. If path matches any consumer include_paths pattern → re-included
+#      (overrides steps 2 and 3).
+#
+# Args:
+#   $1 = relative path
+#   $2 = newline-separated profile include patterns (may be empty)
+#   $3 = newline-separated profile exclude patterns (may be empty)
+#   $4 = newline-separated consumer exclude_paths (may be empty)
+#   $5 = newline-separated consumer include_paths (may be empty)
+#
+# Returns 0 if the path should be synced, 1 if it should be skipped.
+path_passes_filters() {
+  local rel="$1"
+  local profile_includes="$2"
+  local profile_excludes="$3"
+  local consumer_excludes="$4"
+  local consumer_includes="$5"
+
+  # Step 1: profile include whitelist
+  if [[ -n "$profile_includes" ]]; then
+    local matched=0
+    while IFS= read -r pat; do
+      [[ -z "$pat" ]] && continue
+      path_matches_pattern "$rel" "$pat" && matched=1 && break
+    done <<< "$profile_includes"
+    [[ "$matched" -eq 0 ]] && return 1
+  fi
+
+  # Steps 2+3: profile and consumer excludes
+  local excluded=0
+  while IFS= read -r pat; do
+    [[ -z "$pat" ]] && continue
+    path_matches_pattern "$rel" "$pat" && excluded=1 && break
+  done <<< "$profile_excludes"
+
+  if [[ "$excluded" -eq 0 && -n "$consumer_excludes" ]]; then
+    while IFS= read -r pat; do
+      [[ -z "$pat" ]] && continue
+      path_matches_pattern "$rel" "$pat" && excluded=1 && break
+    done <<< "$consumer_excludes"
+  fi
+
+  # Step 4: consumer include_paths re-include
+  if [[ "$excluded" -eq 1 && -n "$consumer_includes" ]]; then
+    while IFS= read -r pat; do
+      [[ -z "$pat" ]] && continue
+      path_matches_pattern "$rel" "$pat" && excluded=0 && break
+    done <<< "$consumer_includes"
+  fi
+
+  [[ "$excluded" -eq 0 ]]
+}
+
 # ── Collect template files ────────────────────────────────────────────────────
 
-# Returns a list of relative paths for all files in TEMPLATE_ROOT that are
-# not excluded. One path per line.
+# Returns a list of relative paths for all files in TEMPLATE_ROOT that pass
+# both the global exclusion list and the provided profile/consumer filters.
+# One path per line.
+#
+# Args:
+#   $1 = newline-separated profile include patterns (may be empty)
+#   $2 = newline-separated profile exclude patterns (may be empty)
+#   $3 = newline-separated consumer exclude_paths (may be empty)
+#   $4 = newline-separated consumer include_paths (may be empty)
 collect_template_files() {
+  local profile_includes="${1:-}"
+  local profile_excludes="${2:-}"
+  local consumer_excludes="${3:-}"
+  local consumer_includes="${4:-}"
+
   find "$TEMPLATE_ROOT" -type f \
     | sed "s|^${TEMPLATE_ROOT}/||" \
     | while IFS= read -r rel; do
         is_excluded_path "$rel" && continue
+        path_passes_filters "$rel" \
+          "$profile_includes" "$profile_excludes" \
+          "$consumer_excludes" "$consumer_includes" \
+          || continue
         echo "$rel"
       done \
     | sort
@@ -213,8 +425,19 @@ collect_template_files() {
 
 # ── Sync all template files into a single target repo ────────────────────────
 
+# Args:
+#   $1 = repo name
+#   $2 = profile include patterns (newline-separated, may be empty)
+#   $3 = profile exclude patterns (newline-separated, may be empty)
+#   $4 = consumer exclude_paths (newline-separated, may be empty)
+#   $5 = consumer include_paths (newline-separated, may be empty)
 sync_into_repo() {
   local repo="$1"
+  local profile_includes="${2:-}"
+  local profile_excludes="${3:-}"
+  local consumer_excludes="${4:-}"
+  local consumer_includes="${5:-}"
+
   info "──────────────────────────────────────────"
   info "Syncing template → ${GITHUB_OWNER}/${repo}"
 
@@ -243,7 +466,9 @@ sync_into_repo() {
     # Brief pause to avoid secondary rate limits on rapid sequential writes
     [[ "$DRY_RUN" != "true" ]] && sleep 0.3
 
-  done < <(collect_template_files)
+  done < <(collect_template_files \
+    "$profile_includes" "$profile_excludes" \
+    "$consumer_excludes" "$consumer_includes")
 
   info "  Files processed: ${files_ok} | failed: ${files_failed}"
   [[ "$files_failed" -eq 0 ]]
@@ -254,9 +479,15 @@ sync_into_repo() {
 run_create() {
   info "========================================"
   info "  CREATE mode: ${GITHUB_OWNER}/${NEW_REPO_NAME}"
-  info "  DRY_RUN=${DRY_RUN}  FORCE=${FORCE}  PRIVATE=${PRIVATE}"
+  info "  DRY_RUN=${DRY_RUN}  FORCE=${FORCE}  PRIVATE=${PRIVATE}  PROFILE=${PROFILE}"
   info "========================================"
   echo ""
+
+  # Resolve profile filters
+  local filter_output profile_includes profile_excludes
+  filter_output=$(resolve_profile_filters "$PROFILE")
+  profile_includes=$(echo "$filter_output" | sed '/^---SENTINEL---$/,$d')
+  profile_excludes=$(echo "$filter_output" | sed '1,/^---SENTINEL---$/d')
 
   # 1. Create the repo if it doesn't exist
   local existing
@@ -289,7 +520,8 @@ run_create() {
   echo ""
 
   # 2. Sync template files
-  sync_into_repo "$NEW_REPO_NAME" || warn "Template sync had failures."
+  sync_into_repo "$NEW_REPO_NAME" "$profile_includes" "$profile_excludes" "" "" \
+    || warn "Template sync had failures."
   echo ""
 
   # 3. OSP/OOC mirror setup
@@ -340,9 +572,15 @@ run_inject() {
   info "========================================"
   info "  INJECT mode"
   info "  Targets: ${TARGET_REPOS}"
-  info "  DRY_RUN=${DRY_RUN}  FORCE=${FORCE}"
+  info "  DRY_RUN=${DRY_RUN}  FORCE=${FORCE}  PROFILE=${PROFILE}"
   info "========================================"
   echo ""
+
+  # Resolve profile filters (shared across all inject targets)
+  local filter_output profile_includes profile_excludes
+  filter_output=$(resolve_profile_filters "$PROFILE")
+  profile_includes=$(echo "$filter_output" | sed '/^---SENTINEL---$/,$d')
+  profile_excludes=$(echo "$filter_output" | sed '1,/^---SENTINEL---$/d')
 
   local ok=0 failed=0
   for repo in $TARGET_REPOS; do
@@ -357,7 +595,7 @@ run_inject() {
       continue
     fi
 
-    if sync_into_repo "$repo"; then
+    if sync_into_repo "$repo" "$profile_includes" "$profile_excludes" "" ""; then
       (( ok++ )) || true
     else
       (( failed++ )) || true
@@ -386,26 +624,47 @@ run_propagate() {
   [[ -f "$CONSUMERS_FILE" ]] || error "CONSUMERS_FILE not found: ${CONSUMERS_FILE}"
 
   # Parse consumers from YAML using python3 (no PyYAML needed — stdlib only).
-  # Outputs one line per enabled consumer: name|force|skip_osp_setup
-  local consumer_lines
-  consumer_lines=$(python3 - "$CONSUMERS_FILE" << 'PYEOF'
+  # Outputs one record per enabled consumer. Fields are newline-separated within
+  # a record; records are separated by "---RECORD---".
+  #
+  # Record format (one field per line):
+  #   name
+  #   force (true|false)
+  #   skip_osp_setup (true|false)
+  #   profile (name, default: full)
+  #   exclude_paths (space-separated, may be empty)
+  #   include_paths (space-separated, may be empty)
+  local consumer_records
+  consumer_records=$(python3 - "$CONSUMERS_FILE" << 'PYEOF'
 import sys, re
 
 path = sys.argv[1]
 with open(path) as f:
     content = f.read()
 
-# Strip comments
+# Strip inline comments
 lines = [re.sub(r'\s*#.*$', '', l) for l in content.splitlines()]
 
-# Find the consumers: list block
 in_consumers = False
-in_entry = False
-name = force = skip_osp = disabled = None
+in_entry     = False
+in_excludes  = False
+in_includes  = False
+
+name = force = skip_osp = disabled = profile = None
+exclude_paths = []
+include_paths = []
 
 def emit():
     if name and disabled != 'true':
-        print(f"{name}|{force or 'false'}|{skip_osp or 'false'}")
+        excl = ' '.join(exclude_paths) if exclude_paths else ''
+        incl = ' '.join(include_paths) if include_paths else ''
+        print(name)
+        print(force    or 'false')
+        print(skip_osp or 'false')
+        print(profile  or 'full')
+        print(excl)
+        print(incl)
+        print('---RECORD---')
 
 for line in lines:
     stripped = line.strip()
@@ -419,67 +678,130 @@ for line in lines:
     if not in_consumers:
         continue
 
-    # New list entry
-    if re.match(r'^  - name:', stripped) or re.match(r'^- name:', stripped):
+    # New list entry (starts with "  - name:" at 2-space indent)
+    if re.match(r'^\s*-\s*name:\s*\S', line):
         if in_entry:
             emit()
-        name     = re.sub(r'^-?\s*name:\s*', '', stripped).strip().strip('"\'')
-        force    = None
-        skip_osp = None
-        disabled = None
-        in_entry = True
+        name          = re.sub(r'^\s*-\s*name:\s*', '', line).strip().strip('"\'')
+        force         = None
+        skip_osp      = None
+        disabled      = None
+        profile       = None
+        exclude_paths = []
+        include_paths = []
+        in_entry      = True
+        in_excludes   = False
+        in_includes   = False
         continue
 
-    if in_entry:
-        m = re.match(r'^\s*(force|skip_osp_setup|disabled):\s*(\S+)', line)
-        if m:
-            key, val = m.group(1), m.group(2).strip().strip('"\'')
-            if key == 'force':        force    = val
-            elif key == 'skip_osp_setup': skip_osp = val
-            elif key == 'disabled':   disabled = val
+    if not in_entry:
+        continue
+
+    # Scalar fields
+    m = re.match(r'^\s+(force|skip_osp_setup|disabled|profile):\s*(\S+)', line)
+    if m:
+        key, val = m.group(1), m.group(2).strip().strip('"\'')
+        if   key == 'force':          force    = val
+        elif key == 'skip_osp_setup': skip_osp = val
+        elif key == 'disabled':       disabled = val
+        elif key == 'profile':        profile  = val
+        in_excludes = False
+        in_includes = False
+        continue
+
+    # List-header fields
+    if re.match(r'^\s+exclude_paths:\s*$', line):
+        in_excludes = True
+        in_includes = False
+        continue
+    if re.match(r'^\s+include_paths:\s*$', line):
+        in_includes = True
+        in_excludes = False
+        continue
+
+    # List items
+    m = re.match(r'^\s+-\s+(.+)$', line)
+    if m:
+        val = m.group(1).strip().strip('"\'')
+        if in_excludes:
+            exclude_paths.append(val)
+        elif in_includes:
+            include_paths.append(val)
+        continue
+
+    # Any other key at entry indent resets list context
+    if re.match(r'^\s+\S', line):
+        in_excludes = False
+        in_includes = False
 
 if in_entry:
     emit()
 PYEOF
   ) || error "Failed to parse ${CONSUMERS_FILE}"
 
-  if [[ -z "$consumer_lines" ]]; then
+  if [[ -z "$consumer_records" ]]; then
     info "No enabled consumers found in ${CONSUMERS_FILE} — nothing to do."
     return 0
   fi
 
   local total ok failed
-  total=$(echo "$consumer_lines" | grep -c '^') || total=0
+  total=$(echo "$consumer_records" | grep -c '^---RECORD---$') || total=0
   ok=0; failed=0
 
   info "Found ${total} enabled consumer(s)."
   echo ""
 
-  while IFS='|' read -r repo consumer_force consumer_skip_osp; do
-    [[ -z "$repo" ]] && continue
+  # Process each record
+  while IFS= read -r record; do
+    [[ -z "$record" ]] && continue
+
+    local c_name c_force c_skip_osp c_profile c_excludes c_includes
+    c_name     =$(echo "$record" | sed -n '1p')
+    c_force    =$(echo "$record" | sed -n '2p')
+    c_skip_osp=$(echo "$record" | sed -n '3p')
+    c_profile  =$(echo "$record" | sed -n '4p')
+    c_excludes=$(echo "$record" | sed -n '5p')
+    c_includes=$(echo "$record" | sed -n '6p')
+
+    [[ -z "$c_name" ]] && continue
 
     # Per-consumer force overrides global FORCE
     local effective_force="$FORCE"
-    [[ "$consumer_force" == "true" ]] && effective_force="true"
+    [[ "$c_force" == "true" ]] && effective_force="true"
 
     info "──────────────────────────────────────────"
-    info "Consumer: ${GITHUB_OWNER}/${repo}"
-    info "  force=${effective_force}  skip_osp_setup=${consumer_skip_osp}"
+    info "Consumer: ${GITHUB_OWNER}/${c_name}"
+    info "  profile=${c_profile}  force=${effective_force}  skip_osp_setup=${c_skip_osp}"
+    [[ -n "$c_excludes" ]] && info "  exclude_paths: ${c_excludes}"
+    [[ -n "$c_includes" ]] && info "  include_paths: ${c_includes}"
 
     # Verify repo exists
     local meta
-    meta=$(gh_get "${API}/repos/${GITHUB_OWNER}/${repo}" 2>/dev/null) || true
-    if [[ -z "$meta" || "$(echo "$meta" | jq -r '.name // empty' 2>/dev/null)" != "$repo" ]]; then
-      warn "  Repo ${GITHUB_OWNER}/${repo} not found — skipping."
+    meta=$(gh_get "${API}/repos/${GITHUB_OWNER}/${c_name}" 2>/dev/null) || true
+    if [[ -z "$meta" || "$(echo "$meta" | jq -r '.name // empty' 2>/dev/null)" != "$c_name" ]]; then
+      warn "  Repo ${GITHUB_OWNER}/${c_name} not found — skipping."
       (( failed++ )) || true
       echo ""
       continue
     fi
 
+    # Resolve profile filters
+    local filter_output profile_includes profile_excludes
+    filter_output=$(resolve_profile_filters "$c_profile")
+    profile_includes=$(echo "$filter_output" | sed '/^---SENTINEL---$/,$d')
+    profile_excludes=$(echo "$filter_output" | sed '1,/^---SENTINEL---$/d')
+
+    # Convert space-separated consumer paths to newline-separated for filter functions
+    local consumer_excl_nl consumer_incl_nl
+    consumer_excl_nl=$(echo "$c_excludes" | tr ' ' '\n')
+    consumer_incl_nl=$(echo "$c_includes" | tr ' ' '\n')
+
     # Temporarily override FORCE for this consumer
     local saved_force="$FORCE"
     FORCE="$effective_force"
-    if sync_into_repo "$repo"; then
+    if sync_into_repo "$c_name" \
+        "$profile_includes" "$profile_excludes" \
+        "$consumer_excl_nl" "$consumer_incl_nl"; then
       (( ok++ )) || true
     else
       (( failed++ )) || true
@@ -487,7 +809,14 @@ PYEOF
     FORCE="$saved_force"
     echo ""
 
-  done <<< "$consumer_lines"
+  done < <(python3 -c "
+import sys
+content = sys.stdin.read()
+for rec in content.split('---RECORD---\n'):
+    rec = rec.strip()
+    if rec:
+        print(rec)
+" <<< "$consumer_records")
 
   info "========================================"
   info "  Propagate complete"


### PR DESCRIPTION
## What

Adds a two-layer filter system to `sync-template.sh` so consumer repos receive only the template files relevant to their role, rather than the entire tree.

## Why

KPort inherited all fork-sync-all workflows via template propagation. Workflows like `validate-config.yml` and `update-readmes.yml` called scripts that don't exist in KPort, causing CI failures on every push. The fix needed to be structural — not a one-time cleanup — so future consumers with diverged file trees don't hit the same problem.

## How

**Layer 1 — profiles** (`config/template-manifest.yml`):

| Profile | What it syncs |
|---|---|
| `full` | Everything (default, backward-compatible) |
| `mirror` | Full mirror/sync suite; drops the 8 fork-sync-all-only files |
| `infra-core` | CI hygiene whitelist: PR automation, token rotation, branch cleanup, failure resolution, dep updates |
| `standalone` | Minimal: PR automation + token rotation only |

**Layer 2 — per-consumer overrides** (`config/template-consumers.yml`):
- `exclude_paths` — additional glob exclusions on top of the profile
- `include_paths` — re-include specific files dropped by the profile

Filter resolution order:
1. Profile include whitelist (if defined, only listed paths pass)
2. Profile exclude patterns
3. Consumer `exclude_paths`
4. Consumer `include_paths` (re-adds over steps 2–3)

## Files changed

- `config/template-manifest.yml` — new; defines the four built-in profiles
- `config/template-consumers.yml` — schema expanded with `profile`, `exclude_paths`, `include_paths` fields and updated examples
- `scripts/sync-template.sh` — `resolve_profile_filters()`, `path_passes_filters()`, and `path_matches_pattern()` added; `collect_template_files()` and `sync_into_repo()` updated to accept filter args; all three modes updated
- `.github/workflows/sync-template.yml` — `MANIFEST_FILE` passed to both jobs; `profile` input added to dispatch form; `config/template-manifest.yml` added to `paths-ignore`
- `README.md` — new `## Template Sync` section documenting profiles, consumer registration, and filter resolution

## Compatibility

`full` profile with no rules is a no-op. `consumers: []` behaves identically to before. No existing behaviour changes unless a consumer is explicitly given a non-`full` profile.