### PR TITLE
fix(setup-gitlab-schedules): add checkout step and env vars for write-summary

### DIFF
--- a/.github/workflows/setup-gitlab-schedules.yml
+++ b/.github/workflows/setup-gitlab-schedules.yml
@@ -19,6 +19,8 @@ jobs:
   setup-schedules:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - name: Setup GitLab CI schedules
         env:
           GITLAB_TOKEN: ${{ secrets.GITLAB_SYNC_TOKEN }}
@@ -157,4 +159,7 @@ jobs:
 
       - name: Write summary
         if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
         run: bash scripts/write-summary.sh


### PR DESCRIPTION
## What

The `Write summary` step in `setup-gitlab-schedules.yml` was always failing because:

1. No `actions/checkout@v4` step — `scripts/write-summary.sh` was not present on the runner
2. `JOB_STATUS` and `INPUTS_JSON` env vars were not passed to the step

The `Setup GitLab CI schedules` step itself succeeded in all previous runs (schedules were created). This PR only fixes the summary step.

## Changes

- Add `actions/checkout@v4` as the first step
- Add `JOB_STATUS` and `INPUTS_JSON` env vars to the `Write summary` step
