### PR TITLE
feat: add KPort to neon-deving GitLab subgroup

### DIFF
--- a/config/gitlab-subgroups.yml
+++ b/config/gitlab-subgroups.yml
@@ -69,6 +69,11 @@ subgroups:
       - talos-incus
       - waydroid-toolkit
 
+  neon-deving:
+    id: 130739746
+    repos:
+      - KPort
+
   ops:
     id: 130734009
     repos:


### PR DESCRIPTION
## Summary

Registers KPort in the OSP → GitLab mirror chain, routed to the `neon-deving` subgroup.

## What this does

- Adds `KPort` to `config/gitlab-subgroups.yml` under `neon-deving` (namespace ID `130739746`)
- Once merged, the ongoing `mirror-osp-to-gitlab.sh` sync will push KPort to:
  `gitlab.com/openos-project/kde-ecosystem-deving/neon-deving/KPort`

## Pre-requisite (already done)

The `add-mirror-repo.yml` workflow was triggered manually with `repo_url: https://github.com/Interested-Deving-1896/KPort` before this PR was opened. It completed successfully — KPort is now registered in OSP (OpenOS-Project-OSP on GitHub) and the initial mirror has been pushed.

## Why neon-deving?

KPort is a KDE/Neon pacscript packaging tool — it produces pacscripts for KDE Frameworks 6, KDE Plasma 6, KDE Gear, and Qt6, targeting KDE Neon as the base system. `openos-project/kde-ecosystem-deving/neon-deving` is the correct home alongside other KDE/Neon development work.
