### PR TITLE
fix: make gl_create_project failure non-fatal in mirror

### DIFF
--- a/scripts/mirror-osp-to-gitlab.sh
+++ b/scripts/mirror-osp-to-gitlab.sh
@@ -432,8 +432,8 @@ for name in "${osp_repos[@]}"; do
   if [[ -z "$gl_http_url" ]]; then
     gl_http_url=$(gl_create_project "$name" "$namespace_id")
     if [[ -z "$gl_http_url" ]]; then
-      warn "  Could not create GitLab project — skipping"
-      (( failed++ )) || true
+      warn "  Could not create GitLab project — skipping (token may lack create permission)"
+      (( skipped++ )) || true
       continue
     fi
     info "  Created: ${gl_http_url}"


### PR DESCRIPTION
## Root cause

7 repos added to `incus_deving` in PR #54 (`Incus-MacOS-Toolkit`, `incus-image-server`, `incus-windows-toolkit`, `incusbox`, `kapsule-incus-manager`, `talos-incus`, `waydroid-toolkit`) don't yet exist on GitLab. The mirror tries to create them via `gl_create_project` on every run, which fails (token likely lacks create permission in `incus_deving`, or the projects haven't been bootstrapped). Each failure incremented `failed++`, causing the entire mirror run to exit 1 — even though all existing repos were pushed successfully.

## Change

`gl_create_project` failure now increments `skipped++` instead of `failed++`. The run continues and succeeds for all repos that can be pushed. Skipped repos are retried on the next run.

## Follow-up needed

The 7 missing `incus_deving` GitLab projects need to be created. Options:
- Verify `GITLAB_SYNC_TOKEN` has `api` scope and Maintainer role on `openos-project/incus_deving`
- Or create the projects manually on GitLab and let the next mirror run push to them