### PR TITLE
fix: resolve-failures scope + mirror force-push protection

### DIFF
--- a/.github/workflows/resolve-failures.yml
+++ b/.github/workflows/resolve-failures.yml
@@ -56,6 +56,47 @@ jobs:
             }}
           REPO_FILTER: ${{ inputs.repo_filter || '' }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          # Scopes the I-D-1896 scan to OSP-bound repos only.
+          # Scanning all 4 000+ I-D-1896 repos exhausts the rate limit and
+          # times out. OSP/OOC orgs (33 repos each) are scanned in full.
+          # Keep in sync with OSP_REPOS in scripts/generate-dep-graph.sh.
+          OSP_REPOS_OVERRIDE: >-
+            btrfs-dwarfs-framework
+            docker-images
+            eggs-ai
+            eggs-gui
+            gitlab-enhanced
+            immutable-linux-framework
+            Incus-MacOS-Toolkit
+            incus-image-server
+            incus-windows-toolkit
+            incusbox
+            kapsule-incus-manager
+            kport
+            linux-powerwash
+            liquorix-unified-kernel
+            liqxanmod
+            lkf
+            lkm
+            oa-tools
+            penguins-eggs
+            penguins-eggs-audit
+            penguins-eggs-book
+            penguins-immutable-framework
+            penguins-incus-platform
+            penguins-kernel-manager
+            penguins-powerwash
+            penguins-recovery
+            pkg-kde-dev-scripts
+            pkg-kde-jenkins
+            pkg-kde-tools
+            qt-kde-team.pages.debian.net
+            talos
+            talos-incus
+            ubuntu-core
+            ukm
+            waydroid-toolkit
+            xanmod-unified-kernel
         run: |
           if [[ -z "${GH_TOKEN}" ]]; then
             echo "SYNC_TOKEN not configured — skipping CI failure scan."

--- a/scripts/mirror-osp-to-gitlab.sh
+++ b/scripts/mirror-osp-to-gitlab.sh
@@ -113,9 +113,9 @@ PYEOF
 # Add repo names here to permanently exclude them from mirroring.
 #
 # Note: org-mirror (openos-project/ops/org-mirror) is NOT excluded — it is
-# mirrored normally. Its GitLab branch protection has allow_force_push=true
-# so the mirror push succeeds. Do not add it here unless you want to stop
-# mirroring it entirely.
+# mirrored normally. gl_ensure_force_push() handles branch protection
+# automatically before each push. Do not add it here unless you want to
+# stop mirroring it entirely.
 EXCLUDED_REPOS=()
 
 info() { echo "[mirror-osp-to-gitlab] $*"; }
@@ -237,6 +237,56 @@ gl_create_project() {
   echo "$result" | grep -o '"http_url_to_repo":"[^"]*"' | sed 's/"http_url_to_repo":"//;s/"//'
 }
 
+# Ensures allow_force_push=true on every protected branch of a GitLab project.
+# The mirror uses force-push (+refs/heads/...) so any protected branch with
+# allow_force_push=false will reject the push. This function unprotects and
+# re-protects each branch with force-push enabled.
+# $1 = namespace_path (e.g. openos-project/neon-deving/KPort)
+gl_ensure_force_push() {
+  local namespace_path="$1"
+  local encoded
+  encoded=$(printf '%s' "$namespace_path" | sed 's|/|%2F|g')
+
+  local branches_json
+  branches_json=$(gl_api GET "${GL_API}/projects/${encoded}/protected_branches") || return 0
+  # If no protected branches, nothing to do
+  echo "$branches_json" | python3 -c "import sys,json; d=json.load(sys.stdin); exit(0 if d else 1)" 2>/dev/null || return 0
+
+  while IFS= read -r branch_name; do
+    [[ -z "$branch_name" ]] && continue
+    local branch_encoded
+    branch_encoded=$(printf '%s' "$branch_name" | sed 's|/|%2F|g')
+
+    # Check if force_push is already enabled
+    local force_push
+    force_push=$(echo "$branches_json" | python3 -c "
+import sys, json
+branches = json.load(sys.stdin)
+for b in branches:
+    if b['name'] == sys.argv[1]:
+        print('true' if b.get('allow_force_push') else 'false')
+        break
+" "$branch_name" 2>/dev/null)
+
+    [[ "$force_push" == "true" ]] && continue
+
+    info "  Enabling force-push on protected branch '${branch_name}' ..."
+
+    # Unprotect first (DELETE), then re-protect with allow_force_push=true
+    gl_api DELETE "${GL_API}/projects/${encoded}/protected_branches/${branch_encoded}" > /dev/null 2>&1 || true
+    gl_api POST "${GL_API}/projects/${encoded}/protected_branches" \
+      --header "Content-Type: application/json" \
+      --data "{\"name\":\"${branch_name}\",\"push_access_level\":40,\"merge_access_level\":40,\"allow_force_push\":true}" \
+      > /dev/null || warn "  Could not re-protect branch '${branch_name}' — push may fail"
+
+  done < <(echo "$branches_json" | python3 -c "
+import sys, json
+for b in json.load(sys.stdin):
+    if not b.get('allow_force_push'):
+        print(b['name'])
+" 2>/dev/null)
+}
+
 get_osp_repos() {
   # Use gh CLI (respects GH_TOKEN env and handles auth more robustly than
   # raw curl with a PAT that may lack read:org scope).
@@ -249,7 +299,7 @@ get_osp_repos() {
 }
 
 mirror_repo() {
-  local gh_name="$1" gl_url="$2"
+  local gh_name="$1" gl_url="$2" gl_ns_path="$3"
 
   local gh_clone_url="https://x-access-token:${GH_TOKEN}@github.com/${OSP_ORG}/${gh_name}.git"
   local gl_auth_url="${gl_url/https:\/\//https://oauth2:${GITLAB_TOKEN}@}"
@@ -264,6 +314,11 @@ mirror_repo() {
     rm -rf "$work_dir"
     return 1
   fi
+
+  # Ensure force-push is allowed on all protected branches before pushing.
+  # GitLab creates a default branch protection on new projects; the mirror
+  # uses force-push (+refs/heads/...) which is blocked unless explicitly enabled.
+  gl_ensure_force_push "$gl_ns_path"
 
   cd "$work_dir"
 
@@ -368,7 +423,7 @@ for name in "${osp_repos[@]}"; do
     sleep 3
   fi
 
-  if mirror_repo "$name" "$gl_http_url"; then
+  if mirror_repo "$name" "$gl_http_url" "$ns_path"; then
     info "✅ ${name} done"
     (( synced++ )) || true
   else

--- a/scripts/resolve-failures.sh
+++ b/scripts/resolve-failures.sh
@@ -15,6 +15,12 @@ set -uo pipefail
 DRY_RUN="${DRY_RUN:-false}"
 REPO_FILTER="${REPO_FILTER:-}"
 
+# OSP_REPOS_OVERRIDE: space-separated list of short repo names to scan for a
+# given owner instead of paginating the entire org. Set by the workflow for
+# Interested-Deving-1896 (4 000+ repos) to avoid exhausting the rate limit and
+# timing out. Leave empty to fall back to a full org scan (used for OSP/OOC).
+OSP_REPOS_OVERRIDE="${OSP_REPOS_OVERRIDE:-}"
+
 API="https://api.github.com"
 
 # Repos the resolver must never commit to directly. These are repos where
@@ -196,12 +202,21 @@ llm_ask() {
 
 get_repos_for_owner() {
   local owner="$1"
-  local page=1
 
+  # For Interested-Deving-1896, use the OSP-bound repo list from
+  # OSP_REPOS_OVERRIDE rather than paginating 4 000+ repos. The override is
+  # a space-separated list of short names set by the workflow; this function
+  # emits "owner/name" lines to match the full-scan output format.
+  if [[ -n "$OSP_REPOS_OVERRIDE" && "$owner" == "Interested-Deving-1896" ]]; then
+    for name in $OSP_REPOS_OVERRIDE; do
+      echo "${owner}/${name}"
+    done
+    return 0
+  fi
+
+  # Full org scan for OSP/OOC orgs (33 repos each — fast).
   # Try as org first, fall back to user.
-  # gh_api echoes the response body and returns 0 on 2xx, 1 otherwise —
-  # use its exit code directly rather than gh_api_ok (which expects a
-  # body+code string, not a plain body).
+  local page=1
   while true; do
     local body
     if ! body=$(gh_api GET "${API}/orgs/${owner}/repos?type=all&per_page=${PER_PAGE}&page=${page}"); then
@@ -650,7 +665,11 @@ resolve_notifications
 echo ""
 
 for owner in $SCAN_OWNERS; do
-  echo "Scanning ${owner}..."
+  if [[ -n "$OSP_REPOS_OVERRIDE" && "$owner" == "Interested-Deving-1896" ]]; then
+    echo "Scanning ${owner} (OSP-bound repos only — override active)..."
+  else
+    echo "Scanning ${owner}..."
+  fi
   mapfile -t repos < <(get_repos_for_owner "$owner")
   echo "  Found ${#repos[@]} repos"
 


### PR DESCRIPTION
## Summary

Two independent fixes for persistent workflow failures.

## Changes

### `resolve-failures`: scope I-D-1896 scan to OSP-bound repos

`resolve-failures.sh` was paginating all 4,299 `Interested-Deving-1896` repos on every run, exhausting the GitHub rate limit and consistently timing out at 120m. The relevant repos are the 36 OSP-bound ones.

- Add `OSP_REPOS_OVERRIDE` env var to the workflow: space-separated list of the 36 OSP-bound repo names
- `get_repos_for_owner()` short-circuits to that list when set and `owner == Interested-Deving-1896`, emitting `owner/name` lines in the same format as the full scan
- OSP/OOC orgs (33 repos each) are unaffected — still scanned in full
- Keep `OSP_REPOS_OVERRIDE` in sync with `OSP_REPOS` in `generate-dep-graph.sh` when adding new repos

### `mirror-osp-to-gitlab`: auto-enable force-push on protected branches

GitLab creates a default branch protection (`allow_force_push=false`) on every new project. The mirror uses force-push (`+refs/heads/...`) which is blocked by this protection, causing every push to a newly-created GitLab project to fail.

Root cause: KPort's GitLab `main` branch had `allow_force_push=false`. The failure chain started at commit `541324f` (2026-05-18) when the `SUBGROUP_FILTER='all'` fix unblocked the mirror and it actually attempted to push KPort for the first time.

- Add `gl_ensure_force_push(namespace_path)`: fetches protected branches, unprotects (DELETE) and re-protects (POST with `allow_force_push=true`) any branch that blocks force-push
- Called in `mirror_repo()` after clone, before push — `ns_path` passed as a new third argument
- Branches already set to `allow_force_push=true` are skipped (no-op for most repos)
- Re-protect failures are logged as warnings but do not abort the mirror

## Notes

- PR #52 (`deps/update-infra-2026-05-18`) should be closed and its branch deleted — it has invalid `permissions:` syntax in two workflow files causing noise failures on every push to that branch. The version bumps it contains are already superseded by `main`.