### PR TITLE
fix: use latest_comment_url for CheckSuite subject URL; bump timeout to 120m

### DIFF
--- a/.github/workflows/resolve-failures.yml
+++ b/.github/workflows/resolve-failures.yml
@@ -41,7 +41,7 @@ concurrency:
 jobs:
   resolve:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v6
 

--- a/scripts/resolve-failures.sh
+++ b/scripts/resolve-failures.sh
@@ -625,7 +625,7 @@ resolve_notifications() {
         .repository.full_name,
         .reason,
         .subject.type,
-        .subject.url
+        (.subject.url // .subject.latest_comment_url // "")
       ] | @tsv' 2>/dev/null)
 
     page=$(( page + 1 ))


### PR DESCRIPTION
## Problem

GitHub's notifications API returns `null` for `subject.url` on `CheckSuite` notifications — the actual URL is in `subject.latest_comment_url`. The jq query was only reading `.subject.url`, so `subject_url` was always empty and every notification was dismissed with "Could not extract check suite ID".

## Fix

Fall back to `latest_comment_url` in the jq query:
```jq
(.subject.url // .subject.latest_comment_url // "")
```

Also bumps `timeout-minutes` from 90 to 120 — the repo scan across 3 orgs consistently exceeds 90 minutes.