### PR TITLE
feat: add language switcher bar to README and translated files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 [![Built with Ona](https://ona.com/build-with-ona.svg)](https://app.ona.com/#https://github.com/OpenOS-Project-OSP/fork-sync-all)
 
+🇬🇧 English • [🇩🇪 Deutsch](README.de.md) • [🇪🇸 Español](README.es.md) • [🇫🇷 Français](README.fr.md) • [🇮🇹 Italiano](README.it.md) • [🇳🇱 Nederlands](README.nl.md) • [🇵🇱 Polski](README.pl.md) • [🇵🇹 Português](README.pt.md) • [🇸🇪 Svenska](README.sv.md) • [🇹🇷 Türkçe](README.tr.md) • [🇺🇦 Українська](README.uk.md) • [🇷🇺 Русский](README.ru.md) • [🇸🇦 العربية](README.ar.md) • [🇮🇳 हिन्दी](README.hi.md) • [🇯🇵 日本語](README.ja.md) • [🇰🇷 한국어](README.ko.md) • [🇨🇳 中文](README.zh.md) • [🇹🇼 繁體中文](README.zh-tw.md)
+
 Sync and mirror infrastructure for the three-org chain:
 
 ```

--- a/scripts/translate-readmes.sh
+++ b/scripts/translate-readmes.sh
@@ -107,6 +107,35 @@ lang_name() {
   esac
 }
 
+# Builds the language switcher bar for a given target language.
+# The current language is shown as plain text; all others are links.
+# Matches the set supported by translate-readmes.yml workflow inputs.
+build_switcher() {
+  local current="$1"
+  local -A labels=(
+    [en]="🇬🇧 English"   [de]="🇩🇪 Deutsch"    [es]="🇪🇸 Español"
+    [fr]="🇫🇷 Français"  [it]="🇮🇹 Italiano"   [nl]="🇳🇱 Nederlands"
+    [pl]="🇵🇱 Polski"    [pt]="🇵🇹 Português"  [sv]="🇸🇪 Svenska"
+    [tr]="🇹🇷 Türkçe"    [uk]="🇺🇦 Українська" [ru]="🇷🇺 Русский"
+    [ar]="🇸🇦 العربية"   [hi]="🇮🇳 हिन्दी"      [ja]="🇯🇵 日本語"
+    [ko]="🇰🇷 한국어"     [zh]="🇨🇳 中文"        [zh-tw]="🇹🇼 繁體中文"
+  )
+  local order=(en de es fr it nl pl pt sv tr uk ru ar hi ja ko zh zh-tw)
+  local parts=()
+  for lang in "${order[@]}"; do
+    local label="${labels[$lang]}"
+    local file
+    file=$(readme_filename "$lang")
+    if [[ "$lang" == "$current" ]]; then
+      parts+=("$label")
+    else
+      parts+=("[${label}](${file})")
+    fi
+  done
+  local IFS=" • "
+  echo "${parts[*]}"
+}
+
 # Returns the README filename for a given language code.
 # English is always README.md; others are README.<code>.md.
 readme_filename() {
@@ -471,10 +500,14 @@ for repo in "${repo_list[@]}"; do
     continue
   }
 
-  # Prepend a SHA watermark so future runs can detect staleness
+  # Prepend a SHA watermark and language switcher so future runs can detect
+  # staleness and readers can navigate between language versions.
+  switcher=$(build_switcher "$TARGET_LANG")
   final_content="<!-- translated-from-sha: ${src_sha} -->
 <!-- This file was automatically translated from ${actual_src_file} by translate-readmes.sh -->
 <!-- Do not edit manually — changes will be overwritten on the next translation run -->
+
+${switcher}
 
 ${translated_text}"
 


### PR DESCRIPTION
Adds a flag emoji + native name language switcher bar to the README, matching the style of the penguins-eggs blog.

## Changes

**`README.md`**
- Switcher bar added below the badge, above the org chain diagram
- Current language (English) shown as plain text; all 17 others are relative links to their `README.<lang>.md` files
- Covers all 18 languages supported by `translate-readmes.yml`: en, de, es, fr, it, nl, pl, pt, sv, tr, uk, ru, ar, hi, ja, ko, zh, zh-tw

**`scripts/translate-readmes.sh`**
- New `build_switcher()` function generates the switcher for any target language — current language is plain text, all others are relative links
- Switcher is injected into `final_content` after the SHA watermark, so every generated `README.<lang>.md` gets the bar automatically on the next translation run

## After merging

The translated files (`README.it.md`, `README.de.md`, etc.) don't exist yet in this repo. Trigger `translate-readmes.yml` with `scope=custom`, `repos=fork-sync-all` (targeting `Interested-Deving-1896/fork-sync-all`) for each language, or run a full `scope=all` pass — each generated file will include the switcher automatically.