### PR TITLE
fix: use full GitLab namespace path for nested subgroups in mirror

### DIFF
--- a/.github/workflows/mirror-orgs-watchdog.yml
+++ b/.github/workflows/mirror-orgs-watchdog.yml
@@ -22,6 +22,12 @@ on:
       - "Mirror Artifacts"
     types: [completed]
 
+concurrency:
+  # One watchdog retry per workflow at a time — prevents retry storms when
+  # a mirror fails repeatedly. Uses the triggering workflow name as the key.
+  group: mirror-watchdog-${{ github.event.workflow_run.name }}
+  cancel-in-progress: true  # If a newer retry is queued, cancel the older one
+
 permissions:
   actions: write   # needed to re-trigger workflows
   contents: read

--- a/.github/workflows/mirror-osp-to-gitlab.yml
+++ b/.github/workflows/mirror-osp-to-gitlab.yml
@@ -38,6 +38,10 @@ on:
           - mirrors
           - ops
 
+concurrency:
+  group: mirror-osp-to-gitlab
+  cancel-in-progress: false  # Never cancel mid-mirror — let it finish
+
 permissions:
   contents: read
 

--- a/config/gitlab-subgroups.yml
+++ b/config/gitlab-subgroups.yml
@@ -22,11 +22,13 @@ subgroups:
 
   git-management_deving:
     id: 130516820
+    path: openos-project/git-management_deving
     repos:
       - gitlab-enhanced
 
   penguins-eggs_deving:
     id: 130516402
+    path: openos-project/penguins-eggs_deving
     repos:
       - penguins-eggs
       - penguins-recovery
@@ -42,11 +44,13 @@ subgroups:
 
   immutable-filesystem_deving:
     id: 130516465
+    path: openos-project/immutable-filesystem_deving
     repos:
       - immutable-linux-framework
 
   linux-kernel_filesystem_deving:
     id: 130516188
+    path: openos-project/linux-kernel_filesystem_deving
     repos:
       - liqxanmod
       - lkm
@@ -59,6 +63,7 @@ subgroups:
 
   incus_deving:
     id: 130516536
+    path: openos-project/incus_deving
     repos:
       - incus-image-server
       - kapsule-incus-manager
@@ -71,6 +76,8 @@ subgroups:
 
   neon-deving:
     id: 130739746
+    # Nested subgroup — full path differs from the key name
+    path: openos-project/kde-ecosystem-deving/neon-deving
     repos:
       - KPort
       - ubuntu-core
@@ -82,6 +89,7 @@ subgroups:
 
   ops:
     id: 130734009
+    path: openos-project/ops
     repos:
       - fork-sync-all
       - flatpak-repo

--- a/scripts/mirror-osp-to-gitlab.sh
+++ b/scripts/mirror-osp-to-gitlab.sh
@@ -59,9 +59,10 @@ with open(config) as f:
     content = f.read()
 
 # Minimal YAML parser — no PyYAML dependency required
-current_sg = None
-current_id = None
-default_sg = None
+current_sg   = None
+current_id   = None
+current_path = None
+default_sg   = None
 
 for line in content.splitlines():
     # default_subgroup: ops
@@ -69,43 +70,59 @@ for line in content.splitlines():
     if m:
         default_sg = m.group(1)
         continue
-    # Top-level subgroup key (2-space indent or none, ends with colon)
+    # Top-level subgroup key (2-space indent, ends with colon)
     m = re.match(r'^  (\S+):$', line)
     if m:
-        current_sg = m.group(1)
-        current_id = None
+        current_sg   = m.group(1)
+        current_id   = None
+        current_path = None
         continue
     # id: 130516402
     m = re.match(r'^\s+id:\s*(\d+)', line)
     if m and current_sg:
         current_id = int(m.group(1))
         continue
+    # path: openos-project/kde-ecosystem-deving/neon-deving
+    m = re.match(r'^\s+path:\s*(\S+)', line)
+    if m and current_sg:
+        current_path = m.group(1)
+        continue
     # - repo-name
     m = re.match(r'^\s+-\s+(\S+)', line)
     if m and current_sg and current_id is not None:
         if m.group(1) == repo:
-            print(f"{current_id}|{current_sg}")
+            # Use explicit path if present, otherwise derive from subgroup key
+            path = current_path or f"openos-project/{current_sg}"
+            print(f"{current_id}|{current_sg}|{path}")
             sys.exit(0)
 
 # Not found — use default
 if default_sg:
-    # Find the default subgroup's id
-    current_sg = None
-    current_id = None
+    # Find the default subgroup's id and path
+    current_sg   = None
+    current_id   = None
+    current_path = None
     for line in content.splitlines():
         m = re.match(r'^  (\S+):$', line)
         if m:
-            current_sg = m.group(1)
-            current_id = None
+            current_sg   = m.group(1)
+            current_id   = None
+            current_path = None
             continue
         m = re.match(r'^\s+id:\s*(\d+)', line)
         if m and current_sg:
             current_id = int(m.group(1))
+            continue
+        m = re.match(r'^\s+path:\s*(\S+)', line)
+        if m and current_sg:
+            current_path = m.group(1)
+            continue
         if current_sg == default_sg and current_id is not None:
-            print(f"{current_id}|{current_sg}")
+            path = current_path or f"openos-project/{current_sg}"
+            print(f"{current_id}|{current_sg}|{path}")
             sys.exit(0)
 
-print("130734009|ops")  # hard fallback
+print("130734009|ops|openos-project/ops")  # hard fallback
 PYEOF
 }
 
@@ -391,8 +408,9 @@ for name in "${osp_repos[@]}"; do
   # Determine target subgroup from config/gitlab-subgroups.yml
   lookup=$(gl_subgroup_lookup "$name")
   namespace_id="${lookup%%|*}"
-  subgroup_name="${lookup##*|}"
-  ns_path="openos-project/${subgroup_name}/${name}"
+  subgroup_name="${lookup#*|}"; subgroup_name="${subgroup_name%%|*}"
+  subgroup_path="${lookup##*|}"
+  ns_path="${subgroup_path}/${name}"
 
   # Apply subgroup filter ("all" or empty means no filter)
   if [[ -n "$SUBGROUP_FILTER" && "$SUBGROUP_FILTER" != "all" && "$subgroup_name" != "$SUBGROUP_FILTER" ]]; then


### PR DESCRIPTION
## Root cause

`mirror-osp-to-gitlab.sh` constructed `ns_path` as `openos-project/{subgroup_key}/{repo}` using only the last segment of the subgroup key. For `neon-deving` (actual full path: `openos-project/kde-ecosystem-deving/neon-deving`) this produced `openos-project/neon-deving/KPort` — a 404 on every GitLab API call.

Cascading failures from the wrong path:
1. `gl_project_url()` returned empty on every run → `gl_create_project()` was called repeatedly (trying to re-create an existing project, failing silently or returning a bad URL)
2. `gl_ensure_force_push()` hit the wrong URL → no-op → KPort's `main` branch kept `allow_force_push=false` → every push rejected

This is why the mirror has been failing since `541324f` (2026-05-18) despite the `gl_ensure_force_push` fix in PR #55.

## Changes

### `config/gitlab-subgroups.yml`
- Add `path:` field to every subgroup entry with the verified full GitLab namespace path (confirmed via `GET /api/v4/groups/:id` for all 7 subgroup IDs)
- `neon-deving` is the only nested subgroup: `openos-project/kde-ecosystem-deving/neon-deving`

### `scripts/mirror-osp-to-gitlab.sh`
- `gl_subgroup_lookup()` now emits `id|key|full_path` (three `|`-separated fields)
- Main loop extracts `subgroup_path` from the third field and builds `ns_path` as `{subgroup_path}/{repo_name}`
- Default and hard-fallback paths updated to the three-field format
- `path:` line parsing added to the minimal YAML parser in `gl_subgroup_lookup`

### Concurrency groups (retry storm prevention)
- `mirror-osp-to-gitlab.yml`: `group=mirror-osp-to-gitlab`, `cancel-in-progress=false` — queues runs rather than piling them up
- `mirror-orgs-watchdog.yml`: `group=mirror-watchdog-{workflow_name}`, `cancel-in-progress=true` — cancels stale watchdog retries when a newer one is queued for the same workflow