### PR TITLE
debug: log subject_url in notifications; bump job timeout to 90m

### DIFF
--- a/.github/workflows/resolve-failures.yml
+++ b/.github/workflows/resolve-failures.yml
@@ -41,7 +41,7 @@ concurrency:
 jobs:
   resolve:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
 

--- a/scripts/resolve-failures.sh
+++ b/scripts/resolve-failures.sh
@@ -546,6 +546,7 @@ resolve_notifications() {
 
       # subject_url points to a CheckSuite, not a run.
       # Extract the check suite ID and resolve it to the most recent failed run.
+      echo "    subject_url: ${subject_url}"
       local check_suite_id=""
       check_suite_id=$(echo "$subject_url" | grep -oE '[0-9]+$')
 


### PR DESCRIPTION
## Changes

- Adds `subject_url` logging in `resolve_notifications` so we can see the actual URL format and diagnose why check suite ID extraction is failing for all notifications
- Bumps `timeout-minutes` from 30 to 90 — the scan across 3 orgs consistently hits the 30m limit and gets cancelled before completing