### PR TITLE
fix: guard gh_api and gh_api_ok against empty HTTP code

### DIFF
--- a/config/gitlab-subgroups.yml
+++ b/config/gitlab-subgroups.yml
@@ -69,6 +69,11 @@ subgroups:
       - talos-incus
       - waydroid-toolkit
 
+  neon-deving:
+    id: 130739746
+    repos:
+      - KPort
+
   ops:
     id: 130734009
     repos:

--- a/scripts/resolve-failures.sh
+++ b/scripts/resolve-failures.sh
@@ -74,6 +74,20 @@ gh_api() {
     http_code=$(echo "$response" | tail -1)
     body=$(echo "$response" | sed '$d')
 
+    # Guard: curl can fail silently (network error, DNS failure) and return an
+    # empty string. tail -1 of "" is "", which causes [[ "" -ge 200 ]] to throw
+    # "operand expected". Treat a missing/non-numeric code as a transient 000.
+    if [[ -z "$http_code" || ! "$http_code" =~ ^[0-9]+$ ]]; then
+      (( attempt++ )) || true
+      if (( attempt > max_retries )); then
+        echo "$body"
+        return 1
+      fi
+      echo "  [curl-error] empty HTTP code — backing off 5s (attempt ${attempt}/${max_retries})" >&2
+      sleep 5
+      continue
+    fi
+
     if [[ "$http_code" == "403" || "$http_code" == "429" ]]; then
       (( attempt++ )) || true
       if (( attempt > max_retries )); then
@@ -105,7 +119,9 @@ gh_api_ok() {
   local response="$1"
   local code
   code=$(echo "$response" | tail -1)
-  [[ "$code" -ge 200 && "$code" -lt 300 ]]
+  # Guard against empty or non-numeric code (e.g. when gh_api returns "" on
+  # curl failure before the retry logic can handle it).
+  [[ -n "$code" && "$code" =~ ^[0-9]+$ && "$code" -ge 200 && "$code" -lt 300 ]]
 }
 
 gh_api_body() {


### PR DESCRIPTION
## Problem

`resolve-failures.sh` was silently scanning 0 repos across all three owners (`Interested-Deving-1896`, `OpenOS-Project-OSP`, `OpenOS-Project-Ecosystem-OOC`) and doing nothing.

Root cause confirmed from dry-run log (run [#26057365483](https://github.com/Interested-Deving-1896/fork-sync-all/actions/runs/26057365483)):

```
line 108: [[: ]: syntax error: operand expected (error token is "]")
Found 0 repos
line 108: [[: ]: syntax error: operand expected (error token is "]")
Found 0 repos
line 108: [[: ]: syntax error: operand expected (error token is "]")
Found 0 repos
```

When `curl` fails entirely (network error, DNS failure, or connection timeout), it returns an empty string. `tail -1` of `""` is `""`, and `[[ "" -ge 200 ]]` throws `operand expected` in bash. This caused `gh_api_ok` to error out on every call, which made `get_repos_for_owner` break out of its `while true` loop on the very first page — returning 0 repos for every owner and skipping the entire CI failure scan.

## Fix

**`gh_api`**: Add a retry branch before the 403/429 handler that catches empty or non-numeric `http_code`. Backs off 5s and retries up to `max_retries` times, then returns 1. This means transient curl failures are retried rather than silently propagated as empty strings.

**`gh_api_ok`**: Guard the numeric comparison with `[[ -n "$code" && "$code" =~ ^[0-9]+$ ]]` before `[[ "$code" -ge 200 ]]`. An empty or non-numeric code now returns 1 cleanly instead of throwing a syntax error that crashes the caller.
