### PR TITLE
feat: KPort origins seeding + dep-graph/update-readmes fixes

### DIFF
--- a/.github/workflows/create-readmes.yml
+++ b/.github/workflows/create-readmes.yml
@@ -44,7 +44,7 @@ jobs:
           GITHUB_OWNER: Interested-Deving-1896
           REPO_FILTER: ${{ inputs.repo_filter || '' }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
-          PRIORITY_ONLY: ${{ github.event_name == 'workflow_run' && 'true' || 'false' }}
+          PRIORITY_ONLY: "true"
         run: bash scripts/create-readmes.sh
       - name: Write summary
         if: always()

--- a/.github/workflows/create-readmes.yml
+++ b/.github/workflows/create-readmes.yml
@@ -38,11 +38,22 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Resolve new repo name (Add Mirror Repo trigger)
+        id: resolve
+        if: github.event_name == 'workflow_run' && github.event.workflow.name == 'Add Mirror Repo'
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+        run: |
+          run_id="${{ github.event.workflow_run.id }}"
+          new_repo=$(gh api "repos/${{ github.repository }}/actions/runs/${run_id}" \
+            | jq -r '.inputs.repo_url // empty' | sed 's|.*/||')
+          echo "new_repo=${new_repo}" >> "$GITHUB_OUTPUT"
+
       - name: Create missing READMEs
         env:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
           GITHUB_OWNER: Interested-Deving-1896
-          REPO_FILTER: ${{ inputs.repo_filter || '' }}
+          REPO_FILTER: ${{ steps.resolve.outputs.new_repo || inputs.repo_filter || '' }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
           PRIORITY_ONLY: "true"
         run: bash scripts/create-readmes.sh

--- a/.github/workflows/mirror-osp-to-gitlab.yml
+++ b/.github/workflows/mirror-osp-to-gitlab.yml
@@ -8,6 +8,10 @@ name: Mirror OSP → GitLab
 on:
   schedule:
     - cron: '30 * * * *'   # Hourly at :30
+  workflow_run:
+    workflows:
+      - "Add Mirror Repo"
+    types: [completed]
   workflow_dispatch:
     inputs:
       repo_filter:
@@ -55,12 +59,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Resolve new repo name (Add Mirror Repo trigger)
+        id: resolve
+        if: github.event_name == 'workflow_run' && github.event.workflow.name == 'Add Mirror Repo'
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+        run: |
+          run_id="${{ github.event.workflow_run.id }}"
+          new_repo=$(gh api "repos/${{ github.repository }}/actions/runs/${run_id}" \
+            | jq -r '.inputs.repo_url // empty' | sed 's|.*/||')
+          echo "new_repo=${new_repo}" >> "$GITHUB_OUTPUT"
+
       - name: Mirror OSP repos to GitLab
         env:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
           GITLAB_TOKEN: ${{ secrets.GITLAB_SYNC_TOKEN }}
           OSP_ORG: OpenOS-Project-OSP
-          REPO_FILTER: ${{ inputs.repo_filter || '' }}
+          REPO_FILTER: ${{ steps.resolve.outputs.new_repo || inputs.repo_filter || '' }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
           SUBGROUP_FILTER: ${{ inputs.subgroup_filter || 'all' }}
         run: bash scripts/mirror-osp-to-gitlab.sh

--- a/.github/workflows/resolve-failures.yml
+++ b/.github/workflows/resolve-failures.yml
@@ -41,7 +41,7 @@ concurrency:
 jobs:
   resolve:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v6
 

--- a/scripts/create-readmes.sh
+++ b/scripts/create-readmes.sh
@@ -273,23 +273,25 @@ echo "  Owner: ${GITHUB_OWNER}"
 echo "========================================"
 echo ""
 
-# PRIORITY_ONLY=true → restrict to OSP-mirrored repos (fast, low API usage)
-PRIORITY_ONLY="${PRIORITY_ONLY:-false}"
-
-if [[ "$PRIORITY_ONLY" == "true" ]]; then
-  info "Priority-only mode — fetching OSP-mirrored repos..."
-  repos=$(gh_get "${GH_API}/orgs/OpenOS-Project-OSP/repos?per_page=100&sort=pushed" \
-    | jq -r '.[].name' 2>/dev/null) || { warn "Failed to list OSP repos"; exit 1; }
-else
-  repos=$(gh_get "${GH_API}/users/${GITHUB_OWNER}/repos?per_page=100&sort=pushed" \
-    | jq -r '.[].name' 2>/dev/null) || { warn "Failed to list repos"; exit 1; }
-fi
+# Only process repos that are mirrored to OSP — these are the only repos
+# where README creation/updates are required from Interested-Deving-1896.
+info "Fetching OSP-mirrored repos..."
+repos=$(gh_get "${GH_API}/orgs/OpenOS-Project-OSP/repos?per_page=100&sort=pushed" \
+  | jq -r '.[].name' 2>/dev/null) || { warn "Failed to list OSP repos"; exit 1; }
+info "Found $(echo "$repos" | wc -w) OSP-mirrored repos to check."
 
 created=0
 skipped=0
 
 for repo in $repos; do
   [[ -n "$REPO_FILTER" && "$repo" != *"$REPO_FILTER"* ]] && continue
+
+  # Skip repos that don't exist on Interested-Deving-1896 (e.g. added to OSP directly)
+  if ! gh_get "${GH_API}/repos/${GITHUB_OWNER}/${repo}" 2>/dev/null | jq -e '.id' >/dev/null 2>&1; then
+    info "  ${repo} — not found on ${GITHUB_OWNER}, skipping"
+    (( skipped++ )) || true
+    continue
+  fi
 
   if readme_exists "$GITHUB_OWNER" "$repo"; then
     (( skipped++ )) || true

--- a/scripts/generate-dep-graph.sh
+++ b/scripts/generate-dep-graph.sh
@@ -44,6 +44,7 @@ OSP_REPOS=(
   eggs-ai
   eggs-gui
   immutable-linux-framework
+  kport
   liquorix-unified-kernel
   liqxanmod
   lkf

--- a/scripts/patch-origins-sections.sh
+++ b/scripts/patch-origins-sections.sh
@@ -92,6 +92,47 @@ patched=0
 skipped=0
 failed=0
 
+# Push a file to a repo, creating or updating it.
+# $1=repo $2=branch $3=path $4=commit_message $5=file_content (plain text)
+push_file() {
+  local repo="$1" branch="$2" path="$3" message="$4" content="$5"
+
+  # Check if file already exists (to get its SHA for update)
+  local existing sha=""
+  existing=$(gh_api GET "${API}/repos/${GITHUB_OWNER}/${repo}/contents/${path}?ref=${branch}" 2>/dev/null) || existing=""
+  sha=$(echo "$existing" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('sha',''))" 2>/dev/null || true)
+
+  local content_b64
+  content_b64=$(printf '%s' "$content" | base64 | tr -d '\n')
+
+  local payload
+  payload=$(python3 -c "
+import json, sys
+d = {
+  'message': sys.argv[1],
+  'content': sys.argv[2],
+  'branch':  sys.argv[3],
+}
+if sys.argv[4]:
+    d['sha'] = sys.argv[4]
+print(json.dumps(d))
+" "$message" "$content_b64" "$branch" "$sha")
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    dry "Would push ${GITHUB_OWNER}/${repo}/${path}"
+    return 0
+  fi
+
+  if gh_api PUT "${API}/repos/${GITHUB_OWNER}/${repo}/contents/${path}" \
+      -H "Content-Type: application/json" --data "$payload" > /dev/null; then
+    info "  ✓ pushed ${path}"
+    return 0
+  else
+    warn "  ✗ failed to push ${path}"
+    return 1
+  fi
+}
+
 patch_repo() {
   local repo="$1" branch="$2" origins_block="$3"
 
@@ -300,6 +341,53 @@ patch_repo "penguins-eggs" "master" \
 penguins-eggs is the original Linux remastering tool by Piero Proietti:
 - [pieroproietti/penguins-eggs](https://github.com/pieroproietti/penguins-eggs) — upstream source (this repo tracks it)
 - [pieroproietti/oa-tools](https://github.com/pieroproietti/oa-tools) — next-generation successor (oa + coa architecture)'
+
+# ── KPort — original project, push dep-graph/origins.md + README patch ───────
+#
+# KPort was created from the following upstream inspirations:
+#   - KDE Neon (neon.kde.org, invent.kde.org/neon/neon, invent.kde.org/neon)
+#   - KDE Neon repositories (github.com/KDE/neon-neon-repositories)
+#   - Gentoo Portage (github.com/gentoo/portage)
+#   - Pacstall (github.com/pacstall/pacstall)
+#   - KDE Craft + blueprints (github.com/KDE/craft, craft-blueprints-kde, craft-blueprints-community)
+#   - KDE build tooling (kde-builder, kdesrc-build, kde-build-metadata, kdevplatform, superbuild)
+#   - KDE Android builder (github.com/KDE/android-builder)
+#
+# All of these exist as forks in Interested-Deving-1896.
+
+KPORT_ORIGINS_MD='# KPort Origins
+
+KPort is an original project — a Portage-inspired package repository for KDE Neon using Pacstall.
+It was created from the following upstream inspirations:
+
+| Origin | Host | Fork in I-D-1896 |
+|--------|------|-----------------|
+| [KDE/neon-neon-repositories](https://github.com/KDE/neon-neon-repositories) | GitHub | ✅ |
+| [neon/neon](https://invent.kde.org/neon/neon) | KDE Invent | — |
+| [gentoo/portage](https://github.com/gentoo/portage) | GitHub | ✅ |
+| [pacstall/pacstall](https://github.com/pacstall/pacstall) | GitHub | ✅ |
+| [KDE/craft](https://github.com/KDE/craft) | GitHub | ✅ |
+| [KDE/craft-blueprints-kde](https://github.com/KDE/craft-blueprints-kde) | GitHub | ✅ |
+| [KDE/craft-blueprints-community](https://github.com/KDE/craft-blueprints-community) | GitHub | ✅ |
+| [KDE/kde-builder](https://github.com/KDE/kde-builder) | GitHub | ✅ |
+| [KDE/kdesrc-build](https://github.com/KDE/kdesrc-build) | GitHub | ✅ |
+| [KDE/kde-build-metadata](https://github.com/KDE/kde-build-metadata) | GitHub | ✅ |
+| [KDE/kdevplatform](https://github.com/KDE/kdevplatform) | GitHub | ✅ |
+| [KDE/superbuild](https://github.com/KDE/superbuild) | GitHub | ✅ |
+| [KDE/android-builder](https://github.com/KDE/android-builder) | GitHub | ✅ |
+'
+
+info "── kport (main) — push dep-graph/origins.md"
+# KPort's README already has an ## Origins block managed by update-readmes.sh.
+# We only need to push dep-graph/origins.md; update-readmes.sh will render it
+# into the <!-- AI:start:origins --> block on its next run.
+if push_file "kport" "main" "dep-graph/origins.md" \
+    "chore: add dep-graph/origins.md (upstream inspirations)" \
+    "$KPORT_ORIGINS_MD"; then
+  (( patched++ )) || true
+else
+  (( failed++ )) || true
+fi
 
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""

--- a/scripts/resolve-failures.sh
+++ b/scripts/resolve-failures.sh
@@ -625,7 +625,7 @@ resolve_notifications() {
         .repository.full_name,
         .reason,
         .subject.type,
-        .subject.url
+        (.subject.url // .subject.latest_comment_url // "")
       ] | @tsv' 2>/dev/null)
 
     page=$(( page + 1 ))

--- a/scripts/update-readmes.sh
+++ b/scripts/update-readmes.sh
@@ -274,7 +274,7 @@ generate_origins() {
     # Strip the top-level heading (already in the section heading)
     echo "$content" | sed '1{/^# /d}'
   else
-    echo "_No dependency graph found. Run \`generate-dep-graph.yml\` to generate \`dep-graph/origins.md\`._"
+    echo "_Original project — no upstream fork._"
   fi
 }
 


### PR DESCRIPTION
## Summary

This branch accumulates fixes and features across the OSP-bound workflow chain, with the most recent commits focused on KPort origins and dep-graph correctness.

## Changes

### KPort origins (`patch-origins-sections.sh`)
- Added `push_file()` helper — creates or updates any file in a repo via the GitHub Contents API (handles both create and update by probing for an existing SHA)
- Added KPort entry that pushes `dep-graph/origins.md` into `Interested-Deving-1896/kport` listing all 13 upstream inspirations: KDE Neon, Portage, Pacstall, KDE Craft, KDE build tooling (kde-builder, kdesrc-build, kde-build-metadata, kdevplatform, superbuild), and android-builder

### Dep graph (`generate-dep-graph.sh`)
- Added `kport` to `OSP_REPOS` so it appears in the global dep graph on the next `generate-dep-graph.yml` run

### README origins fallback (`update-readmes.sh`)
- Replaced the misleading `"No dependency graph found. Run generate-dep-graph.yml..."` fallback with `"Original project — no upstream fork."` for repos that have no `dep-graph/origins.md`

### Workflow chain (`add-mirror-repo.yml`, `create-readmes.yml`, `mirror-osp-to-gitlab.yml`)
- Wire `add-mirror-repo` completion to trigger the full OSP-bound workflow chain (mirror → readme → dep-graph)
- Scope `create-readmes` to OSP-mirrored repos only

### `resolve-failures.sh`
- Fall back to `latest_comment_url` for CheckSuite `subject.url` (GitHub returns null for CheckSuite notifications)
- Bump timeout to 120m

### Earlier fixes
- `gh_api_ok`/`gh_api_body` direct exit-code checks
- CheckSuite → workflow run resolution via `/actions/runs?check_suite_id=...`
- `SUBGROUP_FILTER='all'` treated as no-op
- `gl_create_project` stdout pollution fix
- Force-push allowed on `org-mirror` GitLab branch
- `artefacts` → `artifacts` spelling

## Execution order after merge

To fully populate KPort's README `## Origins` block:

1. Run **`patch-origins-sections.yml`** → pushes `dep-graph/origins.md` into KPort
2. Run **`update-readmes.yml`** with `repos: KPort` → renders the table into `<!-- AI:start:origins -->`
3. Run **`generate-dep-graph.yml`** → picks up KPort in the global dep graph