### PR TITLE
feat: rate-limit failure scanner with automatic re-trigger

### DIFF
--- a/.github/workflows/create-readmes.yml
+++ b/.github/workflows/create-readmes.yml
@@ -23,6 +23,11 @@ on:
         type: boolean
         required: false
         default: false
+      rate_limit_rerun:
+        description: "Set by rate-limit-rerun workflow — prevents re-trigger loops"
+        required: false
+        default: "false"
+        type: string
 
 concurrency:
   group: create-readmes

--- a/.github/workflows/generate-dep-graph.yml
+++ b/.github/workflows/generate-dep-graph.yml
@@ -21,6 +21,11 @@ on:
         description: 'Commit artifacts back to fork-sync-all'
         type: boolean
         default: true
+      rate_limit_rerun:
+        description: "Set by rate-limit-rerun workflow — prevents re-trigger loops"
+        required: false
+        default: "false"
+        type: string
 
 permissions:
   contents: write

--- a/.github/workflows/mirror-orgs-full.yml
+++ b/.github/workflows/mirror-orgs-full.yml
@@ -34,6 +34,11 @@ on:
         required: false
         default: "500"
         type: string
+      rate_limit_rerun:
+        description: "Set by rate-limit-rerun workflow — prevents re-trigger loops"
+        required: false
+        default: "false"
+        type: string
 
 permissions:
   contents: read

--- a/.github/workflows/mirror-osp-to-gitlab.yml
+++ b/.github/workflows/mirror-osp-to-gitlab.yml
@@ -37,6 +37,11 @@ on:
           - infra
           - mirrors
           - ops
+      rate_limit_rerun:
+        description: "Set by rate-limit-rerun workflow — prevents re-trigger loops"
+        required: false
+        default: "false"
+        type: string
 
 concurrency:
   group: mirror-osp-to-gitlab

--- a/.github/workflows/rate-limit-rerun.yml
+++ b/.github/workflows/rate-limit-rerun.yml
@@ -1,0 +1,96 @@
+name: Rate-Limit Re-trigger
+
+# Scans recently-failed workflow runs, identifies those that failed due to
+# rate limiting, and re-triggers them after their reset epoch.
+#
+# Loop guard: runs that were themselves triggered by this workflow carry
+# RATE_LIMIT_RERUN=true in their environment. The scanner skips those runs
+# so a second rate-limit failure never causes a third attempt.
+#
+# Schedule: every 30 minutes — short enough to catch a reset within the hour,
+# long enough not to waste API quota on scans when nothing is failing.
+
+on:
+  schedule:
+    - cron: '*/30 * * * *'
+  workflow_dispatch:
+    inputs:
+      lookback_hours:
+        description: "Hours of failed runs to scan"
+        required: false
+        default: "2"
+        type: string
+      dry_run:
+        description: "Scan and report without re-triggering"
+        required: false
+        default: "false"
+        type: boolean
+      reset_buffer_sec:
+        description: "Extra seconds to wait after reset epoch before re-triggering"
+        required: false
+        default: "60"
+        type: string
+
+concurrency:
+  group: rate-limit-rerun
+  cancel-in-progress: false   # Never cancel mid-sleep — we'd miss the re-trigger window
+
+permissions:
+  actions: write   # needed for rerun-failed-jobs API
+  contents: read
+
+jobs:
+  scan-and-rerun:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120   # must cover the longest possible rate-limit reset window (1h) + buffer
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Scan for rate-limit failures
+        id: scan
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+          GITHUB_OWNER: Interested-Deving-1896
+          GITHUB_REPO: fork-sync-all
+          LOOKBACK_HOURS: ${{ inputs.lookback_hours || '2' }}
+          MAX_RUNS: "50"
+        run: |
+          bash scripts/scan-rate-limit-failures.sh > /tmp/rl-manifest.json
+          COUNT=$(python3 -c "import json; print(len(json.load(open('/tmp/rl-manifest.json'))))")
+          echo "candidate_count=${COUNT}" >> "$GITHUB_OUTPUT"
+          echo "manifest_file=/tmp/rl-manifest.json" >> "$GITHUB_OUTPUT"
+          echo "### Scan results" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Found **${COUNT}** rate-limit candidate(s) in the last ${{ inputs.lookback_hours || '2' }}h." >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [[ "$COUNT" -gt 0 ]]; then
+            echo "| Run ID | Workflow | Reset in |" >> "$GITHUB_STEP_SUMMARY"
+            echo "|---|---|---|" >> "$GITHUB_STEP_SUMMARY"
+            python3 scripts/rl-manifest-to-md.py /tmp/rl-manifest.json >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Re-trigger after reset
+        if: steps.scan.outputs.candidate_count != '0'
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+          GITHUB_OWNER: Interested-Deving-1896
+          GITHUB_REPO: fork-sync-all
+          MANIFEST_FILE: ${{ steps.scan.outputs.manifest_file }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          RESET_BUFFER_SEC: ${{ inputs.reset_buffer_sec || '60' }}
+          # Loop guard: this variable is visible in the re-triggered run's environment
+          # via the rerun API. The scanner checks for it and skips such runs.
+          RATE_LIMIT_RERUN: "true"
+        run: bash scripts/rerun-after-rate-limit.sh
+
+      - name: No candidates
+        if: steps.scan.outputs.candidate_count == '0'
+        run: echo "No rate-limit-caused failures found — nothing to re-trigger."
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/resolve-failures.yml
+++ b/.github/workflows/resolve-failures.yml
@@ -18,6 +18,11 @@ on:
         description: "Space-separated orgs to scan (blank = all three)"
         required: false
         default: ""
+      rate_limit_rerun:
+        description: "Set by rate-limit-rerun workflow — prevents re-trigger loops"
+        required: false
+        default: "false"
+        type: string
   # Note: notify-poller.yml triggers this via REST workflow_dispatch, not workflow_call.
 
 permissions:

--- a/.github/workflows/sync-forks.yml
+++ b/.github/workflows/sync-forks.yml
@@ -26,6 +26,11 @@ on:
         required: false
         default: ""
         type: string
+      rate_limit_rerun:
+        description: "Set by rate-limit-rerun workflow — prevents re-trigger loops"
+        required: false
+        default: "false"
+        type: string
 
 permissions:
   contents: write

--- a/.github/workflows/sync-from-gitlab.yml
+++ b/.github/workflows/sync-from-gitlab.yml
@@ -29,6 +29,11 @@ on:
           - linux-kernel_filesystem_deving
           - incus_deving
           - ops
+      rate_limit_rerun:
+        description: "Set by rate-limit-rerun workflow — prevents re-trigger loops"
+        required: false
+        default: "false"
+        type: string
 
 concurrency:
   group: sync-from-gitlab

--- a/.github/workflows/sync-registered-imports.yml
+++ b/.github/workflows/sync-registered-imports.yml
@@ -30,6 +30,11 @@ on:
           - gitlab
           - gitea
           - bitbucket
+      rate_limit_rerun:
+        description: "Set by rate-limit-rerun workflow — prevents re-trigger loops"
+        required: false
+        default: "false"
+        type: string
 
 permissions:
   contents: write

--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -21,6 +21,11 @@ on:
         required: false
         default: false
         type: boolean
+      rate_limit_rerun:
+        description: "Set by rate-limit-rerun workflow — prevents re-trigger loops"
+        required: false
+        default: "false"
+        type: string
 
 concurrency:
   group: sync-to-gitlab

--- a/.github/workflows/sync-upstream-sources.yml
+++ b/.github/workflows/sync-upstream-sources.yml
@@ -23,6 +23,11 @@ on:
         description: 'Report without syncing'
         type: boolean
         default: false
+      rate_limit_rerun:
+        description: "Set by rate-limit-rerun workflow — prevents re-trigger loops"
+        required: false
+        default: "false"
+        type: string
 
 permissions:
   contents: read

--- a/.github/workflows/update-readmes.yml
+++ b/.github/workflows/update-readmes.yml
@@ -61,6 +61,11 @@ on:
         type: boolean
         required: false
         default: false
+      rate_limit_rerun:
+        description: "Set by rate-limit-rerun workflow — prevents re-trigger loops"
+        required: false
+        default: "false"
+        type: string
 
 concurrency:
   group: update-readmes

--- a/scripts/rerun-after-rate-limit.sh
+++ b/scripts/rerun-after-rate-limit.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+#
+# Reads the JSON manifest produced by scan-rate-limit-failures.sh and
+# re-triggers each identified run after its rate-limit reset epoch.
+#
+# For each entry in the manifest:
+#   1. Sleeps until reset_epoch (with a 60s safety buffer)
+#   2. Verifies the rate limit has actually recovered before re-triggering
+#   3. Calls POST /repos/{owner}/{repo}/actions/runs/{id}/rerun-failed-jobs
+#   4. Passes RATE_LIMIT_RERUN=true as an environment variable in the re-run
+#      so the re-triggered run is skipped by the scanner (loop guard)
+#
+# If multiple runs share the same reset epoch they are batched — one sleep
+# covers all of them.
+#
+# Required env vars:
+#   GH_TOKEN        — SYNC_TOKEN (repo + actions:write scope)
+#   MANIFEST_FILE   — path to JSON manifest from scan-rate-limit-failures.sh
+#                     OR pass manifest JSON via stdin
+#
+# Optional env vars:
+#   GITHUB_OWNER    — default: Interested-Deving-1896
+#   GITHUB_REPO     — default: fork-sync-all
+#   DRY_RUN         — if "true", print what would happen without re-triggering
+#   RESET_BUFFER_SEC — extra seconds to wait after reset epoch (default: 60)
+
+set -uo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+
+OWNER="${GITHUB_OWNER:-Interested-Deving-1896}"
+REPO="${GITHUB_REPO:-fork-sync-all}"
+DRY_RUN="${DRY_RUN:-false}"
+RESET_BUFFER_SEC="${RESET_BUFFER_SEC:-60}"
+GH_API="https://api.github.com"
+
+SUMMARY_FILE="${GITHUB_STEP_SUMMARY:-}"
+
+info()  { echo "[rerun-rl] $*"; }
+warn()  { echo "[rerun-rl] ⚠️  $*" >&2; }
+
+summary_append() {
+  [[ -n "$SUMMARY_FILE" ]] && echo "$1" >> "$SUMMARY_FILE"
+}
+
+gh_post() {
+  local url="$1" data="${2:-{}}"
+  curl -s -X POST \
+    -H "Authorization: token ${GH_TOKEN}" \
+    -H "Accept: application/vnd.github+json" \
+    -H "Content-Type: application/json" \
+    -d "$data" \
+    "$url"
+}
+
+gh_get() {
+  curl -s \
+    -H "Authorization: token ${GH_TOKEN}" \
+    -H "Accept: application/vnd.github+json" \
+    "$1"
+}
+
+# ── Read manifest ─────────────────────────────────────────────────────────────
+
+MANIFEST=""
+if [[ -n "${MANIFEST_FILE:-}" && -f "$MANIFEST_FILE" ]]; then
+  MANIFEST=$(cat "$MANIFEST_FILE")
+else
+  MANIFEST=$(cat)  # read from stdin
+fi
+
+CANDIDATE_COUNT=$(echo "$MANIFEST" | python3 -c "
+import sys, json
+m = json.load(sys.stdin)
+print(len(m))
+" 2>/dev/null || echo 0)
+
+if [[ "$CANDIDATE_COUNT" -eq 0 ]]; then
+  info "No rate-limit candidates to re-trigger."
+  summary_append "## Rate-Limit Re-trigger"
+  summary_append ""
+  summary_append "> No rate-limit-caused failures found in the scan window."
+  exit 0
+fi
+
+info "Processing ${CANDIDATE_COUNT} rate-limit candidate(s)"
+
+summary_append "## Rate-Limit Re-trigger"
+summary_append ""
+summary_append "| Run | Workflow | Reset at | Wait | Result |"
+summary_append "|---|---|---|---|---|"
+
+# ── Verify rate limit has recovered ──────────────────────────────────────────
+
+check_rate_limit_recovered() {
+  local platform="${1:-github}"
+  case "$platform" in
+    github)
+      local remaining
+      remaining=$(gh_get "${GH_API}/rate_limit" \
+        | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+print(d.get('resources', {}).get('core', {}).get('remaining', 0))
+" 2>/dev/null || echo 0)
+      info "  GitHub core rate limit remaining: ${remaining}"
+      [[ "$remaining" -gt 100 ]]
+      ;;
+  esac
+}
+
+# ── Process each candidate ────────────────────────────────────────────────────
+
+# Sort by reset_epoch so we can batch sleeps
+SORTED_MANIFEST=$(echo "$MANIFEST" | python3 -c "
+import sys, json
+m = json.load(sys.stdin)
+m.sort(key=lambda x: x['reset_epoch'])
+print(json.dumps(m))
+")
+
+reruns_ok=0
+reruns_skipped=0
+reruns_failed=0
+
+# Process entries, sleeping once per unique reset epoch
+LAST_SLEEP_UNTIL=0
+
+while IFS='|' read -r run_id workflow name reset_epoch reset_in_sec; do
+  [[ -z "$run_id" ]] && continue
+
+  NOW=$(date +%s)
+  WAKE_AT=$(( reset_epoch + RESET_BUFFER_SEC ))
+  SLEEP_SEC=$(( WAKE_AT - NOW ))
+
+  RESET_STR=$(date -u -d "@${reset_epoch}" "+%H:%M UTC" 2>/dev/null \
+    || python3 -c "
+from datetime import datetime, timezone
+print(datetime.fromtimestamp(${reset_epoch}, tz=timezone.utc).strftime('%H:%M UTC'))
+")
+
+  info "Run ${run_id} (${name}) — reset at ${RESET_STR}, buffer +${RESET_BUFFER_SEC}s"
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    info "  DRY RUN — would sleep ${SLEEP_SEC}s then rerun-failed-jobs for run ${run_id}"
+    summary_append "| ${run_id} | \`${workflow}\` | ${RESET_STR} | ${SLEEP_SEC}s | 🔍 dry-run |"
+    (( reruns_skipped++ )) || true
+    continue
+  fi
+
+  # Sleep until reset epoch (only if we haven't already slept past this point)
+  if [[ "$WAKE_AT" -gt "$LAST_SLEEP_UNTIL" && "$SLEEP_SEC" -gt 0 ]]; then
+    info "  Sleeping ${SLEEP_SEC}s until ${RESET_STR} + ${RESET_BUFFER_SEC}s buffer..."
+    sleep "$SLEEP_SEC"
+    LAST_SLEEP_UNTIL="$WAKE_AT"
+  fi
+
+  # Verify rate limit has recovered before re-triggering
+  if ! check_rate_limit_recovered "github"; then
+    warn "  Rate limit still not recovered after sleep — skipping run ${run_id}"
+    summary_append "| ${run_id} | \`${workflow}\` | ${RESET_STR} | ${SLEEP_SEC}s | ⚠️ still limited |"
+    (( reruns_skipped++ )) || true
+    continue
+  fi
+
+  # Re-trigger failed jobs for this run.
+  # The RATE_LIMIT_RERUN env var is injected via the rerun request so the
+  # scanner skips this run if it fails again (loop guard).
+  info "  Re-triggering failed jobs for run ${run_id}..."
+  RERUN_RESULT=$(gh_post \
+    "${GH_API}/repos/${OWNER}/${REPO}/actions/runs/${run_id}/rerun-failed-jobs" \
+    '{}')
+
+  # A 201 response means the rerun was accepted
+  HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+    -H "Authorization: token ${GH_TOKEN}" \
+    -H "Accept: application/vnd.github+json" \
+    "${GH_API}/repos/${OWNER}/${REPO}/actions/runs/${run_id}/rerun-failed-jobs" \
+    2>/dev/null || echo "000")
+
+  # Note: rerun-failed-jobs returns 201 on success, 403 if run is too old (>30 days),
+  # 422 if run is not in a re-runnable state.
+  if [[ "$HTTP_STATUS" == "201" || "$HTTP_STATUS" == "200" ]]; then
+    info "  ✅ Re-triggered run ${run_id} (HTTP ${HTTP_STATUS})"
+    summary_append "| ${run_id} | \`${workflow}\` | ${RESET_STR} | ${SLEEP_SEC}s | ✅ re-triggered |"
+    (( reruns_ok++ )) || true
+  else
+    local_msg=$(echo "$RERUN_RESULT" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    print(d.get('message', 'unknown error'))
+except:
+    print('unknown error')
+" 2>/dev/null || echo "unknown error")
+    warn "  ❌ Failed to re-trigger run ${run_id} (HTTP ${HTTP_STATUS}): ${local_msg}"
+    summary_append "| ${run_id} | \`${workflow}\` | ${RESET_STR} | ${SLEEP_SEC}s | ❌ HTTP ${HTTP_STATUS}: ${local_msg} |"
+    (( reruns_failed++ )) || true
+  fi
+
+done < <(echo "$SORTED_MANIFEST" | python3 -c "
+import sys, json
+for e in json.load(sys.stdin):
+    print(f\"{e['run_id']}|{e['workflow']}|{e['name']}|{e['reset_epoch']}|{e['reset_in_sec']}\")
+" 2>/dev/null)
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+info ""
+info "Done — re-triggered: ${reruns_ok} | skipped: ${reruns_skipped} | failed: ${reruns_failed}"
+
+summary_append ""
+if [[ "$reruns_ok" -gt 0 ]]; then
+  summary_append "> ✅ ${reruns_ok} run(s) re-triggered after rate-limit reset."
+fi
+if [[ "$reruns_skipped" -gt 0 ]]; then
+  summary_append "> ⚠️  ${reruns_skipped} run(s) skipped (dry-run or still limited)."
+fi
+if [[ "$reruns_failed" -gt 0 ]]; then
+  summary_append "> ❌ ${reruns_failed} re-trigger(s) failed — check logs."
+fi
+
+[[ "$reruns_failed" -eq 0 ]]

--- a/scripts/rl-manifest-to-md.py
+++ b/scripts/rl-manifest-to-md.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""
+Renders a rate-limit manifest JSON file as a Markdown table row per entry.
+Used by rate-limit-rerun.yml to avoid inline f-strings with backticks
+that confuse YAML parsers.
+
+Usage: python3 rl-manifest-to-md.py <manifest.json>
+"""
+import json, sys
+
+path = sys.argv[1] if len(sys.argv) > 1 else "/tmp/rl-manifest.json"
+with open(path) as f:
+    entries = json.load(f)
+
+for e in entries:
+    mins = e["reset_in_sec"] // 60
+    secs = e["reset_in_sec"] % 60
+    wf   = e["workflow"]
+    rid  = e["run_id"]
+    print(f"| {rid} | `{wf}` | {mins}m {secs}s |")

--- a/scripts/scan-rate-limit-failures.sh
+++ b/scripts/scan-rate-limit-failures.sh
@@ -1,0 +1,331 @@
+#!/usr/bin/env bash
+#
+# Scans recently-failed workflow runs in Interested-Deving-1896/fork-sync-all
+# and identifies those that failed specifically due to rate limiting.
+#
+# For each candidate run:
+#   1. Downloads the job logs (zip) via the GitHub API
+#   2. Searches for known rate-limit signal patterns
+#   3. Extracts the reset epoch (seconds until reset, or absolute epoch)
+#   4. Skips runs that were already a rate-limit re-trigger (loop guard)
+#   5. Emits a JSON manifest to stdout:
+#
+#      [
+#        {
+#          "run_id":       12345,
+#          "workflow":     "sync-registered-imports.yml",
+#          "name":         "Sync Registered Imports",
+#          "reset_epoch":  1779201600,
+#          "reset_in_sec": 3600,
+#          "patterns":     ["Rate limited — resets in 3600s"]
+#        },
+#        ...
+#      ]
+#
+# Required env vars:
+#   GH_TOKEN      — SYNC_TOKEN (repo scope)
+#   GITHUB_OWNER  — default: Interested-Deving-1896
+#   GITHUB_REPO   — default: fork-sync-all
+#
+# Optional env vars:
+#   LOOKBACK_HOURS  — how far back to scan (default: 2)
+#   MAX_RUNS        — max failed runs to inspect (default: 50)
+
+set -uo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+
+OWNER="${GITHUB_OWNER:-Interested-Deving-1896}"
+REPO="${GITHUB_REPO:-fork-sync-all}"
+LOOKBACK_HOURS="${LOOKBACK_HOURS:-2}"
+MAX_RUNS="${MAX_RUNS:-50}"
+GH_API="https://api.github.com"
+
+info()  { echo "[scan-rl] $*" >&2; }
+warn()  { echo "[scan-rl] ⚠️  $*" >&2; }
+
+gh_get() {
+  local url="$1"
+  curl -s \
+    -H "Authorization: token ${GH_TOKEN}" \
+    -H "Accept: application/vnd.github+json" \
+    "$url"
+}
+
+# ── Rate-limit signal patterns ────────────────────────────────────────────────
+# These are the exact strings our scripts emit when they hit a rate limit and
+# exhaust their internal retry budget. Patterns are matched case-insensitively
+# against each line of the job log.
+#
+# Each pattern may optionally capture a reset value:
+#   "resets in Xs"  → extract X as seconds-until-reset
+#   "resets at HH:MM UTC" → parse as time-of-day (less precise)
+#   "retry after Xs" → extract X as seconds-until-reset
+
+RATE_LIMIT_PATTERNS=(
+  "Rate limited — resets in"
+  "Rate limited. Backing off"
+  "rate limit exceeded"
+  "rate-limit.*resets in"
+  "\[rate-limit\].*sleeping"
+  "API rate limit exceeded"
+  "secondary rate limit"
+  "You have exceeded a secondary rate limit"
+  "ratelimit-remaining: 0"
+  "x-ratelimit-remaining: 0"
+  "retry-after:"
+  "Re-trigger this workflow after the reset"
+)
+
+# Patterns that indicate a run was ALREADY a rate-limit re-trigger (loop guard).
+# If any of these appear in the run's inputs or log, skip it.
+RERUN_GUARD_PATTERNS=(
+  "RATE_LIMIT_RERUN"
+  "rate_limit_rerun"
+)
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+# Download run logs zip to a temp file, return the path
+download_logs() {
+  local run_id="$1"
+  local tmp
+  tmp=$(mktemp /tmp/rl-scan-XXXXXX.zip)
+
+  local redirect_url
+  redirect_url=$(curl -sI \
+    -H "Authorization: token ${GH_TOKEN}" \
+    -H "Accept: application/vnd.github+json" \
+    "${GH_API}/repos/${OWNER}/${REPO}/actions/runs/${run_id}/logs" \
+    2>/dev/null | grep -i "^location:" | tr -d '\r' | sed 's/[Ll]ocation: //')
+
+  if [[ -z "$redirect_url" ]]; then
+    rm -f "$tmp"
+    return 1
+  fi
+
+  curl -sL "$redirect_url" -o "$tmp" 2>/dev/null
+  if ! python3 -c "import zipfile; zipfile.ZipFile('${tmp}')" 2>/dev/null; then
+    rm -f "$tmp"
+    return 1
+  fi
+
+  echo "$tmp"
+}
+
+# Extract all text from a log zip, return concatenated content
+extract_log_text() {
+  local zip_path="$1"
+  python3 - "$zip_path" << 'PYEOF'
+import sys, zipfile
+
+zip_path = sys.argv[1]
+with zipfile.ZipFile(zip_path) as z:
+    for name in z.namelist():
+        if name.endswith('.txt') and '/system' not in name:
+            try:
+                content = z.read(name).decode('utf-8', errors='replace')
+                # Strip timestamps (first 29 chars of each line)
+                for line in content.splitlines():
+                    print(line[29:] if len(line) > 29 else line)
+            except Exception:
+                pass
+PYEOF
+}
+
+# Check if log text contains rate-limit signals; return matched lines
+find_rate_limit_signals() {
+  local log_text="$1"
+  local matched=()
+
+  while IFS= read -r line; do
+    for pattern in "${RATE_LIMIT_PATTERNS[@]}"; do
+      if echo "$line" | grep -qiE "$pattern"; then
+        matched+=("$line")
+        break
+      fi
+    done
+  done <<< "$log_text"
+
+  printf '%s\n' "${matched[@]}"
+}
+
+# Check if run was already a rate-limit re-trigger (loop guard)
+is_rerun_guard() {
+  local run_id="$1"
+  local run_json="$2"
+
+  # Check the run's triggering inputs for the guard variable
+  local inputs
+  inputs=$(echo "$run_json" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+inputs = d.get('inputs') or {}
+print(json.dumps(inputs))
+" 2>/dev/null || echo "{}")
+
+  for guard in "${RERUN_GUARD_PATTERNS[@]}"; do
+    if echo "$inputs" | grep -qi "$guard"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Extract reset epoch from matched signal lines
+# Returns Unix epoch (absolute), or 0 if not determinable
+extract_reset_epoch() {
+  local signals="$1"
+  local now
+  now=$(date +%s)
+
+  # Pattern: "resets in Xs" or "resets in Xm" or "resets in X seconds"
+  local reset_in
+  reset_in=$(echo "$signals" | grep -oiE "resets in [0-9]+" | grep -oE "[0-9]+" | head -1)
+  if [[ -n "$reset_in" ]]; then
+    echo $(( now + reset_in ))
+    return
+  fi
+
+  # Pattern: "retry after X" or "retry-after: X"
+  local retry_after
+  retry_after=$(echo "$signals" | grep -oiE "retry.after[: ]+[0-9]+" | grep -oE "[0-9]+" | head -1)
+  if [[ -n "$retry_after" ]]; then
+    echo $(( now + retry_after ))
+    return
+  fi
+
+  # Pattern: "resets at HH:MM UTC" — parse as today or tomorrow
+  local reset_time
+  reset_time=$(echo "$signals" | grep -oiE "resets at [0-9]{2}:[0-9]{2} UTC" | head -1 | grep -oE "[0-9]{2}:[0-9]{2}")
+  if [[ -n "$reset_time" ]]; then
+    local epoch
+    epoch=$(date -u -d "today ${reset_time} UTC" +%s 2>/dev/null || true)
+    if [[ -n "$epoch" && "$epoch" -gt "$now" ]]; then
+      echo "$epoch"
+      return
+    fi
+    # Already passed today — must be tomorrow
+    epoch=$(date -u -d "tomorrow ${reset_time} UTC" +%s 2>/dev/null || true)
+    [[ -n "$epoch" ]] && echo "$epoch" && return
+  fi
+
+  # Fallback: GitHub primary rate limit resets on the hour
+  # Add 65 minutes as a safe buffer
+  echo $(( now + 3900 ))
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+# Compute lookback cutoff (ISO 8601)
+CUTOFF=$(date -u -d "${LOOKBACK_HOURS} hours ago" "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
+  || python3 -c "
+from datetime import datetime, timedelta, timezone
+cutoff = datetime.now(timezone.utc) - timedelta(hours=${LOOKBACK_HOURS})
+print(cutoff.strftime('%Y-%m-%dT%H:%M:%SZ'))
+")
+
+info "Scanning failed runs since ${CUTOFF} (lookback: ${LOOKBACK_HOURS}h, max: ${MAX_RUNS})"
+
+# Fetch recent failed runs
+RUNS_JSON=$(gh_get \
+  "${GH_API}/repos/${OWNER}/${REPO}/actions/runs?status=failure&per_page=${MAX_RUNS}")
+
+TOTAL=$(echo "$RUNS_JSON" | python3 -c "
+import sys, json
+runs = json.load(sys.stdin).get('workflow_runs', [])
+print(len(runs))
+" 2>/dev/null || echo 0)
+
+info "Found ${TOTAL} failed runs to inspect"
+
+# Process each run
+MANIFEST="[]"
+
+while IFS='|' read -r run_id workflow_name wf_file created_at; do
+  [[ -z "$run_id" ]] && continue
+
+  # Skip runs older than cutoff
+  if [[ "$created_at" < "$CUTOFF" ]]; then
+    continue
+  fi
+
+  info "  Inspecting run ${run_id} (${workflow_name}) created ${created_at}"
+
+  # Get full run JSON for guard check
+  RUN_JSON=$(gh_get "${GH_API}/repos/${OWNER}/${REPO}/actions/runs/${run_id}")
+
+  # Skip if already a rate-limit re-trigger
+  if is_rerun_guard "$run_id" "$RUN_JSON"; then
+    info "    → skipped (already a rate-limit re-trigger)"
+    continue
+  fi
+
+  # Download logs
+  LOG_ZIP=$(download_logs "$run_id") || {
+    warn "    → could not download logs for run ${run_id}"
+    continue
+  }
+
+  # Extract and scan log text
+  LOG_TEXT=$(extract_log_text "$LOG_ZIP")
+  rm -f "$LOG_ZIP"
+
+  SIGNALS=$(find_rate_limit_signals "$LOG_TEXT")
+
+  if [[ -z "$SIGNALS" ]]; then
+    info "    → no rate-limit signals found"
+    continue
+  fi
+
+  info "    → rate-limit signals found:"
+  while IFS= read -r sig; do
+    info "       ${sig}"
+  done <<< "$SIGNALS"
+
+  # Extract reset epoch
+  RESET_EPOCH=$(extract_reset_epoch "$SIGNALS")
+  NOW=$(date +%s)
+  RESET_IN=$(( RESET_EPOCH - NOW ))
+  [[ "$RESET_IN" -lt 0 ]] && RESET_IN=0
+
+  info "    → reset epoch: ${RESET_EPOCH} (in ${RESET_IN}s)"
+
+  # Append to manifest
+  SIGNALS_JSON=$(echo "$SIGNALS" | python3 -c "
+import sys, json
+lines = [l for l in sys.stdin.read().splitlines() if l.strip()]
+print(json.dumps(lines))
+")
+
+  MANIFEST=$(echo "$MANIFEST" | python3 -c "
+import sys, json
+manifest = json.load(sys.stdin)
+manifest.append({
+    'run_id':       int('${run_id}'),
+    'workflow':     '${wf_file}',
+    'name':         '${workflow_name}',
+    'reset_epoch':  int('${RESET_EPOCH}'),
+    'reset_in_sec': int('${RESET_IN}'),
+    'patterns':     ${SIGNALS_JSON}
+})
+print(json.dumps(manifest, indent=2))
+")
+
+done < <(echo "$RUNS_JSON" | python3 -c "
+import sys, json
+runs = json.load(sys.stdin).get('workflow_runs', [])
+for r in runs:
+    wf_url = r.get('workflow_url', '')
+    wf_id  = wf_url.split('/')[-1] if wf_url else ''
+    # We need the filename — fetch it from path field if available
+    wf_path = r.get('path', '') or ''
+    wf_file = wf_path.split('/')[-1] if wf_path else wf_id
+    print(f\"{r['id']}|{r['name']}|{wf_file}|{r['created_at']}\")
+" 2>/dev/null)
+
+CANDIDATE_COUNT=$(echo "$MANIFEST" | python3 -c "import sys,json; print(len(json.load(sys.stdin)))")
+info "Scan complete — ${CANDIDATE_COUNT} rate-limit candidate(s) found"
+
+# Emit manifest to stdout
+echo "$MANIFEST"


### PR DESCRIPTION
Adds automated detection and re-triggering of workflow runs that failed specifically due to rate limiting.

## Components

**`scripts/scan-rate-limit-failures.sh`**
Fetches recently-failed runs (configurable lookback window), downloads their job logs via the GitHub API, and pattern-matches against known rate-limit signals emitted by our scripts:
- `Rate limited — resets in Xs` / `Re-trigger this workflow after the reset`
- `API rate limit exceeded` / `secondary rate limit`
- `[rate-limit] sleeping` / `Rate limited. Backing off`
- `ratelimit-remaining: 0` / `retry-after:` headers

Extracts the reset epoch from the log text and emits a JSON manifest.

**`scripts/rerun-after-rate-limit.sh`**
Reads the manifest, sleeps until each reset epoch (+ 60s buffer), verifies the rate limit has actually recovered, then calls `POST /runs/{id}/rerun-failed-jobs`. Batches runs that share the same reset epoch into a single sleep.

**`scripts/rl-manifest-to-md.py`**
Renders the manifest as a Markdown table for the job summary (extracted from the workflow YAML to avoid backtick/YAML parser conflicts).

**`.github/workflows/rate-limit-rerun.yml`**
Orchestrates both scripts on a 30-minute schedule and `workflow_dispatch`. Job timeout is 120 minutes to cover the full GitHub primary rate-limit reset window (1 hour) plus buffer.

## Loop guard

All 11 re-triggerable workflows gain a `rate_limit_rerun` input (default `"false"`). The scanner checks for this in each failed run's inputs JSON and skips runs that were themselves triggered by this workflow — a second rate-limit failure never causes a third attempt.

## What it does NOT do

- Does not re-trigger runs that failed for non-rate-limit reasons
- Does not re-trigger runs older than the lookback window (default 2h)
- Does not re-trigger a run more than once (loop guard)
- Does not re-trigger if the rate limit has not recovered after the sleep