### PR TITLE
chore(deps): update 19 workflow dependencies

### DIFF
--- a/.github/workflows/add-mirror-repo.yml
+++ b/.github/workflows/add-mirror-repo.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Mirror repo into OSP and register for ongoing sync
         env:

--- a/.github/workflows/create-readmes.yml
+++ b/.github/workflows/create-readmes.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Create missing READMEs
         env:

--- a/.github/workflows/import-repo.yml
+++ b/.github/workflows/import-repo.yml
@@ -44,7 +44,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Import repository
         env:

--- a/.github/workflows/mirror-artifacts.yml
+++ b/.github/workflows/mirror-artifacts.yml
@@ -41,7 +41,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/mirror-osp-to-gitlab.yml
+++ b/.github/workflows/mirror-osp-to-gitlab.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Mirror OSP repos to GitLab
         env:

--- a/.github/workflows/mirror-to-osp.yml
+++ b/.github/workflows/mirror-to-osp.yml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Mirror matched repos from upstream into OSP
         env:

--- a/.github/workflows/rebase-lts.yml
+++ b/.github/workflows/rebase-lts.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout fork-sync-all
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Rebuild lts on Interested-Deving-1896/penguins-eggs
         env:

--- a/.github/workflows/reconcile-org-refs.yml
+++ b/.github/workflows/reconcile-org-refs.yml
@@ -42,7 +42,7 @@ jobs:
 
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Rewrite org references in OSP + OOC mirrors
         env:

--- a/.github/workflows/resolve-failures.yml
+++ b/.github/workflows/resolve-failures.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Scan and resolve failures
         env:

--- a/.github/workflows/setup-osp-mirrors.yml
+++ b/.github/workflows/setup-osp-mirrors.yml
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup OSP mirror workflows
         env:

--- a/.github/workflows/sync-eggs-docs-to-book.yml
+++ b/.github/workflows/sync-eggs-docs-to-book.yml
@@ -29,14 +29,14 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout penguins-eggs-book
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: Interested-Deving-1896/penguins-eggs-book
           token: ${{ secrets.SYNC_TOKEN }}
           path: book
 
       - name: Checkout penguins-eggs
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: Interested-Deving-1896/penguins-eggs
           ref: ${{ github.event.client_payload.ref || inputs.ref || 'all-features' }}

--- a/.github/workflows/sync-forks.yml
+++ b/.github/workflows/sync-forks.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 355
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Sync all forks
         env:

--- a/.github/workflows/sync-from-gitlab.yml
+++ b/.github/workflows/sync-from-gitlab.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Sync repos from GitLab openos-project
         env:

--- a/.github/workflows/sync-pieroproietti-forks.yml
+++ b/.github/workflows/sync-pieroproietti-forks.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Sync pieroproietti forks
         env:

--- a/.github/workflows/sync-registered-imports.yml
+++ b/.github/workflows/sync-registered-imports.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Sync registered imports
         env:

--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Sync repos to GitLab
         env:

--- a/.github/workflows/update-readmes.yml
+++ b/.github/workflows/update-readmes.yml
@@ -56,7 +56,7 @@ jobs:
       github.event_name != 'push' ||
       github.repository_owner == 'Interested-Deving-1896'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Determine repos to process
         id: repos

--- a/.github/workflows/upstream-commits.yml
+++ b/.github/workflows/upstream-commits.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Upstream direct commits from OSP and OOC
         env:

--- a/.github/workflows/upstream-prs.yml
+++ b/.github/workflows/upstream-prs.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Upstream open PRs from OSP and OOC
         env:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <!-- AI:skip -->
 # fork-sync-all
 
+[![Built with Ona](https://ona.com/build-with-ona.svg)](https://app.ona.com/#https://github.com/OpenOS-Project-OSP/fork-sync-all)
+
 Sync and mirror infrastructure for the three-org chain:
 
 ```


### PR DESCRIPTION
Upstreamed from OpenOS-Project-OSP/fork-sync-all#2.

---

Automated dependency update for GitHub Actions workflow files.

**`.github/workflows/rebase-lts.yml`**
- `actions/checkout@v4` → `actions/checkout@v6` — newer major available (v4 → v6)

**`.github/workflows/setup-osp-mirrors.yml`**
- `actions/checkout@v4` → `actions/checkout@v6` — newer major available (v4 → v6)

**`.github/workflows/mirror-to-osp.yml`**
- `actions/checkout@v4` → `actions/checkout@v6` — newer major available (v4 → v6)

**`.github/workflows/add-mirror-repo.yml`**
- `actions/checkout@v4` → `actions/checkout@v6` — newer major available (v4 → v6)

**`.github/workflows/mirror-artifacts.yml`**
- `actions/checkout@v4` → `actions/checkout@v6` — newer major available (v4 → v6)

**`.github/workflows/sync-forks.yml`**
- `actions/checkout@v4` → `actions/checkout@v6` — newer major available (v4 → v6)

**`.github/workflows/sync-eggs-docs-to-book.yml`**
- `actions/checkout@v4` → `actions/checkout@v6` — newer major available (v4 → v6)

**`.github/workflows/mirror-osp-to-gitlab.yml`**
- `actions/checkout@v4` → `actions/checkout@v6` — newer major available (v4 → v6)

**`.github/workflows/upstream-commits.yml`**
- `actions/checkout@v4` → `actions/checkout@v6` — newer major available (v4 → v6)

**`.github/workflows/create-readmes.yml`**
- `actions/checkout@v4` → `actions/checkout@v6` — newer major available (v4 → v6)

**`.github/workflows/upstream-prs.yml`**
- `actions/checkout@v4` → `actions/checkout@v6` — newer major available (v4 → v6)

**`.github/workflows/import-repo.yml`**
- `actions/checkout@v4` → `actions/checkout@v6` — newer major available (v4 → v6)

**`.github/workflows/sync-registered-imports.yml`**
- `actions/checkout@v4` → `actions/checkout@v6` — newer major available (v4 → v6)

**`.github/workflows/update-readmes.yml`**
- `actions/checkout@v4` → `actions/checkout@v6` — newer major available (v4 → v6)

**`.github/workflows/resolve-failures.yml`**
- `actions/checkout@v4` → `actions/checkout@v6` — newer major available (v4 → v6)

**`.github/workflows/sync-to-gitlab.yml`**
- `actions/checkout@v4` → `actions/checkout@v6` — newer major available (v4 → v6)

**`.github/workflows/sync-pieroproietti-forks.yml`**
- `actions/checkout@v4` → `actions/checkout@v6` — newer major available (v4 → v6)

**`.github/workflows/reconcile-org-refs.yml`**
- `actions/checkout@v3` → `actions/checkout@v6` — newer major available (v3 → v6)

**`.github/workflows/sync-from-gitlab.yml`**
- `actions/checkout@v4` → `actions/checkout@v6` — newer major available (v4 → v6)


---
*Generated by [update-infra-deps.yml](/.github/workflows/update-infra-deps.yml) on 2026-05-18.*
*EOL data sourced from [endoflife.date](https://endoflife.date).*