### PR TITLE
fix: resolve three recurring workflow failures

### DIFF
--- a/scripts/sync-from-gitlab.sh
+++ b/scripts/sync-from-gitlab.sh
@@ -186,11 +186,19 @@ sync_repo() {
   work_dir=$(mktemp -d)
 
   info "  Cloning gitlab.com/${gl_path} ..."
-  if ! git clone --mirror "$gl_url" "$work_dir" 2>&1; then
-    warn "  Clone failed for ${gl_path}"
+  local clone_out
+  clone_out=$(git clone --mirror "$gl_url" "$work_dir" 2>&1) || {
+    # Distinguish access-denied (token lacks scope) from other errors.
+    # Return 2 for access failures so the caller can skip rather than fail.
+    if echo "$clone_out" | grep -qiE "403|401|not found|access denied|repository not found"; then
+      warn "  Clone skipped (access denied) for ${gl_path} — check GITLAB_SYNC_TOKEN scope"
+      rm -rf "$work_dir"
+      return 2
+    fi
+    warn "  Clone failed for ${gl_path}: ${clone_out}"
     rm -rf "$work_dir"
     return 1
-  fi
+  }
 
   cd "$work_dir"
 
@@ -256,9 +264,14 @@ for group_id in "${SUBGROUP_IDS[@]}"; do
       continue
     fi
 
-    if sync_repo "$gl_path" "$gl_name"; then
+    local sync_rc=0
+    sync_repo "$gl_path" "$gl_name" || sync_rc=$?
+    if [[ $sync_rc -eq 0 ]]; then
       info "✅ ${gl_name} done"
       (( synced++ )) || true
+    elif [[ $sync_rc -eq 2 ]]; then
+      warn "⚠️  ${gl_name} skipped (access denied)"
+      (( skipped++ )) || true
     else
       warn "❌ ${gl_name} failed"
       (( failed++ )) || true

--- a/scripts/sync-to-gitlab.sh
+++ b/scripts/sync-to-gitlab.sh
@@ -58,21 +58,23 @@ try:
 except FileNotFoundError:
     sys.exit(0)
 
-default_sg = "ops"
-m = re.search(r'^default_subgroup:\s*(\S+)', content, re.MULTILINE)
-if m:
-    default_sg = m.group(1)
-
 current_sg = None
+current_path = None  # explicit path: field overrides key-derived path
 for line in content.splitlines():
     sg_m = re.match(r'^  (\S+):$', line)
     if sg_m:
         current_sg = sg_m.group(1)
+        current_path = None  # reset for each new subgroup
+        continue
+    path_m = re.match(r'^\s+path:\s+(\S+)', line)
+    if path_m and current_sg:
+        current_path = path_m.group(1)
         continue
     repo_m = re.match(r'^\s+-\s+(\S+)', line)
-    if repo_m and current_sg and current_sg not in ('id', 'repos'):
+    if repo_m and current_sg and current_sg not in ('id', 'repos', 'path'):
         repo = repo_m.group(1)
-        print(f"{repo}|openos-project/{current_sg}/{repo}")
+        ns = current_path if current_path else f"openos-project/{current_sg}"
+        print(f"{repo}|{ns}/{repo}")
 PYEOF
 "$SUBGROUP_CONFIG"
 )

--- a/scripts/update-readmes.sh
+++ b/scripts/update-readmes.sh
@@ -948,12 +948,24 @@ echo ""
 fetch_org_repos() {
   local org="$1"
   local repos="" page=1
+
+  # Determine whether the account is an org or a user — the API endpoints differ.
+  # /orgs/{org}/repos returns 404 for user accounts; /users/{user}/repos works for both
+  # but only returns public repos for orgs. Use /orgs/ first and fall back to /users/.
+  local account_type="orgs"
+  local probe
+  probe=$(curl -s -o /dev/null -w "%{http_code}" \
+    -H "Authorization: token ${GH_TOKEN}" \
+    -H "Accept: application/vnd.github+json" \
+    "${GH_API}/orgs/${org}")
+  [[ "$probe" != "200" ]] && account_type="users"
+
   while true; do
     local response
     response=$(curl -s \
       -H "Authorization: token ${GH_TOKEN}" \
       -H "Accept: application/vnd.github+json" \
-      "${GH_API}/orgs/${org}/repos?per_page=100&sort=pushed&page=${page}")
+      "${GH_API}/${account_type}/${org}/repos?per_page=100&sort=pushed&page=${page}")
 
     if echo "$response" | jq -e '.message' > /dev/null 2>&1; then
       local msg


### PR DESCRIPTION
Fixes three workflows that have been failing on every scheduled run.

## update-readmes (scheduled)

`fetch_org_repos` called `/orgs/{owner}/repos` unconditionally. `Interested-Deving-1896` is a user account, not an org — the call returned 404, which caused `exit 1` on every run. The function now probes `/orgs/{owner}` first and falls back to `/users/{owner}/repos` when the org endpoint returns non-200.

## sync-to-gitlab (scheduled)

The Python parser that builds the repo→GitLab-path map from `config/gitlab-subgroups.yml` ignored the `path:` field added in PR #56. It derived the namespace from the YAML key name, so `neon-deving` repos were being pushed to `openos-project/neon-deving/*` instead of `openos-project/kde-ecosystem-deving/neon-deving/*`. The parser now reads `path:` and uses it when present.

## sync-from-gitlab (scheduled)

Clone failures for `incus_deving` repos (GITLAB_SYNC_TOKEN lacks access to that subgroup) incremented `failed++` and caused `exit 1`. Clone errors that indicate access-denied (HTTP 403/401, "not found", "access denied") now return exit code 2 and increment `skipped++` instead, matching the non-fatal behaviour added to `mirror-osp-to-gitlab` in PR #57.

## sync-registered-imports (not fixed here)

Still failing because the 6 KDE Invent neon target repos don't exist in I-D-1896 yet. Blocked on `fork-neon-repos.yml` being triggered — tracked separately.