### PR TITLE
feat: add Ona skills for KPort audit and fork-sync-all audit workflows

### DIFF
--- a/.ona/skills/fork-sync-all-audit.md
+++ b/.ona/skills/fork-sync-all-audit.md
@@ -1,0 +1,172 @@
+---
+name: fork-sync-all-audit
+description: >
+  Audit and fix fork-sync-all GitHub Actions workflows for correctness,
+  consistency, and completeness. Use when asked to audit fork-sync-all,
+  fix workflow bugs, review CI, check workflow triggers, or improve the
+  mirror/sync infrastructure.
+  Triggers on "audit fork-sync-all", "fix workflows", "workflow audit",
+  "mirror chain audit", "sync workflow", "fork-sync audit".
+---
+
+# fork-sync-all Audit Skill
+
+## Overview
+
+`fork-sync-all` is the central infrastructure repo for `Interested-Deving-1896`.
+It contains:
+- **Workflows** (`.github/workflows/`) — 40+ GitHub Actions workflows for
+  mirroring, syncing, README generation, token rotation, and CI hygiene
+- **Scripts** (`scripts/`) — bash/python scripts called by workflows
+- **Config** (`config/`) — YAML config files for template consumers, GitLab
+  subgroups, overlay manifests, etc.
+
+The repo acts as a **template** that propagates files to consumer repos via
+`sync-template.sh` / `sync-template.yml`.
+
+---
+
+## Audit Checklist
+
+### 1. workflow_run trigger name mismatches
+The most common silent bug. `workflow_run` triggers match on the workflow's
+`name:` field, not its filename.
+
+```bash
+# Find all workflow_run triggers
+grep -rn 'workflow_run' .github/workflows/ | grep 'workflows:'
+
+# Cross-check each referenced name against actual workflow name: fields
+grep -rh '^name:' .github/workflows/ | sort
+```
+**Known instance:** `update-readmes.yml` and `translate-readmes.yml` both
+referenced `"sync-from-gitlab"` but the actual workflow name is
+`"Sync from GitLab"` — causing both post-GitLab-sync passes to be silently dead.
+
+### 2. DRY_RUN / REPO_FILTER input consistency
+Every workflow that iterates over repos should expose:
+```yaml
+inputs:
+  dry_run:
+    description: 'Print actions without making changes'
+    type: boolean
+    default: false
+  repo_filter:
+    description: 'Substring match on repo name (blank = all)'
+    type: string
+    default: ''
+```
+`repo_filter` must be a **substring match** (`[[ "$repo" == *"$REPO_FILTER"* ]]`),
+not an exact match or regex. Check all scripts that iterate repos.
+
+### 3. Script input propagation
+Workflow env vars must be passed through to scripts. Common pattern:
+```yaml
+env:
+  DRY_RUN: ${{ inputs.dry_run }}
+  REPO_FILTER: ${{ inputs.repo_filter }}
+```
+Scripts read `${DRY_RUN:-false}` and `${REPO_FILTER:-}`.
+
+### 4. Retry logic on API calls
+All `curl` calls to GitHub/GitLab APIs should use `--retry 3 --retry-delay 5`.
+Workflows that call scripts in a loop should have `continue-on-error: true`
+on the step or handle failures gracefully.
+
+### 5. Cron schedule stagger
+Multiple workflows should not all run at `:00`. Stagger by 5–10 minutes to
+avoid API rate limit collisions:
+```yaml
+# Good — staggered
+- cron: '0 2 * * *'   # workflow A
+- cron: '10 2 * * *'  # workflow B
+- cron: '20 2 * * *'  # workflow C
+```
+
+### 6. Template consumer registry
+`config/template-consumers.yml` lists repos that receive automatic template
+updates. Check:
+- All active consumer repos are listed
+- Each has the correct `profile` (`full` | `mirror` | `infra-core` | `standalone`)
+- `enabled: true` for repos that should receive updates
+- `skip_osp_setup: true` for repos that don't participate in the OSP mirror chain
+
+Profiles defined in `config/template-manifest.yml`:
+| Profile | Contents |
+|---|---|
+| `full` | Everything (default) |
+| `mirror` | Mirror/sync suite + infra; excludes fork-sync-all-only files |
+| `infra-core` | CI hygiene only (PR automation, token rotation, branch cleanup) |
+| `standalone` | Minimal: PR automation + token rotation only |
+
+### 7. GitLab subgroup assignments
+`config/gitlab-subgroups.yml` maps GitHub repos to GitLab subgroups for the
+OSP mirror chain. Validate with:
+```bash
+python3 scripts/validate-gitlab-subgroups.py
+```
+The CI job `validate-config` runs this on every push.
+
+### 8. Mirror artifact workflow inputs
+`mirror-artifacts.yml` requires `source_repo` and `artifact_name` inputs.
+Check that callers pass both. The workflow should fail fast if either is empty.
+
+### 9. Token health
+`token-health.yml` runs on a schedule and checks PAT expiry. Verify:
+- The schedule is set (not commented out)
+- `rotate-token.yml` is triggered when health check fails
+- `GH_TOKEN` secret is set in the repo
+
+---
+
+## Template sync workflow
+
+`sync-template.sh` has three modes:
+
+| Mode | Trigger | What it does |
+|---|---|---|
+| `CREATE` | Manual | Creates new repo + pushes template + OSP setup |
+| `INJECT` | Manual | Copies template into existing repos (skips existing files unless `FORCE=true`) |
+| `PROPAGATE` | Push to main | Reads `template-consumers.yml`, syncs all enabled consumers |
+
+Always-excluded paths (never overwritten in consumers):
+`README.md`, `registered-imports.json`, `dep-graph/`, `.git/`, `.ona/`
+
+Per-consumer overrides in `template-consumers.yml`:
+```yaml
+- name: my-repo
+  profile: infra-core
+  exclude_paths:
+    - .github/workflows/update-readmes.yml
+  include_paths:
+    - .github/workflows/rotate-token.yml
+  force: true
+```
+
+---
+
+## Commit conventions
+
+```
+fix: <pass>-pass audit — <short summary>
+
+- <workflow>: <what was wrong and what was fixed>
+
+Co-authored-by: Ona <no-reply@ona.com>
+```
+
+Branch naming: `fix/<description>` or `feat/<description>`
+
+---
+
+## Anti-patterns
+
+- Do NOT use exact string match for `REPO_FILTER` — must be substring
+  (`*"$filter"*`) so partial names work
+- Do NOT schedule all workflows at `:00` — stagger to avoid rate limits
+- Do NOT reference workflow filenames in `workflow_run` triggers — use the
+  `name:` field value
+- Do NOT add repos to `template-consumers.yml` with `enabled: true` before
+  verifying the repo exists and has the correct branch structure
+- Do NOT set `force: true` globally in `template-consumers.yml` — it will
+  overwrite repo-specific customisations on every push to main

--- a/.ona/skills/kport-audit.md
+++ b/.ona/skills/kport-audit.md
@@ -1,0 +1,230 @@
+---
+name: kport-audit
+description: >
+  Audit and fix KPort pacscripts for completeness, correctness, and consistency.
+  Use when asked to audit KPort, fix pacscript fields, fill sha256sums, bump
+  versions, fill depends=(), fix GPU/CPU tiers, or clean up URLs.
+  Triggers on "audit KPort", "fix pacscripts", "fill sha256", "bump version",
+  "fill depends", "kport audit", "pacscript audit".
+---
+
+# KPort Audit Skill
+
+## Overview
+
+KPort pacscripts live under `packages/` (production) and `overlays/`
+(arch-specific or community packages). Each pacscript is a bash file with
+standard Pacstall fields plus KPort-specific fields (`KNEON_CHANNEL`,
+`KGPU_MIN`, `KCPU_MIN`, `KUSE`, `KSLOT`).
+
+The audit workflow runs in rounds. Each round scans for a class of issues,
+fixes them, commits, and opens a PR. Merge each PR before starting the next.
+
+---
+
+## Audit Checklist
+
+Run these checks in order. All use `find packages/ overlays/ -name "*.pacscript"`.
+
+### 1. SKIP / placeholder sha256sums
+```bash
+# Remaining SKIP placeholders
+find packages/ overlays/ -name "*.pacscript" | xargs grep -l '"SKIP"'
+
+# Fake hashes (repeating byte pattern)
+find packages/ overlays/ -name "*.pacscript" | \
+  xargs grep -rn '"[a-f0-9]\{64\}"' | \
+  awk -F'"' '{print $2}' | sort | uniq -d
+```
+Fix with `scripts/kport/fill-sha256.sh --dir <dir>`. The script expands
+`${pkgver}`/`${pkgname}` in URLs before fetching. For overlays, patch manually:
+```bash
+curl -sL "<url>" | sha256sum
+# then edit the pacscript directly
+```
+
+### 2. Missing required KPort fields
+```bash
+find packages/ overlays/ -name "*.pacscript" | xargs grep -L 'KNEON_CHANNEL'
+find packages/ overlays/ -name "*.pacscript" | xargs grep -L 'KGPU_MIN'
+find packages/ overlays/ -name "*.pacscript" | xargs grep -L 'KCPU_MIN'
+find packages/ overlays/ -name "*.pacscript" | xargs grep -L 'KUSE'
+```
+**Intentional omissions:**
+- `KCPU_MIN`: pure data/icon/doc packages (`kf6-*-icon-theme`, `qt6-doc`,
+  `qt6-translations`, `kdeedu-data`)
+- `KUSE`: pure data/build-tools with no test suite (`lxqt-build-tools`,
+  `lxqt-menu-data`, `lxqt-themes`)
+
+Standard values:
+- `KNEON_CHANNEL`: `"stable"` | `"unstable"` | `"nightly"`
+- `KGPU_MIN`: `"gpu-none"` | `"gpu-sw"` | `"gpu-gl2"` | `"gpu-vk12"`
+- `KCPU_MIN`: `"x86-64-v1"` | `"x86-64-v2"` | `"x86-64-v3"` | `"aarch64-baseline"` | `"i686-baseline"`
+- `KUSE`: array of USE flags, e.g. `("-test")` to disable tests
+
+### 3. Stub depends=()
+```bash
+find packages/ overlays/ -name "*.pacscript" | \
+  xargs grep -l 'Populate after a test build\|No named runtime deps'
+```
+Fill from the KDE Neon apt index:
+```bash
+# Download once — jammy index covers most KF6/Plasma/Gear packages
+curl -sL "https://archive.neon.kde.org/user/dists/jammy/main/binary-amd64/Packages.gz" \
+  | gunzip > /tmp/neon-packages.txt
+
+# Noble index for newer packages (libpyside6, qt6-interfaceframework, etc.)
+curl -sL "https://archive.neon.kde.org/unstable/dists/noble/main/binary-amd64/Packages.gz" \
+  | gunzip > /tmp/neon-noble-packages.txt
+```
+Look up each package by its KPort `pkgname` — Neon uses the same names for
+most packages. Known renames:
+
+| KPort name | Neon package name |
+|---|---|
+| `kf6-kactivities` | `plasma-activities` |
+| `kf6-kactivities-stats` | `plasma-activities-stats` |
+| `kf6-kwayland` | `kwayland` |
+| `kf6-plasma-framework` | `libplasma6` |
+
+Filter out pure system libs (`libc6`, `libstdc++6`, `libgcc-s1`, `zlib1g`).
+Keep named system libs and all KPort-managed packages.
+
+**Malformed block patterns to watch for:**
+
+1. `).` + stub comment + bare `)` — real deps were filled but stub comment
+   left as a dangling tail. Fix with:
+   ```python
+   re.sub(r'\)\.\n(?:  #[^\n]*\n)+\)', ')', content)
+   ```
+
+2. Unclosed `depends=(` with comment but no closing `)` — the blank line
+   before `makedepends=(` acts as implicit end. Fix:
+   ```python
+   re.sub(r'^(depends=\()\n(?:  #[^\n]*\n)+\n', make_block(deps) + '\n\n', content, flags=re.M)
+   ```
+
+Pure data/header packages with no runtime deps: use `depends=()` (empty,
+closed). Examples: `kdeedu-data`, `plasma-wayland-protocols`, `libastro1`.
+
+### 4. Version drift
+```bash
+# Check version spread per category
+find packages/plasma/ -name "*.pacscript" | xargs grep 'pkgver=' | \
+  awk -F'"' '{print $2}' | sort -Vu
+
+find packages/frameworks/ -name "*.pacscript" | xargs grep 'pkgver=' | \
+  awk -F'"' '{print $2}' | sort -Vu
+
+find packages/qt6/ -name "*.pacscript" | xargs grep 'pkgver=' | \
+  awk -F'"' '{print $2}' | sort -Vu
+```
+Packages within the same upstream release train should share a version.
+Outliers with independent versioning (intentional):
+- `libpolkit-qt6-1-1` (0.201.x), `kf6-kirigami-addons` (1.x),
+  `kf6-ktextaddons` (2.x), `qt6-phonon` (4.x), `qtcreator` (19.x),
+  `plasma-wayland-protocols` (1.x), `kf6-oxygen-icon-theme` (6.1.0 is latest)
+
+Verify tarballs exist before bumping:
+```bash
+curl -sI "https://download.kde.org/stable/plasma/<ver>/<name>-<ver>.tar.xz" | head -3
+```
+KDE download URL patterns:
+- Plasma: `https://download.kde.org/stable/plasma/<ver>/<name>-<ver>.tar.xz`
+- Frameworks: `https://download.kde.org/stable/frameworks/<maj.min>/<name>-<ver>.tar.xz`
+- Gear: `https://download.kde.org/stable/release-service/<ver>/src/<name>-<ver>.tar.xz`
+- Qt6 (GitHub): `https://github.com/qt/<repo>/archive/refs/tags/v<ver>.tar.gz`
+
+Check available versions:
+```bash
+curl -sL "https://download.kde.org/stable/plasma/" | grep -oP '(?<=href=")[0-9.]+(?=/)' | sort -V | tail -5
+curl -sL "https://download.kde.org/stable/frameworks/" | grep -oP '(?<=href=")[0-9.]+(?=/)' | sort -V | tail -5
+```
+
+### 5. GPU/CPU tier consistency
+```bash
+# Vulkan packages should use x86-64-v2 minimum, not v1
+find packages/ -name "*.pacscript" | \
+  xargs grep -l 'KGPU_MIN="gpu-vk' | \
+  xargs grep -l 'KCPU_MIN="x86-64-v1"'
+```
+Vulkan 1.2 hardware requires SSE4.2-era CPUs → `x86-64-v2`.
+
+### 6. URL cleanup
+```bash
+find packages/ overlays/ -name "*.pacscript" | xargs grep -rl 'url="http://' | \
+  xargs sed -i 's|url="http://|url="https://|g'
+```
+
+### 7. dep-map.yml coverage
+```bash
+find packages/ overlays/ -name "*.pacscript" | \
+  xargs grep -rh '"~apt:[^"]*"' | \
+  sed 's/.*"~apt:\([^"]*\)".*/\1/' | sort -u | while read dep; do
+    grep -q "^  $dep:" config/dep-map.yml || echo "UNMAPPED: $dep"
+  done
+```
+Three KDE Gear libs resolve to KPort packages (not `~apt:`):
+- `libdolphinvcs6` → `dolphin`
+- `libksanecore` → `libksane`
+- `okular-backends` → `okular`
+
+### 8. masks.yml — Vulkan packages
+Packages with `KGPU_MIN="gpu-vk12"` should have explicit entries in
+`config/masks.yml`:
+```yaml
+- pkg: qt6/qt6-shadertools
+  gpu: [gpu-sw, gpu-gl2]
+  reason: "Requires Vulkan 1.2 (KGPU_MIN=gpu-vk12)"
+```
+
+---
+
+## Overlay notes
+
+### community-32bit (LXQt 1.4 for i686)
+- Qt 6 / KF6 require 64-bit; this overlay uses Qt5/LXQt
+- `lxqt-themes` is at 1.3.0 — upstream jumped from 1.3.0 to 2.0.0; no 1.4.0 exists
+- `lxqt-build-tools`, `lxqt-menu-data`, `lxqt-themes` intentionally omit `KUSE`/`KCPU_MIN`
+
+### community-32bit-plasma5 (KDE Plasma 5.27 LTS for i686)
+- Validated against Arch Linux 32 (Plasma 5.27.7 builds on i686)
+- Plasma 5.27 is the last Qt5/KF5 release; Plasma 6 requires 64-bit
+
+---
+
+## kport-detect-npu.sh arch dispatch
+
+The NPU detector uses `case "$ARCH" in` to gate detectors by arch:
+- `i686`: NVIDIA Tensor + OpenCL only (Intel NPU / AMD XDNA are x86-64-only)
+- `x86_64`: Intel NPU → AMD XDNA → NVIDIA Tensor → OpenCL
+- `aarch64`: Qualcomm HTP → ARM NPU → OpenCL
+- `riscv64`: OpenCL only
+- `*`: full chain as fallback
+
+---
+
+## Commit conventions
+
+```
+fix: audit round N — <short summary>
+
+- <category>: <what changed>
+
+Co-authored-by: Ona <no-reply@ona.com>
+```
+
+Branch naming: `fix/audit-round<N>`
+
+---
+
+## Anti-patterns
+
+- Do NOT bump `kf6-oxygen-icon-theme` past 6.1.0 — 6.1.0 is the upstream ceiling
+- Do NOT add `KCPU_MIN` to pure data packages — intentionally absent
+- Do NOT treat duplicate sha256sums as suspicious — `kwin`/`kwin-wayland` share
+  a tarball; the example overlay mirrors main tree intentionally
+- Do NOT run `fill-sha256.sh` on `packages/` without `--dir packages/` — it
+  defaults to `generated/`
+- Do NOT use `6.26.0` as a Plasma version — latest Plasma is 6.6.x; `6.26.0`
+  is a KF6 frameworks version

--- a/config/template-manifest.yml
+++ b/config/template-manifest.yml
@@ -23,6 +23,10 @@
 # overrides (they are repo-specific and must never be overwritten):
 #   README.md, registered-imports.json, dep-graph/, .git/, .ona/
 #
+# Note: .ona/ contains workspace-specific Ona agent data (review comments,
+# skills). Skills in .ona/skills/ are intentionally not propagated — each
+# repo's skills should reflect that repo's own workflows, not fork-sync-all's.
+#
 # Per-consumer overrides in template-consumers.yml:
 #   exclude_paths: [...]  — additional paths to exclude on top of the profile
 #   include_paths: [...]  — re-include paths that the profile excluded


### PR DESCRIPTION
## Summary

Two reusable Ona skills extracted from session history, added to `.ona/skills/`.

## Skills added

### `kport-audit.md`
Full audit checklist for KPort pacscripts covering all checks developed across audit rounds 1–6:
- sha256sum validation (SKIP placeholders, fake hashes)
- Required KPort field completeness (`KNEON_CHANNEL`, `KGPU_MIN`, `KCPU_MIN`, `KUSE`)
- Stub `depends=()` filling from the KDE Neon apt index (jammy + noble), including known package renames and malformed block patterns
- Version drift detection per category with KDE download URL patterns
- GPU/CPU tier consistency (Vulkan packages need `x86-64-v2`, not `v1`)
- URL cleanup (`http://` → `https://`)
- `dep-map.yml` coverage for `~apt:` deps
- `masks.yml` Vulkan mask entries
- Overlay-specific notes (community-32bit LXQt, community-32bit-plasma5)
- NPU detector arch dispatch reference
- Anti-patterns (common mistakes to avoid)

### `fork-sync-all-audit.md`
Audit checklist for fork-sync-all GitHub Actions workflows covering all issues found across audit passes 1–5:
- `workflow_run` trigger name mismatch (filename vs `name:` field)
- `DRY_RUN` / `REPO_FILTER` input consistency and substring match requirement
- Script input propagation patterns
- Retry logic on API calls
- Cron schedule stagger
- Template consumer registry (`template-consumers.yml`) review
- GitLab subgroup validation
- Mirror artifact workflow inputs
- Token health check
- Template sync mode reference (CREATE / INJECT / PROPAGATE)
- Anti-patterns

## Notes

Skills live in `.ona/skills/` which Ona reads from the workspace. The `.ona/` directory is in the global always-excluded list in `template-manifest.yml` and is **not** propagated to consumer repos — skills are workspace-specific.
