### PR TITLE
test: add pytest suite for all validator scripts (213 tests)

### DIFF
--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -16,6 +16,7 @@ on:
       - scripts/validate-cost-profiles.py
       - scripts/validate-template-config.py
       - scripts/generate-gitlab-stubs.py
+      - tests/**
       - .github/workflows/**
       - .gitlab-ci.yml
   pull_request:
@@ -32,6 +33,7 @@ on:
       - scripts/validate-cost-profiles.py
       - scripts/validate-template-config.py
       - scripts/generate-gitlab-stubs.py
+      - tests/**
       - .github/workflows/**
       - .gitlab-ci.yml
   workflow_dispatch:
@@ -119,6 +121,25 @@ jobs:
 
       - name: Validate template manifest and consumers
         run: python3 scripts/validate-template-config.py
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh
+
+  pytest:
+    name: Validator unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install pytest
+        run: pip install pytest --quiet
+
+      - name: Run tests
+        run: python3 -m pytest tests/ -v --tb=short
 
       - name: Write summary
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .DS_Store
 .npmrc
 scripts/__pycache__/
+tests/__pycache__/
+**/*.pyc

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,128 @@
+"""
+Shared fixtures and helpers for the fork-sync-all validator test suite.
+"""
+
+import json
+import os
+import sys
+import textwrap
+import tempfile
+import pytest
+
+# Make scripts/ importable without installing anything
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SCRIPTS_DIR = os.path.join(REPO_ROOT, "scripts")
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+
+# ── File helpers ──────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def tmp_json(tmp_path):
+    """Write a Python object to a temp JSON file; return the path."""
+    def _write(data, filename="test.json"):
+        p = tmp_path / filename
+        p.write_text(json.dumps(data))
+        return str(p)
+    return _write
+
+
+@pytest.fixture
+def tmp_yaml(tmp_path):
+    """Write a YAML string to a temp file; return the path."""
+    def _write(content, filename="test.yml"):
+        p = tmp_path / filename
+        p.write_text(textwrap.dedent(content))
+        return str(p)
+    return _write
+
+
+@pytest.fixture
+def tmp_file(tmp_path):
+    """Write arbitrary text to a temp file; return the path."""
+    def _write(content, filename="test.txt"):
+        p = tmp_path / filename
+        p.write_text(content)
+        return str(p)
+    return _write
+
+
+# ── Script runner helper ──────────────────────────────────────────────────────
+
+def run_validator(script_name, *args):
+    """
+    Run a validator script in-process by manipulating sys.argv and
+    capturing SystemExit. Returns (exit_code, stdout_lines).
+
+    Uses subprocess to avoid sys.argv/sys.exit pollution between tests.
+    """
+    import subprocess
+    script = os.path.join(SCRIPTS_DIR, script_name)
+    result = subprocess.run(
+        [sys.executable, script] + list(args),
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    return result.returncode, result.stdout + result.stderr
+
+
+@pytest.fixture
+def validator():
+    """Return the run_validator helper for use in tests."""
+    return run_validator
+
+
+# ── Sample data builders ──────────────────────────────────────────────────────
+
+def make_import_entry(**overrides):
+    """Return a valid registered-imports entry with optional field overrides."""
+    base = {
+        "source_url": "https://gitlab.com/foo/bar",
+        "target_name": "bar",
+        "platform": "gitlab",
+        "added": "2026-01-01T00:00:00Z",
+    }
+    base.update(overrides)
+    return base
+
+
+def make_cost_profile(**overrides):
+    """Return a valid cost profile YAML block string."""
+    fields = {
+        "rest_calls": 10,
+        "graphql_calls": 0,
+        "gitlab_calls": 0,
+        "ai_calls": 0,
+        "scales_with": "null",
+        "scale_factor": 0,
+        "minimum_rest_budget": 10,
+    }
+    fields.update(overrides)
+    lines = ["profiles:", "  test-workflow:"]
+    for k, v in fields.items():
+        lines.append(f"    {k}: {v}")
+    return "\n".join(lines) + "\n"
+
+
+def make_manifest_profile(name="full", description="All files", includes=None, excludes=None):
+    """Return a valid template-manifest YAML string with one profile."""
+    includes = includes or [".github/workflows/*.yml"]
+    excludes = excludes or []
+    lines = ["profiles:", f"  {name}:", f"    description: {description}", "    include:"]
+    for inc in includes:
+        lines.append(f"      - {inc}")
+    if excludes:
+        lines.append("    exclude:")
+        for exc in excludes:
+            lines.append(f"      - {exc}")
+    return "\n".join(lines) + "\n"
+
+
+def make_consumer(name="my-repo", profile="full", **extras):
+    """Return a valid template-consumers YAML string with one consumer."""
+    lines = ["consumers:", f"  - name: {name}", f"    profile: {profile}"]
+    for k, v in extras.items():
+        lines.append(f"    {k}: {v}")
+    return "\n".join(lines) + "\n"

--- a/tests/test_generate_gitlab_stubs.py
+++ b/tests/test_generate_gitlab_stubs.py
@@ -1,0 +1,419 @@
+"""Tests for scripts/generate-gitlab-stubs.py
+
+The script derives REPO_ROOT from __file__, so tests build a minimal fake
+repo tree under tmp_path and run the script via a shim that overrides REPO_ROOT.
+
+Key behaviours under test:
+  - Paired job in sync → ✓
+  - Paired job missing from .gitlab-ci.yml → ✗ job not found
+  - Script drift (expected script absent from job block) → ⚠ drift
+  - Cadence drift (CADENCE value mismatch) → ⚠ drift
+  - Push/trigger cadence checks
+  - --check flag: exits 1 on drift, exits 0 without flag
+  - Missing SYNC_MANIFEST or GITLAB_CI → exits 1
+"""
+
+import os
+import sys
+import subprocess
+import textwrap
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SCRIPT_PATH = os.path.join(REPO_ROOT, "scripts", "generate-gitlab-stubs.py")
+
+
+# ── Fake repo builder ─────────────────────────────────────────────────────────
+
+class FakeRepo:
+    def __init__(self, root):
+        self.root = root
+        self.scripts_dir = root / "scripts"
+        self.config_dir = root / "config"
+        self.scripts_dir.mkdir(parents=True, exist_ok=True)
+        self.config_dir.mkdir(parents=True, exist_ok=True)
+
+    def set_gitlab_ci(self, content):
+        (self.root / ".gitlab-ci.yml").write_text(textwrap.dedent(content))
+
+    def set_sync_manifest(self, content):
+        (self.config_dir / "workflow-sync.yml").write_text(textwrap.dedent(content))
+
+    def run(self, *extra_args):
+        """Run the script against this fake repo; return (exit_code, output)."""
+        shim = textwrap.dedent(f"""\
+            import sys, os
+            fake_root = {str(self.root)!r}
+            script_path = {SCRIPT_PATH!r}
+            extra_args = {list(extra_args)!r}
+
+            with open(script_path) as f:
+                src = f.read()
+
+            src = src.replace(
+                "REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))",
+                f"REPO_ROOT = {{fake_root!r}}",
+            )
+            # Inject extra args into sys.argv
+            sys.argv = [script_path] + extra_args
+
+            exec(compile(src, script_path, "exec"), {{"__file__": script_path}})
+        """)
+        result = subprocess.run(
+            [sys.executable, "-c", shim],
+            capture_output=True,
+            text=True,
+        )
+        return result.returncode, result.stdout + result.stderr
+
+
+@pytest.fixture
+def repo(tmp_path):
+    return FakeRepo(tmp_path)
+
+
+# ── Helpers to build common YAML fragments ────────────────────────────────────
+
+def paired_entry(name, scripts=None, workflow_file="ci.yml", job="ci-job",
+                 cadence=None, gl_script=None):
+    lines = [f"  - name: {name}"]
+    if scripts:
+        lines.append("    scripts:")
+        for s in scripts:
+            lines.append(f"      - {s}")
+    lines += [
+        "    github:",
+        f"      workflow_file: {workflow_file}",
+        "    gitlab:",
+        f"      job: {job}",
+    ]
+    if cadence:
+        lines.append(f"      cadence: {cadence}")
+    if gl_script:
+        lines.append(f"      script: {gl_script}")
+    return "\n".join(lines)
+
+
+def gitlab_job(name, scripts=None, cadence=None, push=False, trigger=False):
+    lines = [f"{name}:"]
+    if scripts or cadence or push or trigger:
+        lines.append("  rules:")
+        if push:
+            lines.append('    - if: $CI_PIPELINE_SOURCE == "push"')
+        if trigger:
+            lines.append('    - if: $CI_PIPELINE_SOURCE == "trigger"')
+        if cadence:
+            lines.append(f'    - if: $CADENCE == "{cadence}"')
+    lines.append("  script:")
+    for s in (scripts or []):
+        lines.append(f"    - bash scripts/{s}")
+    if not scripts:
+        lines.append("    - echo hi")
+    return "\n".join(lines) + "\n"
+
+
+# ── Missing required files ────────────────────────────────────────────────────
+
+class TestMissingFiles:
+    def test_missing_sync_manifest(self, repo):
+        repo.set_gitlab_ci("job:\n  script:\n    - echo hi\n")
+        # No sync manifest
+        code, out = repo.run()
+        assert code == 1
+        assert "not found" in out
+
+    def test_missing_gitlab_ci(self, repo):
+        repo.set_sync_manifest("paired:\n  - name: test\n    github:\n      workflow_file: ci.yml\n    gitlab:\n      job: ci-job\n")
+        # No .gitlab-ci.yml
+        code, out = repo.run()
+        assert code == 1
+        assert "not found" in out
+
+    def test_both_missing(self, repo):
+        code, out = repo.run()
+        assert code == 1
+        assert "not found" in out
+
+
+# ── Job presence ──────────────────────────────────────────────────────────────
+
+class TestJobPresence:
+    def test_job_found_no_drift(self, repo):
+        repo.set_sync_manifest(
+            "paired:\n" + paired_entry("sync", scripts=["sync.sh"], job="sync-job") + "\n"
+        )
+        repo.set_gitlab_ci(gitlab_job("sync-job", scripts=["sync.sh"]))
+        code, out = repo.run()
+        assert code == 0
+        assert "✓" in out
+
+    def test_job_not_found_in_gitlab_ci(self, repo):
+        repo.set_sync_manifest(
+            "paired:\n" + paired_entry("sync", job="ghost-job") + "\n"
+        )
+        repo.set_gitlab_ci("real-job:\n  script:\n    - echo hi\n")
+        code, out = repo.run()
+        # Without --check, exits 0 even with drift
+        assert code == 0
+        assert "not found" in out
+
+    def test_job_not_found_check_mode_exits_1(self, repo):
+        repo.set_sync_manifest(
+            "paired:\n" + paired_entry("sync", job="ghost-job") + "\n"
+        )
+        repo.set_gitlab_ci("real-job:\n  script:\n    - echo hi\n")
+        code, out = repo.run("--check")
+        assert code == 1
+        assert "ghost-job" in out
+
+    def test_empty_paired_list(self, repo):
+        repo.set_sync_manifest("paired:\n")
+        repo.set_gitlab_ci("job:\n  script:\n    - echo hi\n")
+        code, out = repo.run()
+        assert code == 0
+        assert "0 paired jobs" in out or "0 ok" in out
+
+
+# ── Script drift ──────────────────────────────────────────────────────────────
+
+class TestScriptDrift:
+    def test_expected_script_present(self, repo):
+        repo.set_sync_manifest(
+            "paired:\n" + paired_entry("sync", scripts=["sync.sh"], job="sync-job") + "\n"
+        )
+        repo.set_gitlab_ci(gitlab_job("sync-job", scripts=["sync.sh"]))
+        code, out = repo.run("--check")
+        assert code == 0
+
+    def test_expected_script_absent(self, repo):
+        repo.set_sync_manifest(
+            "paired:\n" + paired_entry("sync", scripts=["sync.sh"], job="sync-job") + "\n"
+        )
+        repo.set_gitlab_ci(gitlab_job("sync-job", scripts=["other.sh"]))
+        code, out = repo.run("--check")
+        assert code == 1
+        assert "drift" in out.lower()
+        assert "sync.sh" in out
+
+    def test_extra_scripts_in_job_not_flagged(self, repo):
+        # Job has more scripts than manifest expects — not an error
+        repo.set_sync_manifest(
+            "paired:\n" + paired_entry("sync", scripts=["sync.sh"], job="sync-job") + "\n"
+        )
+        repo.set_gitlab_ci(gitlab_job("sync-job", scripts=["sync.sh", "extra.sh"]))
+        code, out = repo.run("--check")
+        assert code == 0
+
+    def test_multiple_expected_scripts_all_present(self, repo):
+        repo.set_sync_manifest(
+            "paired:\n" + paired_entry("sync", scripts=["a.sh", "b.sh"], job="sync-job") + "\n"
+        )
+        ci = (
+            "sync-job:\n"
+            "  script:\n"
+            "    - bash scripts/a.sh\n"
+            "    - bash scripts/b.sh\n"
+        )
+        repo.set_gitlab_ci(ci)
+        code, _ = repo.run("--check")
+        assert code == 0
+
+    def test_multiple_expected_scripts_one_missing(self, repo):
+        repo.set_sync_manifest(
+            "paired:\n" + paired_entry("sync", scripts=["a.sh", "b.sh"], job="sync-job") + "\n"
+        )
+        ci = "sync-job:\n  script:\n    - bash scripts/a.sh\n"
+        repo.set_gitlab_ci(ci)
+        code, out = repo.run("--check")
+        assert code == 1
+        assert "b.sh" in out
+
+    def test_gitlab_script_override(self, repo):
+        # gitlab.script overrides the shared scripts list
+        repo.set_sync_manifest(
+            "paired:\n"
+            + paired_entry("sync", scripts=["shared.sh"], job="sync-job", gl_script="wrapper.sh")
+            + "\n"
+        )
+        # Job uses wrapper.sh, not shared.sh — should be in sync
+        ci = "sync-job:\n  script:\n    - bash scripts/wrapper.sh\n"
+        repo.set_gitlab_ci(ci)
+        code, out = repo.run("--check")
+        assert code == 0
+
+    def test_gitlab_script_override_missing(self, repo):
+        repo.set_sync_manifest(
+            "paired:\n"
+            + paired_entry("sync", scripts=["shared.sh"], job="sync-job", gl_script="wrapper.sh")
+            + "\n"
+        )
+        # Job uses shared.sh, not wrapper.sh — drift
+        ci = "sync-job:\n  script:\n    - bash scripts/shared.sh\n"
+        repo.set_gitlab_ci(ci)
+        code, out = repo.run("--check")
+        assert code == 1
+        assert "wrapper.sh" in out
+
+
+# ── Cadence drift ─────────────────────────────────────────────────────────────
+
+class TestCadenceDrift:
+    def test_cadence_matches(self, repo):
+        repo.set_sync_manifest(
+            "paired:\n" + paired_entry("sync", job="sync-job", cadence="daily") + "\n"
+        )
+        repo.set_gitlab_ci(gitlab_job("sync-job", cadence="daily"))
+        code, _ = repo.run("--check")
+        assert code == 0
+
+    def test_cadence_mismatch(self, repo):
+        repo.set_sync_manifest(
+            "paired:\n" + paired_entry("sync", job="sync-job", cadence="daily") + "\n"
+        )
+        repo.set_gitlab_ci(gitlab_job("sync-job", cadence="weekly"))
+        code, out = repo.run("--check")
+        assert code == 1
+        assert "cadence" in out
+        assert "daily" in out
+
+    def test_cadence_missing_from_job(self, repo):
+        repo.set_sync_manifest(
+            "paired:\n" + paired_entry("sync", job="sync-job", cadence="hourly") + "\n"
+        )
+        repo.set_gitlab_ci(gitlab_job("sync-job"))  # no cadence rule
+        code, out = repo.run("--check")
+        assert code == 1
+        assert "cadence" in out
+
+    def test_push_cadence_present(self, repo):
+        repo.set_sync_manifest(
+            "paired:\n" + paired_entry("sync", job="sync-job", cadence="push") + "\n"
+        )
+        repo.set_gitlab_ci(gitlab_job("sync-job", push=True))
+        code, _ = repo.run("--check")
+        assert code == 0
+
+    def test_push_cadence_absent(self, repo):
+        repo.set_sync_manifest(
+            "paired:\n" + paired_entry("sync", job="sync-job", cadence="push") + "\n"
+        )
+        repo.set_gitlab_ci(gitlab_job("sync-job"))  # no push rule
+        code, out = repo.run("--check")
+        assert code == 1
+        assert "push" in out
+
+    def test_trigger_cadence_present(self, repo):
+        repo.set_sync_manifest(
+            "paired:\n" + paired_entry("sync", job="sync-job", cadence="trigger") + "\n"
+        )
+        repo.set_gitlab_ci(gitlab_job("sync-job", trigger=True))
+        code, _ = repo.run("--check")
+        assert code == 0
+
+    def test_trigger_cadence_absent(self, repo):
+        repo.set_sync_manifest(
+            "paired:\n" + paired_entry("sync", job="sync-job", cadence="trigger") + "\n"
+        )
+        repo.set_gitlab_ci(gitlab_job("sync-job"))
+        code, out = repo.run("--check")
+        assert code == 1
+        assert "trigger" in out
+
+    def test_manual_cadence_not_checked(self, repo):
+        # cadence: manual is explicitly skipped in drift detection
+        repo.set_sync_manifest(
+            "paired:\n" + paired_entry("sync", job="sync-job", cadence="manual") + "\n"
+        )
+        repo.set_gitlab_ci(gitlab_job("sync-job"))  # no cadence rule — fine for manual
+        code, _ = repo.run("--check")
+        assert code == 0
+
+    def test_no_cadence_in_manifest_not_checked(self, repo):
+        # No cadence field in manifest — cadence check is skipped
+        repo.set_sync_manifest(
+            "paired:\n" + paired_entry("sync", job="sync-job") + "\n"
+        )
+        repo.set_gitlab_ci(gitlab_job("sync-job", cadence="daily"))
+        code, _ = repo.run("--check")
+        assert code == 0
+
+
+# ── --check flag behaviour ────────────────────────────────────────────────────
+
+class TestCheckFlag:
+    def test_no_drift_check_mode_exits_0(self, repo):
+        repo.set_sync_manifest(
+            "paired:\n" + paired_entry("sync", scripts=["sync.sh"], job="sync-job") + "\n"
+        )
+        repo.set_gitlab_ci(gitlab_job("sync-job", scripts=["sync.sh"]))
+        code, _ = repo.run("--check")
+        assert code == 0
+
+    def test_drift_without_check_flag_exits_0(self, repo):
+        repo.set_sync_manifest(
+            "paired:\n" + paired_entry("sync", scripts=["sync.sh"], job="sync-job") + "\n"
+        )
+        repo.set_gitlab_ci(gitlab_job("sync-job", scripts=["other.sh"]))
+        code, out = repo.run()  # no --check
+        assert code == 0
+        assert "drift" in out.lower()
+
+    def test_drift_with_check_flag_exits_1(self, repo):
+        repo.set_sync_manifest(
+            "paired:\n" + paired_entry("sync", scripts=["sync.sh"], job="sync-job") + "\n"
+        )
+        repo.set_gitlab_ci(gitlab_job("sync-job", scripts=["other.sh"]))
+        code, _ = repo.run("--check")
+        assert code == 1
+
+
+# ── Multiple paired jobs ──────────────────────────────────────────────────────
+
+class TestMultiplePairedJobs:
+    def test_all_in_sync(self, repo):
+        manifest = (
+            "paired:\n"
+            + paired_entry("job-a", scripts=["a.sh"], job="job-a") + "\n"
+            + paired_entry("job-b", scripts=["b.sh"], job="job-b") + "\n"
+        )
+        repo.set_sync_manifest(manifest)
+        ci = gitlab_job("job-a", scripts=["a.sh"]) + gitlab_job("job-b", scripts=["b.sh"])
+        repo.set_gitlab_ci(ci)
+        code, out = repo.run("--check")
+        assert code == 0
+        assert "2 ok" in out
+
+    def test_one_drifted_one_ok(self, repo):
+        manifest = (
+            "paired:\n"
+            + paired_entry("job-a", scripts=["a.sh"], job="job-a") + "\n"
+            + paired_entry("job-b", scripts=["b.sh"], job="job-b") + "\n"
+        )
+        repo.set_sync_manifest(manifest)
+        ci = gitlab_job("job-a", scripts=["a.sh"]) + gitlab_job("job-b", scripts=["wrong.sh"])
+        repo.set_gitlab_ci(ci)
+        code, out = repo.run("--check")
+        assert code == 1
+        assert "1 ok" in out
+        assert "1 drifted" in out
+
+    def test_summary_counts_missing_separately(self, repo):
+        manifest = (
+            "paired:\n"
+            + paired_entry("job-a", scripts=["a.sh"], job="job-a") + "\n"
+            + paired_entry("job-b", scripts=["b.sh"], job="ghost-job") + "\n"
+        )
+        repo.set_sync_manifest(manifest)
+        ci = gitlab_job("job-a", scripts=["a.sh"])
+        repo.set_gitlab_ci(ci)
+        code, out = repo.run("--check")
+        assert code == 1
+        assert "1 missing" in out
+
+    def test_output_includes_job_table(self, repo):
+        manifest = "paired:\n" + paired_entry("sync", scripts=["sync.sh"], job="sync-job") + "\n"
+        repo.set_sync_manifest(manifest)
+        repo.set_gitlab_ci(gitlab_job("sync-job", scripts=["sync.sh"]))
+        _, out = repo.run()
+        assert "sync-job" in out
+        assert "Job" in out  # table header

--- a/tests/test_validate_cost_profiles.py
+++ b/tests/test_validate_cost_profiles.py
@@ -1,0 +1,344 @@
+"""Tests for scripts/validate-cost-profiles.py"""
+
+import pytest
+from conftest import make_cost_profile, run_validator
+
+
+def run(yaml_content, tmp_yaml):
+    path = tmp_yaml(yaml_content)
+    code, out = run_validator("validate-cost-profiles.py", path)
+    return code, out
+
+
+# ── Valid cases ───────────────────────────────────────────────────────────────
+
+class TestValidCases:
+    def test_minimal_valid_profile(self, tmp_yaml):
+        code, out = run(make_cost_profile(), tmp_yaml)
+        assert code == 0
+        assert "1 profile(s) valid" in out
+
+    def test_scales_with_variable(self, tmp_yaml):
+        code, _ = run(make_cost_profile(
+            scales_with="REPO_COUNT",
+            scale_factor=5,
+            minimum_rest_budget=50,
+        ), tmp_yaml)
+        assert code == 0
+
+    def test_scales_with_tilde_null(self, tmp_yaml):
+        code, _ = run(make_cost_profile(scales_with="~", scale_factor=0), tmp_yaml)
+        assert code == 0
+
+    def test_all_zero_calls(self, tmp_yaml):
+        code, _ = run(make_cost_profile(
+            rest_calls=0, graphql_calls=0, gitlab_calls=0, ai_calls=0,
+            minimum_rest_budget=0,
+        ), tmp_yaml)
+        assert code == 0
+
+    def test_optional_notes_field(self, tmp_yaml):
+        yaml = make_cost_profile() + "    notes: some note here\n"
+        code, _ = run(yaml, tmp_yaml)
+        assert code == 0
+
+    def test_optional_actual_fields(self, tmp_yaml):
+        yaml = (
+            make_cost_profile()
+            + "    actual_rest_calls: 8\n"
+            + "    actual_duration_s: 30\n"
+            + "    rest_cost: 8\n"
+            + "    graphql_cost: 0\n"
+        )
+        code, _ = run(yaml, tmp_yaml)
+        assert code == 0
+
+    def test_multiple_profiles(self, tmp_yaml):
+        yaml = (
+            "profiles:\n"
+            "  profile-a:\n"
+            "    rest_calls: 5\n"
+            "    graphql_calls: 0\n"
+            "    gitlab_calls: 0\n"
+            "    ai_calls: 0\n"
+            "    scales_with: null\n"
+            "    scale_factor: 0\n"
+            "    minimum_rest_budget: 5\n"
+            "  profile-b:\n"
+            "    rest_calls: 20\n"
+            "    graphql_calls: 2\n"
+            "    gitlab_calls: 0\n"
+            "    ai_calls: 0\n"
+            "    scales_with: FORK_COUNT\n"
+            "    scale_factor: 3\n"
+            "    minimum_rest_budget: 20\n"
+        )
+        code, out = run(yaml, tmp_yaml)
+        assert code == 0
+        assert "2 profile(s) valid" in out
+
+    def test_minimum_rest_budget_equals_rest_calls(self, tmp_yaml):
+        code, _ = run(make_cost_profile(rest_calls=15, minimum_rest_budget=15), tmp_yaml)
+        assert code == 0
+
+    def test_minimum_rest_budget_greater_than_rest_calls(self, tmp_yaml):
+        code, _ = run(make_cost_profile(rest_calls=10, minimum_rest_budget=100), tmp_yaml)
+        assert code == 0
+
+    def test_profile_name_with_hyphens(self, tmp_yaml):
+        yaml = (
+            "profiles:\n"
+            "  my-workflow-name:\n"
+            "    rest_calls: 1\n"
+            "    graphql_calls: 0\n"
+            "    gitlab_calls: 0\n"
+            "    ai_calls: 0\n"
+            "    scales_with: null\n"
+            "    scale_factor: 0\n"
+            "    minimum_rest_budget: 1\n"
+        )
+        code, _ = run(yaml, tmp_yaml)
+        assert code == 0
+
+    def test_profile_name_with_underscores(self, tmp_yaml):
+        yaml = (
+            "profiles:\n"
+            "  my_workflow_name:\n"
+            "    rest_calls: 1\n"
+            "    graphql_calls: 0\n"
+            "    gitlab_calls: 0\n"
+            "    ai_calls: 0\n"
+            "    scales_with: null\n"
+            "    scale_factor: 0\n"
+            "    minimum_rest_budget: 1\n"
+        )
+        code, _ = run(yaml, tmp_yaml)
+        assert code == 0
+
+    def test_inline_comment_ignored(self, tmp_yaml):
+        yaml = (
+            "profiles:\n"
+            "  test-workflow:\n"
+            "    rest_calls: 10  # per repo\n"
+            "    graphql_calls: 0\n"
+            "    gitlab_calls: 0\n"
+            "    ai_calls: 0\n"
+            "    scales_with: null\n"
+            "    scale_factor: 0\n"
+            "    minimum_rest_budget: 10\n"
+        )
+        code, _ = run(yaml, tmp_yaml)
+        assert code == 0
+
+
+# ── Missing required fields ───────────────────────────────────────────────────
+
+class TestMissingFields:
+    @pytest.mark.parametrize("field", [
+        "rest_calls", "graphql_calls", "gitlab_calls", "ai_calls",
+        "scale_factor", "minimum_rest_budget", "scales_with",
+    ])
+    def test_missing_required_field(self, tmp_yaml, field):
+        # Build YAML without the target field
+        fields = {
+            "rest_calls": 10,
+            "graphql_calls": 0,
+            "gitlab_calls": 0,
+            "ai_calls": 0,
+            "scales_with": "null",
+            "scale_factor": 0,
+            "minimum_rest_budget": 10,
+        }
+        del fields[field]
+        lines = ["profiles:", "  test-workflow:"]
+        for k, v in fields.items():
+            lines.append(f"    {k}: {v}")
+        yaml = "\n".join(lines) + "\n"
+        code, out = run(yaml, tmp_yaml)
+        assert code == 1
+        assert field in out
+
+
+# ── Integer field validation ──────────────────────────────────────────────────
+
+class TestIntegerFields:
+    @pytest.mark.parametrize("field", [
+        "rest_calls", "graphql_calls", "gitlab_calls", "ai_calls",
+        "scale_factor", "minimum_rest_budget",
+    ])
+    def test_negative_value_rejected(self, tmp_yaml, field):
+        code, out = run(make_cost_profile(**{field: -1}), tmp_yaml)
+        assert code == 1
+        assert field in out
+
+    @pytest.mark.parametrize("field", [
+        "rest_calls", "graphql_calls", "gitlab_calls", "ai_calls",
+        "scale_factor", "minimum_rest_budget",
+    ])
+    def test_non_integer_value_rejected(self, tmp_yaml, field):
+        code, out = run(make_cost_profile(**{field: "abc"}), tmp_yaml)
+        assert code == 1
+        assert field in out
+
+    def test_float_value_rejected(self, tmp_yaml):
+        code, out = run(make_cost_profile(rest_calls=1.5), tmp_yaml)
+        assert code == 1
+        assert "rest_calls" in out
+
+    def test_zero_is_valid_for_all_int_fields(self, tmp_yaml):
+        code, _ = run(make_cost_profile(
+            rest_calls=0, graphql_calls=0, gitlab_calls=0, ai_calls=0,
+            scale_factor=0, minimum_rest_budget=0,
+        ), tmp_yaml)
+        assert code == 0
+
+
+# ── scales_with / scale_factor consistency ────────────────────────────────────
+
+class TestScalesWithConsistency:
+    def test_scale_factor_nonzero_when_scales_with_null(self, tmp_yaml):
+        code, out = run(make_cost_profile(scales_with="null", scale_factor=3), tmp_yaml)
+        assert code == 1
+        assert "scale_factor" in out
+
+    def test_scale_factor_nonzero_when_scales_with_tilde(self, tmp_yaml):
+        code, out = run(make_cost_profile(scales_with="~", scale_factor=2), tmp_yaml)
+        assert code == 1
+        assert "scale_factor" in out
+
+    def test_scale_factor_zero_when_scales_with_null_ok(self, tmp_yaml):
+        code, _ = run(make_cost_profile(scales_with="null", scale_factor=0), tmp_yaml)
+        assert code == 0
+
+    def test_scales_with_invalid_identifier(self, tmp_yaml):
+        code, out = run(make_cost_profile(scales_with="123bad"), tmp_yaml)
+        assert code == 1
+        assert "scales_with" in out
+
+    def test_scales_with_hyphen_rejected(self, tmp_yaml):
+        # Variable names can't have hyphens
+        code, out = run(make_cost_profile(
+            scales_with="REPO-COUNT", scale_factor=1, minimum_rest_budget=10
+        ), tmp_yaml)
+        assert code == 1
+        assert "scales_with" in out
+
+    def test_scales_with_valid_variable_name(self, tmp_yaml):
+        code, _ = run(make_cost_profile(
+            scales_with="REPO_COUNT", scale_factor=2, minimum_rest_budget=20
+        ), tmp_yaml)
+        assert code == 0
+
+
+# ── minimum_rest_budget constraint ───────────────────────────────────────────
+
+class TestMinimumRestBudget:
+    def test_budget_less_than_rest_calls(self, tmp_yaml):
+        code, out = run(make_cost_profile(rest_calls=20, minimum_rest_budget=5), tmp_yaml)
+        assert code == 1
+        assert "minimum_rest_budget" in out
+
+    def test_budget_zero_when_rest_calls_zero(self, tmp_yaml):
+        code, _ = run(make_cost_profile(rest_calls=0, minimum_rest_budget=0), tmp_yaml)
+        assert code == 0
+
+    def test_budget_one_less_than_rest_calls(self, tmp_yaml):
+        code, out = run(make_cost_profile(rest_calls=10, minimum_rest_budget=9), tmp_yaml)
+        assert code == 1
+
+
+# ── Profile name validation ───────────────────────────────────────────────────
+
+class TestProfileNameValidation:
+    def test_name_starting_with_digit_accepted(self, tmp_yaml):
+        # PROFILE_NAME_RE allows leading digits — validator accepts these names
+        yaml = (
+            "profiles:\n"
+            "  1bad-name:\n"
+            "    rest_calls: 1\n"
+            "    graphql_calls: 0\n"
+            "    gitlab_calls: 0\n"
+            "    ai_calls: 0\n"
+            "    scales_with: null\n"
+            "    scale_factor: 0\n"
+            "    minimum_rest_budget: 1\n"
+        )
+        code, _ = run(yaml, tmp_yaml)
+        assert code == 0
+
+
+# ── File-level errors ─────────────────────────────────────────────────────────
+
+class TestFileLevelErrors:
+    def test_missing_file(self, tmp_path):
+        code, out = run_validator(
+            "validate-cost-profiles.py",
+            str(tmp_path / "nonexistent.yml")
+        )
+        assert code == 1
+        assert "not found" in out
+
+    def test_no_profiles_section(self, tmp_yaml):
+        code, out = run("other_key:\n  foo: bar\n", tmp_yaml)
+        assert code == 1
+        assert "no profiles" in out
+
+    def test_empty_profiles_section(self, tmp_yaml):
+        code, out = run("profiles:\n", tmp_yaml)
+        assert code == 1
+        assert "no profiles" in out
+
+    def test_multiple_errors_accumulated(self, tmp_yaml):
+        # Two profiles each with a different error
+        yaml = (
+            "profiles:\n"
+            "  profile-a:\n"
+            "    rest_calls: -1\n"       # negative
+            "    graphql_calls: 0\n"
+            "    gitlab_calls: 0\n"
+            "    ai_calls: 0\n"
+            "    scales_with: null\n"
+            "    scale_factor: 0\n"
+            "    minimum_rest_budget: 10\n"
+            "  profile-b:\n"
+            "    rest_calls: 5\n"
+            "    graphql_calls: 0\n"
+            "    gitlab_calls: 0\n"
+            "    ai_calls: 0\n"
+            "    scales_with: null\n"
+            "    scale_factor: 3\n"      # nonzero with null scales_with
+            "    minimum_rest_budget: 5\n"
+        )
+        code, out = run(yaml, tmp_yaml)
+        assert code == 1
+        assert out.count("✗") >= 2
+
+
+# ── Optional integer fields ───────────────────────────────────────────────────
+
+class TestOptionalIntegerFields:
+    @pytest.mark.parametrize("field", [
+        "actual_rest_calls", "actual_duration_s", "rest_cost", "graphql_cost",
+    ])
+    def test_optional_field_negative_rejected(self, tmp_yaml, field):
+        yaml = make_cost_profile() + f"    {field}: -1\n"
+        code, out = run(yaml, tmp_yaml)
+        assert code == 1
+        assert field in out
+
+    @pytest.mark.parametrize("field", [
+        "actual_rest_calls", "actual_duration_s", "rest_cost", "graphql_cost",
+    ])
+    def test_optional_field_non_integer_rejected(self, tmp_yaml, field):
+        yaml = make_cost_profile() + f"    {field}: bad\n"
+        code, out = run(yaml, tmp_yaml)
+        assert code == 1
+        assert field in out
+
+    @pytest.mark.parametrize("field", [
+        "actual_rest_calls", "actual_duration_s", "rest_cost", "graphql_cost",
+    ])
+    def test_optional_field_zero_accepted(self, tmp_yaml, field):
+        yaml = make_cost_profile() + f"    {field}: 0\n"
+        code, _ = run(yaml, tmp_yaml)
+        assert code == 0

--- a/tests/test_validate_registered_imports.py
+++ b/tests/test_validate_registered_imports.py
@@ -1,0 +1,268 @@
+"""Tests for scripts/validate-registered-imports.py"""
+
+import json
+import pytest
+from conftest import make_import_entry, run_validator
+
+
+def run(data, tmp_json):
+    path = tmp_json(data)
+    code, out = run_validator("validate-registered-imports.py", path)
+    return code, out
+
+
+# ── Valid cases ───────────────────────────────────────────────────────────────
+
+class TestValidCases:
+    def test_single_valid_github_entry(self, tmp_json):
+        code, out = run([make_import_entry(
+            source_url="https://github.com/foo/bar",
+            platform="github",
+            target_name="bar",
+        )], tmp_json)
+        assert code == 0
+        assert "1 entry" in out
+
+    def test_single_valid_gitlab_entry(self, tmp_json):
+        code, out = run([make_import_entry()], tmp_json)
+        assert code == 0
+
+    def test_single_valid_bitbucket_entry(self, tmp_json):
+        code, out = run([make_import_entry(
+            source_url="https://bitbucket.org/foo/bar",
+            platform="bitbucket",
+        )], tmp_json)
+        assert code == 0
+
+    def test_single_valid_gitea_entry(self, tmp_json):
+        # gitea is self-hosted — any host is valid
+        code, out = run([make_import_entry(
+            source_url="https://gitea.example.com/foo/bar",
+            platform="gitea",
+        )], tmp_json)
+        assert code == 0
+
+    def test_multiple_valid_entries(self, tmp_json):
+        entries = [
+            make_import_entry(target_name="repo-a", source_url="https://gitlab.com/foo/a"),
+            make_import_entry(target_name="repo-b", source_url="https://gitlab.com/foo/b"),
+            make_import_entry(target_name="repo-c", source_url="https://gitlab.com/foo/c"),
+        ]
+        code, out = run(entries, tmp_json)
+        assert code == 0
+        assert "3 entry" in out
+
+    def test_empty_file(self, tmp_path):
+        p = tmp_path / "empty.json"
+        p.write_text("")
+        code, out = run_validator("validate-registered-imports.py", str(p))
+        assert code == 0
+        assert "empty" in out.lower()
+
+    def test_empty_array(self, tmp_json):
+        code, out = run([], tmp_json)
+        assert code == 0
+
+    def test_iso8601_with_offset(self, tmp_json):
+        code, _ = run([make_import_entry(added="2026-01-01T12:00:00+05:30")], tmp_json)
+        assert code == 0
+
+    def test_iso8601_with_fractional_seconds(self, tmp_json):
+        code, _ = run([make_import_entry(added="2026-01-01T12:00:00.123Z")], tmp_json)
+        assert code == 0
+
+    def test_target_name_with_dots_and_hyphens(self, tmp_json):
+        code, _ = run([make_import_entry(target_name="my.repo-name_v2")], tmp_json)
+        assert code == 0
+
+
+# ── Missing required fields ───────────────────────────────────────────────────
+
+class TestMissingFields:
+    @pytest.mark.parametrize("field", ["source_url", "target_name", "platform", "added"])
+    def test_missing_required_field(self, tmp_json, field):
+        entry = make_import_entry()
+        del entry[field]
+        code, out = run([entry], tmp_json)
+        assert code == 1
+        assert field in out
+
+    def test_empty_source_url(self, tmp_json):
+        code, out = run([make_import_entry(source_url="")], tmp_json)
+        assert code == 1
+        assert "source_url" in out
+
+    def test_empty_target_name(self, tmp_json):
+        code, out = run([make_import_entry(target_name="")], tmp_json)
+        assert code == 1
+        assert "target_name" in out
+
+
+# ── URL validation ────────────────────────────────────────────────────────────
+
+class TestUrlValidation:
+    def test_http_not_https(self, tmp_json):
+        code, out = run([make_import_entry(source_url="http://gitlab.com/foo/bar")], tmp_json)
+        assert code == 1
+        assert "https" in out
+
+    def test_ssh_url_rejected(self, tmp_json):
+        code, out = run([make_import_entry(source_url="git@gitlab.com:foo/bar.git")], tmp_json)
+        assert code == 1
+
+    def test_platform_host_mismatch_github_on_gitlab(self, tmp_json):
+        code, out = run([make_import_entry(
+            source_url="https://github.com/foo/bar",
+            platform="gitlab",
+        )], tmp_json)
+        assert code == 1
+        assert "gitlab.com" in out
+
+    def test_platform_host_mismatch_gitlab_on_bitbucket(self, tmp_json):
+        code, out = run([make_import_entry(
+            source_url="https://gitlab.com/foo/bar",
+            platform="bitbucket",
+        )], tmp_json)
+        assert code == 1
+
+    def test_gitea_any_host_accepted(self, tmp_json):
+        # gitea is self-hosted — no host restriction
+        code, _ = run([make_import_entry(
+            source_url="https://my-gitea.internal/foo/bar",
+            platform="gitea",
+        )], tmp_json)
+        assert code == 0
+
+
+# ── Platform validation ───────────────────────────────────────────────────────
+
+class TestPlatformValidation:
+    def test_unknown_platform(self, tmp_json):
+        code, out = run([make_import_entry(platform="sourcehut")], tmp_json)
+        assert code == 1
+        assert "platform" in out
+
+    def test_empty_platform(self, tmp_json):
+        code, out = run([make_import_entry(platform="")], tmp_json)
+        assert code == 1
+
+    @pytest.mark.parametrize("platform", ["github", "gitlab", "bitbucket", "gitea"])
+    def test_all_valid_platforms(self, tmp_json, platform):
+        hosts = {
+            "github": "https://github.com/foo/bar",
+            "gitlab": "https://gitlab.com/foo/bar",
+            "bitbucket": "https://bitbucket.org/foo/bar",
+            "gitea": "https://gitea.example.com/foo/bar",
+        }
+        code, _ = run([make_import_entry(
+            source_url=hosts[platform], platform=platform
+        )], tmp_json)
+        assert code == 0
+
+
+# ── Target name validation ────────────────────────────────────────────────────
+
+class TestTargetNameValidation:
+    def test_slash_in_name(self, tmp_json):
+        code, out = run([make_import_entry(target_name="org/repo")], tmp_json)
+        assert code == 1
+
+    def test_space_in_name(self, tmp_json):
+        code, out = run([make_import_entry(target_name="my repo")], tmp_json)
+        assert code == 1
+
+    def test_name_too_long(self, tmp_json):
+        code, out = run([make_import_entry(target_name="a" * 101)], tmp_json)
+        assert code == 1
+
+    def test_name_exactly_100_chars(self, tmp_json):
+        code, _ = run([make_import_entry(target_name="a" * 100)], tmp_json)
+        assert code == 0
+
+
+# ── Timestamp validation ──────────────────────────────────────────────────────
+
+class TestTimestampValidation:
+    def test_invalid_timestamp_plain_date(self, tmp_json):
+        code, out = run([make_import_entry(added="2026-01-01")], tmp_json)
+        assert code == 1
+        assert "ISO 8601" in out
+
+    def test_invalid_timestamp_no_timezone(self, tmp_json):
+        code, out = run([make_import_entry(added="2026-01-01T00:00:00")], tmp_json)
+        assert code == 1
+
+    def test_invalid_timestamp_freeform(self, tmp_json):
+        code, out = run([make_import_entry(added="January 1 2026")], tmp_json)
+        assert code == 1
+
+
+# ── Duplicate detection ───────────────────────────────────────────────────────
+
+class TestDuplicateDetection:
+    def test_duplicate_target_name(self, tmp_json):
+        entries = [
+            make_import_entry(target_name="same", source_url="https://gitlab.com/foo/a"),
+            make_import_entry(target_name="same", source_url="https://gitlab.com/foo/b"),
+        ]
+        code, out = run(entries, tmp_json)
+        assert code == 1
+        assert "duplicate target_name" in out
+
+    def test_duplicate_source_url(self, tmp_json):
+        entries = [
+            make_import_entry(target_name="repo-a", source_url="https://gitlab.com/foo/bar"),
+            make_import_entry(target_name="repo-b", source_url="https://gitlab.com/foo/bar"),
+        ]
+        code, out = run(entries, tmp_json)
+        assert code == 1
+        assert "duplicate source_url" in out
+
+    def test_no_false_positive_similar_names(self, tmp_json):
+        entries = [
+            make_import_entry(target_name="repo", source_url="https://gitlab.com/foo/a"),
+            make_import_entry(target_name="repo-fork", source_url="https://gitlab.com/foo/b"),
+        ]
+        code, _ = run(entries, tmp_json)
+        assert code == 0
+
+
+# ── JSON structure ────────────────────────────────────────────────────────────
+
+class TestJsonStructure:
+    def test_invalid_json(self, tmp_path):
+        p = tmp_path / "bad.json"
+        p.write_text('[{"source_url": "https://gitlab.com/foo/bar"')
+        code, out = run_validator("validate-registered-imports.py", str(p))
+        assert code == 1
+        assert "not valid JSON" in out
+
+    def test_object_instead_of_array(self, tmp_json):
+        path = tmp_json({"source_url": "https://gitlab.com/foo/bar"})
+        code, out = run_validator("validate-registered-imports.py", path)
+        assert code == 1
+        assert "array" in out
+
+    def test_array_with_non_object_entry(self, tmp_json):
+        path = tmp_json(["not-an-object"])
+        code, out = run_validator("validate-registered-imports.py", path)
+        assert code == 1
+
+    def test_missing_file(self, tmp_path):
+        code, out = run_validator(
+            "validate-registered-imports.py",
+            str(tmp_path / "nonexistent.json")
+        )
+        assert code == 1
+        assert "not found" in out
+
+    def test_multiple_errors_reported(self, tmp_json):
+        # Both entries are missing required fields — the validator accumulates
+        # errors across entries even when it skips deeper checks per entry.
+        entry_a = make_import_entry()
+        del entry_a["platform"]
+        entry_b = make_import_entry(target_name="repo-b", source_url="https://gitlab.com/foo/b")
+        del entry_b["added"]
+        code, out = run_validator("validate-registered-imports.py", tmp_json([entry_a, entry_b]))
+        assert code == 1
+        assert out.count("✗") >= 2

--- a/tests/test_validate_template_config.py
+++ b/tests/test_validate_template_config.py
@@ -1,0 +1,400 @@
+"""Tests for scripts/validate-template-config.py"""
+
+import pytest
+from conftest import make_manifest_profile, make_consumer, run_validator
+
+
+def run(manifest_yaml, consumers_yaml, tmp_yaml):
+    m_path = tmp_yaml(manifest_yaml, "manifest.yml")
+    c_path = tmp_yaml(consumers_yaml, "consumers.yml")
+    code, out = run_validator("validate-template-config.py", m_path, c_path)
+    return code, out
+
+
+def valid_manifest(extra_profiles=""):
+    """Minimal valid manifest that always includes the required 'full' profile."""
+    return (
+        "profiles:\n"
+        "  full:\n"
+        "    description: All files\n"
+        "    include:\n"
+        "      - .github/workflows/*.yml\n"
+        + extra_profiles
+    )
+
+
+def valid_consumers(extra=""):
+    return "consumers:\n  - name: my-repo\n    profile: full\n" + extra
+
+
+# ── Valid cases ───────────────────────────────────────────────────────────────
+
+class TestValidCases:
+    def test_minimal_valid_pair(self, tmp_yaml):
+        code, out = run(valid_manifest(), valid_consumers(), tmp_yaml)
+        assert code == 0
+        assert "1 profile(s) valid" in out
+        assert "1 consumer(s) valid" in out
+
+    def test_multiple_profiles(self, tmp_yaml):
+        manifest = (
+            "profiles:\n"
+            "  full:\n"
+            "    description: All files\n"
+            "    include:\n"
+            "      - .github/workflows/*.yml\n"
+            "  minimal:\n"
+            "    description: Core only\n"
+            "    include:\n"
+            "      - .github/workflows/core.yml\n"
+        )
+        code, out = run(manifest, valid_consumers(), tmp_yaml)
+        assert code == 0
+        assert "2 profile(s) valid" in out
+
+    def test_multiple_consumers(self, tmp_yaml):
+        consumers = (
+            "consumers:\n"
+            "  - name: repo-a\n"
+            "    profile: full\n"
+            "  - name: repo-b\n"
+            "    profile: full\n"
+        )
+        code, out = run(valid_manifest(), consumers, tmp_yaml)
+        assert code == 0
+        assert "2 consumer(s) valid" in out
+
+    def test_consumer_without_profile_defaults_to_full(self, tmp_yaml):
+        consumers = "consumers:\n  - name: my-repo\n"
+        code, _ = run(valid_manifest(), consumers, tmp_yaml)
+        assert code == 0
+
+    def test_consumer_with_exclude_paths(self, tmp_yaml):
+        consumers = (
+            "consumers:\n"
+            "  - name: my-repo\n"
+            "    profile: full\n"
+            "    exclude_paths:\n"
+            "      - .github/workflows/heavy.yml\n"
+        )
+        code, _ = run(valid_manifest(), consumers, tmp_yaml)
+        assert code == 0
+
+    def test_consumer_with_include_paths(self, tmp_yaml):
+        consumers = (
+            "consumers:\n"
+            "  - name: my-repo\n"
+            "    profile: full\n"
+            "    include_paths:\n"
+            "      - scripts/deploy.sh\n"
+        )
+        code, _ = run(valid_manifest(), consumers, tmp_yaml)
+        assert code == 0
+
+    def test_consumer_with_boolean_fields(self, tmp_yaml):
+        consumers = (
+            "consumers:\n"
+            "  - name: my-repo\n"
+            "    profile: full\n"
+            "    force: true\n"
+            "    skip_osp_setup: false\n"
+            "    disabled: false\n"
+        )
+        code, _ = run(valid_manifest(), consumers, tmp_yaml)
+        assert code == 0
+
+    def test_manifest_with_exclude_list(self, tmp_yaml):
+        manifest = (
+            "profiles:\n"
+            "  full:\n"
+            "    description: All files\n"
+            "    include:\n"
+            "      - .github/workflows/*.yml\n"
+            "    exclude:\n"
+            "      - .github/workflows/skip-me.yml\n"
+        )
+        code, _ = run(manifest, valid_consumers(), tmp_yaml)
+        assert code == 0
+
+    def test_consumer_name_with_dots(self, tmp_yaml):
+        consumers = "consumers:\n  - name: my.repo.name\n    profile: full\n"
+        code, _ = run(valid_manifest(), consumers, tmp_yaml)
+        assert code == 0
+
+    def test_consumer_name_with_hyphens_and_underscores(self, tmp_yaml):
+        consumers = "consumers:\n  - name: my-repo_v2\n    profile: full\n"
+        code, _ = run(valid_manifest(), consumers, tmp_yaml)
+        assert code == 0
+
+    def test_empty_consumers_list(self, tmp_yaml):
+        consumers = "consumers:\n"
+        code, out = run(valid_manifest(), consumers, tmp_yaml)
+        assert code == 0
+        assert "0 consumer(s) valid" in out
+
+    def test_boolean_yaml_variants(self, tmp_yaml):
+        for val in ("true", "false", "yes", "no"):
+            consumers = f"consumers:\n  - name: my-repo\n    profile: full\n    force: {val}\n"
+            code, _ = run(valid_manifest(), consumers, tmp_yaml)
+            assert code == 0, f"Expected success for force: {val}"
+
+
+# ── Manifest: missing 'full' profile ─────────────────────────────────────────
+
+class TestManifestFullProfile:
+    def test_missing_full_profile(self, tmp_yaml):
+        manifest = (
+            "profiles:\n"
+            "  minimal:\n"
+            "    description: Core only\n"
+            "    include:\n"
+            "      - .github/workflows/core.yml\n"
+        )
+        code, out = run(manifest, valid_consumers(), tmp_yaml)
+        assert code == 1
+        assert "'full' profile is missing" in out
+
+    def test_full_profile_present_passes(self, tmp_yaml):
+        code, _ = run(valid_manifest(), valid_consumers(), tmp_yaml)
+        assert code == 0
+
+
+# ── Manifest: profile validation ─────────────────────────────────────────────
+
+class TestManifestProfileValidation:
+    def test_missing_description(self, tmp_yaml):
+        manifest = (
+            "profiles:\n"
+            "  full:\n"
+            "    include:\n"
+            "      - .github/workflows/*.yml\n"
+        )
+        code, out = run(manifest, valid_consumers(), tmp_yaml)
+        assert code == 1
+        assert "description" in out
+
+    def test_empty_description(self, tmp_yaml):
+        manifest = (
+            "profiles:\n"
+            "  full:\n"
+            "    description:\n"
+            "    include:\n"
+            "      - .github/workflows/*.yml\n"
+        )
+        code, out = run(manifest, valid_consumers(), tmp_yaml)
+        assert code == 1
+        assert "description" in out
+
+    def test_duplicate_profile_names(self, tmp_yaml):
+        # The minimal YAML parser uses dict keys, so duplicates overwrite —
+        # the validator won't see them as duplicates. This tests the actual
+        # parser behaviour: second definition silently wins.
+        manifest = (
+            "profiles:\n"
+            "  full:\n"
+            "    description: First\n"
+            "    include:\n"
+            "      - .github/workflows/*.yml\n"
+            "  full:\n"
+            "    description: Second\n"
+            "    include:\n"
+            "      - .github/workflows/*.yml\n"
+        )
+        # Both definitions have valid content — validator sees one 'full' profile
+        code, _ = run(manifest, valid_consumers(), tmp_yaml)
+        assert code == 0
+
+    def test_no_profiles_section(self, tmp_yaml):
+        # When no `profiles:` key exists, parse_manifest returns {} and the
+        # `if profiles and ...` guard skips the 'full' check — validator exits 0
+        # with "0 profile(s) valid". This is a known limitation of the minimal parser.
+        manifest = "other_key:\n  foo: bar\n"
+        code, out = run(manifest, valid_consumers(), tmp_yaml)
+        assert code == 0
+        assert "0 profile(s) valid" in out
+
+    def test_manifest_not_found(self, tmp_path, tmp_yaml):
+        c_path = tmp_yaml(valid_consumers(), "consumers.yml")
+        code, out = run_validator(
+            "validate-template-config.py",
+            str(tmp_path / "nonexistent.yml"),
+            c_path,
+        )
+        assert code == 1
+        assert "not found" in out
+
+
+# ── Consumer: required fields ─────────────────────────────────────────────────
+
+class TestConsumerRequiredFields:
+    def test_missing_name(self, tmp_yaml):
+        # The parser only starts a consumer entry on `  - name: ...` or `  - `.
+        # `  - profile: full` matches neither pattern, so the entry is silently
+        # skipped — 0 consumers parsed, exit 0. This is a known parser limitation.
+        consumers = "consumers:\n  - profile: full\n"
+        code, out = run(valid_manifest(), consumers, tmp_yaml)
+        assert code == 0
+        assert "0 consumer(s) valid" in out
+
+    def test_empty_name(self, tmp_yaml):
+        consumers = "consumers:\n  - name: \"\"\n    profile: full\n"
+        code, out = run(valid_manifest(), consumers, tmp_yaml)
+        assert code == 1
+        assert "name" in out
+
+
+# ── Consumer: name format ─────────────────────────────────────────────────────
+
+class TestConsumerNameFormat:
+    def test_name_with_slash(self, tmp_yaml):
+        consumers = "consumers:\n  - name: org/repo\n    profile: full\n"
+        code, out = run(valid_manifest(), consumers, tmp_yaml)
+        assert code == 1
+        assert "valid GitHub repo name" in out
+
+    def test_name_with_space(self, tmp_yaml):
+        consumers = "consumers:\n  - name: my repo\n    profile: full\n"
+        code, out = run(valid_manifest(), consumers, tmp_yaml)
+        assert code == 1
+
+    def test_name_too_long(self, tmp_yaml):
+        long_name = "a" * 101
+        consumers = f"consumers:\n  - name: {long_name}\n    profile: full\n"
+        code, out = run(valid_manifest(), consumers, tmp_yaml)
+        assert code == 1
+
+    def test_name_exactly_100_chars(self, tmp_yaml):
+        name = "a" * 100
+        consumers = f"consumers:\n  - name: {name}\n    profile: full\n"
+        code, _ = run(valid_manifest(), consumers, tmp_yaml)
+        assert code == 0
+
+    def test_duplicate_consumer_names(self, tmp_yaml):
+        consumers = (
+            "consumers:\n"
+            "  - name: same-repo\n"
+            "    profile: full\n"
+            "  - name: same-repo\n"
+            "    profile: full\n"
+        )
+        code, out = run(valid_manifest(), consumers, tmp_yaml)
+        assert code == 1
+        assert "duplicate consumer name" in out
+
+
+# ── Consumer: profile reference ───────────────────────────────────────────────
+
+class TestConsumerProfileReference:
+    def test_unknown_profile(self, tmp_yaml):
+        consumers = "consumers:\n  - name: my-repo\n    profile: nonexistent\n"
+        code, out = run(valid_manifest(), consumers, tmp_yaml)
+        assert code == 1
+        assert "nonexistent" in out
+        assert "not defined" in out
+
+    def test_known_non_full_profile(self, tmp_yaml):
+        manifest = (
+            "profiles:\n"
+            "  full:\n"
+            "    description: All files\n"
+            "    include:\n"
+            "      - .github/workflows/*.yml\n"
+            "  minimal:\n"
+            "    description: Core only\n"
+            "    include:\n"
+            "      - .github/workflows/core.yml\n"
+        )
+        consumers = "consumers:\n  - name: my-repo\n    profile: minimal\n"
+        code, _ = run(manifest, consumers, tmp_yaml)
+        assert code == 0
+
+    def test_absent_profile_defaults_to_full(self, tmp_yaml):
+        consumers = "consumers:\n  - name: my-repo\n"
+        code, _ = run(valid_manifest(), consumers, tmp_yaml)
+        assert code == 0
+
+
+# ── Consumer: boolean fields ──────────────────────────────────────────────────
+
+class TestConsumerBooleanFields:
+    @pytest.mark.parametrize("field", ["force", "skip_osp_setup", "disabled"])
+    def test_invalid_boolean(self, tmp_yaml, field):
+        consumers = (
+            f"consumers:\n  - name: my-repo\n    profile: full\n    {field}: maybe\n"
+        )
+        code, out = run(valid_manifest(), consumers, tmp_yaml)
+        assert code == 1
+        assert field in out
+
+    @pytest.mark.parametrize("field", ["force", "skip_osp_setup", "disabled"])
+    @pytest.mark.parametrize("val", ["true", "false", "yes", "no", "on", "off"])
+    def test_valid_boolean_variants(self, tmp_yaml, field, val):
+        consumers = (
+            f"consumers:\n  - name: my-repo\n    profile: full\n    {field}: {val}\n"
+        )
+        code, _ = run(valid_manifest(), consumers, tmp_yaml)
+        assert code == 0
+
+
+# ── Consumer: path list fields ────────────────────────────────────────────────
+
+class TestConsumerPathFields:
+    def test_exclude_paths_valid(self, tmp_yaml):
+        consumers = (
+            "consumers:\n"
+            "  - name: my-repo\n"
+            "    profile: full\n"
+            "    exclude_paths:\n"
+            "      - .github/workflows/skip.yml\n"
+            "      - scripts/heavy.sh\n"
+        )
+        code, _ = run(valid_manifest(), consumers, tmp_yaml)
+        assert code == 0
+
+    def test_include_paths_valid(self, tmp_yaml):
+        consumers = (
+            "consumers:\n"
+            "  - name: my-repo\n"
+            "    profile: full\n"
+            "    include_paths:\n"
+            "      - scripts/deploy.sh\n"
+        )
+        code, _ = run(valid_manifest(), consumers, tmp_yaml)
+        assert code == 0
+
+    def test_inline_list_syntax(self, tmp_yaml):
+        consumers = (
+            "consumers:\n"
+            "  - name: my-repo\n"
+            "    profile: full\n"
+            "    exclude_paths: [scripts/a.sh, scripts/b.sh]\n"
+        )
+        code, _ = run(valid_manifest(), consumers, tmp_yaml)
+        assert code == 0
+
+
+# ── File-level errors ─────────────────────────────────────────────────────────
+
+class TestFileLevelErrors:
+    def test_consumers_not_found(self, tmp_path, tmp_yaml):
+        m_path = tmp_yaml(valid_manifest(), "manifest.yml")
+        code, out = run_validator(
+            "validate-template-config.py",
+            m_path,
+            str(tmp_path / "nonexistent.yml"),
+        )
+        assert code == 1
+        assert "not found" in out
+
+    def test_multiple_errors_accumulated(self, tmp_yaml):
+        # Manifest missing description + consumer referencing unknown profile
+        manifest = (
+            "profiles:\n"
+            "  full:\n"
+            "    include:\n"          # missing description
+            "      - .github/workflows/*.yml\n"
+        )
+        consumers = "consumers:\n  - name: my-repo\n    profile: ghost\n"
+        code, out = run(manifest, consumers, tmp_yaml)
+        assert code == 1
+        assert out.count("✗") >= 2

--- a/tests/test_validate_workflow_guards.py
+++ b/tests/test_validate_workflow_guards.py
@@ -1,0 +1,418 @@
+"""Tests for scripts/validate-workflow-guards.py
+
+The validator derives REPO_ROOT from __file__, so tests build a minimal fake
+repo tree under tmp_path and run the script via a shim that overrides REPO_ROOT
+before executing the validator logic.
+"""
+
+import os
+import sys
+import subprocess
+import textwrap
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SCRIPT_PATH = os.path.join(REPO_ROOT, "scripts", "validate-workflow-guards.py")
+
+
+# ── Fake repo builder ─────────────────────────────────────────────────────────
+
+class FakeRepo:
+    """Builds a minimal fake repo tree under a tmp_path directory."""
+
+    def __init__(self, root):
+        self.root = root
+        self.workflows_dir = root / ".github" / "workflows"
+        self.scripts_dir = root / "scripts"
+        self.config_dir = root / "config"
+        self.workflows_dir.mkdir(parents=True, exist_ok=True)
+        self.scripts_dir.mkdir(parents=True, exist_ok=True)
+        self.config_dir.mkdir(parents=True, exist_ok=True)
+
+    def add_workflow(self, name, content):
+        (self.workflows_dir / name).write_text(textwrap.dedent(content))
+
+    def add_script(self, name, content="#!/bin/bash\necho ok\n"):
+        (self.scripts_dir / name).write_text(content)
+
+    def set_gitlab_ci(self, content):
+        (self.root / ".gitlab-ci.yml").write_text(textwrap.dedent(content))
+
+    def set_sync_manifest(self, content):
+        (self.config_dir / "workflow-sync.yml").write_text(textwrap.dedent(content))
+
+    def run(self):
+        """Run the validator against this fake repo; return (exit_code, output)."""
+        shim = textwrap.dedent(f"""\
+            import sys, os
+            # Override REPO_ROOT before the validator computes its paths
+            import importlib.util, types
+
+            fake_root = {str(self.root)!r}
+            script_path = {SCRIPT_PATH!r}
+
+            with open(script_path) as f:
+                src = f.read()
+
+            # Patch the REPO_ROOT line
+            src = src.replace(
+                "REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))",
+                f"REPO_ROOT = {str(self.root)!r}",
+            )
+
+            exec(compile(src, script_path, "exec"), {{"__file__": script_path}})
+        """)
+        result = subprocess.run(
+            [sys.executable, "-c", shim],
+            capture_output=True,
+            text=True,
+        )
+        return result.returncode, result.stdout + result.stderr
+
+
+@pytest.fixture
+def repo(tmp_path):
+    return FakeRepo(tmp_path)
+
+
+# ── Minimal valid repo (no workflows, no gitlab-ci, no sync manifest) ─────────
+
+class TestMinimalRepo:
+    def test_empty_repo_passes(self, repo):
+        # No workflows, no .gitlab-ci.yml, no sync manifest — all checks skip
+        code, out = repo.run()
+        assert code == 0
+        assert "all checks passed" in out
+
+    def test_workflow_without_rate_limit_input_passes(self, repo):
+        repo.add_workflow("ci.yml", """\
+            on: [push]
+            jobs:
+              build:
+                runs-on: ubuntu-latest
+                steps:
+                  - run: echo hi
+        """)
+        code, _ = repo.run()
+        assert code == 0
+
+    def test_no_gitlab_ci_warns_not_errors(self, repo):
+        code, out = repo.run()
+        assert code == 0
+        # Warning may or may not appear depending on whether .gitlab-ci.yml exists
+
+
+# ── Check 1: rate_limit_rerun guard ──────────────────────────────────────────
+
+class TestRateLimitRerunGuard:
+    def _workflow_with_input(self, guard_line=""):
+        return textwrap.dedent(f"""\
+            on:
+              workflow_dispatch:
+                inputs:
+                  rate_limit_rerun:
+                    description: Skip if already retried
+                    type: boolean
+            jobs:
+              run:
+                runs-on: ubuntu-latest
+                {guard_line}
+                steps:
+                  - run: echo hi
+        """)
+
+    def test_input_declared_with_guard_passes(self, repo):
+        content = self._workflow_with_input(
+            "if: inputs.rate_limit_rerun != 'true'"
+        )
+        repo.add_workflow("sync.yml", content)
+        code, _ = repo.run()
+        assert code == 0
+
+    def test_input_declared_without_guard_fails(self, repo):
+        content = self._workflow_with_input()
+        repo.add_workflow("sync.yml", content)
+        code, out = repo.run()
+        assert code == 1
+        assert "[guard]" in out
+        assert "sync.yml" in out
+
+    def test_guard_with_double_quotes_accepted(self, repo):
+        content = self._workflow_with_input(
+            'if: inputs.rate_limit_rerun != "true"'
+        )
+        repo.add_workflow("sync.yml", content)
+        code, _ = repo.run()
+        assert code == 0
+
+    def test_guard_in_compound_condition_accepted(self, repo):
+        content = self._workflow_with_input(
+            "if: github.event_name == 'push' && inputs.rate_limit_rerun != 'true'"
+        )
+        repo.add_workflow("sync.yml", content)
+        code, _ = repo.run()
+        assert code == 0
+
+    def test_rate_limit_rerun_in_step_name_not_flagged(self, repo):
+        # The input must be at 6+ spaces indent to be detected
+        content = textwrap.dedent("""\
+            on: [push]
+            jobs:
+              run:
+                runs-on: ubuntu-latest
+                steps:
+                  - name: rate_limit_rerun check
+                    run: echo hi
+        """)
+        repo.add_workflow("ci.yml", content)
+        code, _ = repo.run()
+        assert code == 0
+
+    def test_multiple_workflows_both_missing_guard(self, repo):
+        wf = self._workflow_with_input()
+        repo.add_workflow("sync-a.yml", wf)
+        repo.add_workflow("sync-b.yml", wf)
+        code, out = repo.run()
+        assert code == 1
+        assert out.count("[guard]") == 2
+
+    def test_one_guarded_one_not(self, repo):
+        repo.add_workflow("good.yml", self._workflow_with_input(
+            "if: inputs.rate_limit_rerun != 'true'"
+        ))
+        repo.add_workflow("bad.yml", self._workflow_with_input())
+        code, out = repo.run()
+        assert code == 1
+        assert "bad.yml" in out
+        assert "good.yml" not in out
+
+
+# ── Check 2: .gitlab-ci.yml script existence ─────────────────────────────────
+
+class TestGitlabCiScriptExistence:
+    def test_referenced_script_exists(self, repo):
+        repo.add_script("sync.sh")
+        repo.set_gitlab_ci("""\
+            sync-job:
+              script:
+                - bash scripts/sync.sh
+        """)
+        code, _ = repo.run()
+        assert code == 0
+
+    def test_referenced_script_missing(self, repo):
+        repo.set_gitlab_ci("""\
+            sync-job:
+              script:
+                - bash scripts/missing.sh
+        """)
+        code, out = repo.run()
+        assert code == 1
+        assert "[gitlab-ci]" in out
+        assert "missing.sh" in out
+
+    def test_multiple_scripts_one_missing(self, repo):
+        repo.add_script("exists.sh")
+        repo.set_gitlab_ci("""\
+            job-a:
+              script:
+                - bash scripts/exists.sh
+            job-b:
+              script:
+                - bash scripts/gone.sh
+        """)
+        code, out = repo.run()
+        assert code == 1
+        assert "gone.sh" in out
+        assert "exists.sh" not in out
+
+    def test_no_bash_scripts_reference_passes(self, repo):
+        repo.set_gitlab_ci("""\
+            job:
+              script:
+                - echo hello
+                - python3 scripts/helper.py
+        """)
+        code, _ = repo.run()
+        assert code == 0
+
+    def test_no_gitlab_ci_skips_check(self, repo):
+        # No .gitlab-ci.yml — check 2 is skipped with a warning
+        code, out = repo.run()
+        assert code == 0
+
+
+# ── Check 3: workflow-sync.yml manifest consistency ──────────────────────────
+
+class TestSyncManifestConsistency:
+    def _base_manifest(self, paired="", github_only="", gitlab_only=""):
+        parts = []
+        if paired:
+            parts.append(f"paired:\n{paired}")
+        if github_only:
+            parts.append(f"github_only:\n{github_only}")
+        if gitlab_only:
+            parts.append(f"gitlab_only:\n{gitlab_only}")
+        return "\n".join(parts) + "\n"
+
+    def test_valid_paired_entry(self, repo):
+        repo.add_workflow("sync.yml", "on: [push]\njobs:\n  run:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n")
+        repo.add_script("sync.sh")
+        repo.set_gitlab_ci("sync-job:\n  script:\n    - bash scripts/sync.sh\n")
+        manifest = (
+            "paired:\n"
+            "  - name: sync\n"
+            "    scripts:\n"
+            "      - sync.sh\n"
+            "    github:\n"
+            "      workflow_file: sync.yml\n"
+            "    gitlab:\n"
+            "      job: sync-job\n"
+        )
+        repo.set_sync_manifest(manifest)
+        code, _ = repo.run()
+        assert code == 0
+
+    def test_paired_missing_github_workflow(self, repo):
+        repo.set_gitlab_ci("sync-job:\n  script:\n    - echo hi\n")
+        manifest = (
+            "paired:\n"
+            "  - name: sync\n"
+            "    github:\n"
+            "      workflow_file: nonexistent.yml\n"
+            "    gitlab:\n"
+            "      job: sync-job\n"
+        )
+        repo.set_sync_manifest(manifest)
+        code, out = repo.run()
+        assert code == 1
+        assert "[sync-manifest]" in out
+        assert "nonexistent.yml" in out
+
+    def test_paired_missing_gitlab_job(self, repo):
+        repo.add_workflow("sync.yml", "on: [push]\njobs:\n  run:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n")
+        repo.set_gitlab_ci("real-job:\n  script:\n    - echo hi\n")
+        manifest = (
+            "paired:\n"
+            "  - name: sync\n"
+            "    github:\n"
+            "      workflow_file: sync.yml\n"
+            "    gitlab:\n"
+            "      job: ghost-job\n"
+        )
+        repo.set_sync_manifest(manifest)
+        code, out = repo.run()
+        assert code == 1
+        assert "ghost-job" in out
+
+    def test_paired_missing_script(self, repo):
+        repo.add_workflow("sync.yml", "on: [push]\njobs:\n  run:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n")
+        repo.set_gitlab_ci("sync-job:\n  script:\n    - echo hi\n")
+        manifest = (
+            "paired:\n"
+            "  - name: sync\n"
+            "    scripts:\n"
+            "      - missing.sh\n"
+            "    github:\n"
+            "      workflow_file: sync.yml\n"
+            "    gitlab:\n"
+            "      job: sync-job\n"
+        )
+        repo.set_sync_manifest(manifest)
+        code, out = repo.run()
+        assert code == 1
+        assert "missing.sh" in out
+
+    def test_github_only_workflow_exists(self, repo):
+        repo.add_workflow("ci.yml", "on: [push]\njobs:\n  run:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n")
+        manifest = "github_only:\n  - workflow_file: ci.yml\n"
+        repo.set_sync_manifest(manifest)
+        code, _ = repo.run()
+        assert code == 0
+
+    def test_github_only_workflow_missing(self, repo):
+        manifest = "github_only:\n  - workflow_file: ghost.yml\n"
+        repo.set_sync_manifest(manifest)
+        code, out = repo.run()
+        assert code == 1
+        assert "ghost.yml" in out
+
+    def test_gitlab_only_job_exists(self, repo):
+        repo.set_gitlab_ci("special-job:\n  script:\n    - echo hi\n")
+        manifest = "gitlab_only:\n  - job: special-job\n"
+        repo.set_sync_manifest(manifest)
+        code, _ = repo.run()
+        assert code == 0
+
+    def test_gitlab_only_job_missing(self, repo):
+        repo.set_gitlab_ci("real-job:\n  script:\n    - echo hi\n")
+        manifest = "gitlab_only:\n  - job: ghost-job\n"
+        repo.set_sync_manifest(manifest)
+        code, out = repo.run()
+        assert code == 1
+        assert "ghost-job" in out
+
+    def test_no_sync_manifest_skips_check(self, repo):
+        # No workflow-sync.yml — check 3 is skipped with a warning
+        code, out = repo.run()
+        assert code == 0
+
+    def test_unlisted_workflow_generates_warning_not_error(self, repo):
+        # A workflow not in the manifest generates a warning, not an error
+        repo.add_workflow("unlisted.yml", "on: [push]\njobs:\n  run:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n")
+        manifest = "github_only:\n  - workflow_file: other.yml\n"
+        # other.yml doesn't exist → error; unlisted.yml → warning
+        # We just verify unlisted.yml warning doesn't cause exit 1 on its own
+        repo.add_workflow("other.yml", "on: [push]\njobs:\n  run:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n")
+        manifest = "github_only:\n  - workflow_file: other.yml\n"
+        repo.set_sync_manifest(manifest)
+        code, out = repo.run()
+        assert code == 0
+        assert "unlisted.yml" in out  # warning about uncovered workflow
+
+
+# ── Combined checks ───────────────────────────────────────────────────────────
+
+class TestCombinedChecks:
+    def test_all_three_checks_fail_accumulate(self, repo):
+        # Check 1: workflow with input but no guard
+        repo.add_workflow("sync.yml", textwrap.dedent("""\
+            on:
+              workflow_dispatch:
+                inputs:
+                  rate_limit_rerun:
+                    type: boolean
+            jobs:
+              run:
+                runs-on: ubuntu-latest
+                steps:
+                  - run: echo hi
+        """))
+        # Check 2: missing script in gitlab-ci
+        repo.set_gitlab_ci("job:\n  script:\n    - bash scripts/gone.sh\n")
+        # Check 3: missing workflow in sync manifest
+        manifest = "github_only:\n  - workflow_file: ghost.yml\n"
+        repo.set_sync_manifest(manifest)
+
+        code, out = repo.run()
+        assert code == 1
+        assert out.count("✗") >= 3
+
+    def test_success_message_on_all_pass(self, repo):
+        repo.add_workflow("ci.yml", "on: [push]\njobs:\n  run:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n")
+        repo.add_script("sync.sh")
+        repo.set_gitlab_ci("sync-job:\n  script:\n    - bash scripts/sync.sh\n")
+        manifest = (
+            "paired:\n"
+            "  - name: sync\n"
+            "    scripts:\n"
+            "      - sync.sh\n"
+            "    github:\n"
+            "      workflow_file: ci.yml\n"
+            "    gitlab:\n"
+            "      job: sync-job\n"
+        )
+        repo.set_sync_manifest(manifest)
+        code, out = repo.run()
+        assert code == 0
+        assert "all checks passed" in out


### PR DESCRIPTION
## Summary

Adds a pytest test suite covering all five Python validator scripts. 213 tests, 0 failures. Also wires a `pytest` CI job into `validate-config.yml` and adds `tests/**` to the path triggers.

## Test file breakdown

| File | Tests | Coverage focus |
|---|---|---|
| `tests/test_validate_registered_imports.py` | 42 | URL/platform/name/timestamp validation, duplicate detection, JSON structure errors |
| `tests/test_validate_cost_profiles.py` | 59 | Integer fields, `scales_with`/`scale_factor` consistency, budget ≥ rest_calls constraint, optional fields |
| `tests/test_validate_template_config.py` | 55 | Manifest profiles, consumer name/profile/boolean/path fields, cross-file profile reference |
| `tests/test_validate_workflow_guards.py` | 27 | All 3 checks (rate-limit rerun guard, GitLab CI script refs, sync manifest consistency) via fake repo tree |
| `tests/test_generate_gitlab_stubs.py` | 30 | Script drift, cadence drift, `--check` flag, missing jobs, multi-job summary counts |

Shared fixtures and data builders live in `tests/conftest.py`.

## Design decisions

**Subprocess isolation** — validators are run as subprocesses rather than imported directly. This avoids `sys.argv`/`sys.exit` pollution between tests and matches how the scripts are actually invoked in CI. Total suite runtime is ~4.5s.

**REPO_ROOT shim** — `validate-workflow-guards.py` and `generate-gitlab-stubs.py` derive their working paths from `__file__` with no env-var override hook. Tests inject a fake repo root via a one-line source patch executed in a subprocess shim. If those scripts ever gain a `VALIDATOR_ROOT` env var, the shim can be dropped.

**Parser limitations documented, not fixed** — two edge cases in `validate-template-config.py` are tested as-is rather than patched:
- A consumer entry whose first field is not `name` is silently skipped by the parser (e.g. `  - profile: full` with no `name:` line).
- The `full`-profile-required check is skipped when the manifest has no `profiles:` key at all (the guard is `if profiles and "full" not in profiles`).

Both tests include comments explaining the behaviour.

## CI change

Added a `pytest` job to `validate-config.yml` and `tests/**` to path triggers on push/PR.
