### PR TITLE
fix(sync-template): remove spaces before = in propagate record parsing

### DIFF
--- a/.github/workflows/setup-gitlab-schedules.yml
+++ b/.github/workflows/setup-gitlab-schedules.yml
@@ -19,6 +19,8 @@ jobs:
   setup-schedules:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - name: Setup GitLab CI schedules
         env:
           GITLAB_TOKEN: ${{ secrets.GITLAB_SYNC_TOKEN }}
@@ -157,4 +159,7 @@ jobs:
 
       - name: Write summary
         if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
         run: bash scripts/write-summary.sh

--- a/scripts/sync-template.sh
+++ b/scripts/sync-template.sh
@@ -756,10 +756,10 @@ PYEOF
     [[ -z "$record" ]] && continue
 
     local c_name c_force c_skip_osp c_profile c_excludes c_includes
-    c_name     =$(echo "$record" | sed -n '1p')
-    c_force    =$(echo "$record" | sed -n '2p')
+    c_name=$(echo "$record" | sed -n '1p')
+    c_force=$(echo "$record" | sed -n '2p')
     c_skip_osp=$(echo "$record" | sed -n '3p')
-    c_profile  =$(echo "$record" | sed -n '4p')
+    c_profile=$(echo "$record" | sed -n '4p')
     c_excludes=$(echo "$record" | sed -n '5p')
     c_includes=$(echo "$record" | sed -n '6p')
 


### PR DESCRIPTION
## What

Every push-triggered `Sync Template` propagate run was failing immediately with:

```
scripts/sync-template.sh: line 759: c_name: command not found
scripts/sync-template.sh: line 766: c_name: unbound variable
```

Alignment spaces before `=` caused bash to interpret `c_name     =` as a command invocation rather than an assignment. All 37 consumers were skipped.

## Fix

Remove the alignment spaces from the six variable assignments in `run_propagate()`.

## Also in this branch

- `setup-gitlab-schedules.yml`: add `actions/checkout@v4` step and `JOB_STATUS`/`INPUTS_JSON` env vars to Write summary step (PR #76, already merged to main — this commit is the rebase residue).
