### PR TITLE
perf: replace REST polling loops with GraphQL and add ETag caching

### DIFF
--- a/.github/workflows/add-mirror-repo.yml
+++ b/.github/workflows/add-mirror-repo.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Mirror repo into OSP and register for ongoing sync
         env:

--- a/.github/workflows/create-readmes.yml
+++ b/.github/workflows/create-readmes.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Create missing READMEs
         env:

--- a/.github/workflows/import-repo.yml
+++ b/.github/workflows/import-repo.yml
@@ -44,7 +44,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Import repository
         env:

--- a/.github/workflows/mirror-artifacts.yml
+++ b/.github/workflows/mirror-artifacts.yml
@@ -41,7 +41,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/mirror-osp-to-gitlab.yml
+++ b/.github/workflows/mirror-osp-to-gitlab.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Mirror OSP repos to GitLab
         env:

--- a/.github/workflows/mirror-to-osp.yml
+++ b/.github/workflows/mirror-to-osp.yml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Mirror matched repos from upstream into OSP
         env:

--- a/.github/workflows/notify-poller.yml
+++ b/.github/workflows/notify-poller.yml
@@ -30,23 +30,70 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Restore ETag cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/notify-poller
+          key: notify-poller-etag-v1
+          restore-keys: notify-poller-etag-v1
+
       - name: Check for unread CI failure notifications
         id: check
         env:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
         run: |
+          # ETag caching: a 304 Not Modified response costs 0 against the
+          # rate limit. We persist the ETag from the previous poll in the
+          # Actions cache and send If-None-Match on subsequent requests.
+          # On 304, notifications haven't changed — skip the resolver trigger.
+          CACHE_DIR="${HOME}/.cache/notify-poller"
+          ETAG_FILE="${CACHE_DIR}/notifications.etag"
+          mkdir -p "$CACHE_DIR"
+
+          ETAG_HEADER=""
+          if [[ -f "$ETAG_FILE" ]]; then
+            stored_etag=$(cat "$ETAG_FILE")
+            [[ -n "$stored_etag" ]] && ETAG_HEADER="-H \"If-None-Match: ${stored_etag}\""
+          fi
+
+          # Capture both headers and body; -D - writes headers to stdout
+          response=$(eval curl -s -w "\n%{http_code}" \
+            -H "Authorization: token ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -D "${CACHE_DIR}/response-headers.txt" \
+            ${ETAG_HEADER} \
+            "https://api.github.com/notifications?all=false&per_page=50") || response=""
+
+          http_code=$(printf '%s' "$response" | tail -1)
+          body=$(printf '%s' "$response" | sed '$d')
+
+          # 304 Not Modified — no new notifications since last poll, 0 rate cost
+          if [[ "$http_code" == "304" ]]; then
+            echo "304 Not Modified — notifications unchanged since last poll (0 rate cost)"
+            printf 'ci_failure_count=0\n' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Persist the new ETag for the next poll
+          new_etag=$(grep -i '^etag:' "${CACHE_DIR}/response-headers.txt" 2>/dev/null \
+            | tr -d '\r' | awk '{print $2}')
+          [[ -n "$new_etag" ]] && printf '%s' "$new_etag" > "$ETAG_FILE"
+
           # grep -c outputs a bare integer with a trailing newline.
           # Trim it before writing to GITHUB_OUTPUT — a trailing newline
           # causes "Invalid format" and fails the step.
-          raw=$(curl -sf \
-            -H "Authorization: token ${GH_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/notifications?all=false&per_page=50" \
-            | grep -c '"ci_activity"') || raw=0
+          raw=$(printf '%s' "$body" | grep -c '"ci_activity"') || raw=0
           count=$(printf '%s' "$raw" | tr -d '[:space:]')
 
           printf 'ci_failure_count=%s\n' "${count}" >> "$GITHUB_OUTPUT"
           echo "Unread CI activity notifications: ${count}"
+
+      - name: Save ETag cache
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/notify-poller
+          key: notify-poller-etag-v1
 
       - name: Trigger resolver if failures found
         if: ${{ steps.check.outputs.ci_failure_count != '0' }}

--- a/.github/workflows/rebase-lts.yml
+++ b/.github/workflows/rebase-lts.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout fork-sync-all
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Rebuild lts on Interested-Deving-1896/penguins-eggs
         env:

--- a/.github/workflows/reconcile-org-refs.yml
+++ b/.github/workflows/reconcile-org-refs.yml
@@ -42,7 +42,7 @@ jobs:
 
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Rewrite org references in OSP + OOC mirrors
         env:

--- a/.github/workflows/resolve-failures.yml
+++ b/.github/workflows/resolve-failures.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Scan and resolve failures
         env:

--- a/.github/workflows/setup-osp-mirrors.yml
+++ b/.github/workflows/setup-osp-mirrors.yml
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup OSP mirror workflows
         env:

--- a/.github/workflows/sync-eggs-docs-to-book.yml
+++ b/.github/workflows/sync-eggs-docs-to-book.yml
@@ -29,14 +29,14 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout penguins-eggs-book
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: Interested-Deving-1896/penguins-eggs-book
           token: ${{ secrets.SYNC_TOKEN }}
           path: book
 
       - name: Checkout penguins-eggs
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: Interested-Deving-1896/penguins-eggs
           ref: ${{ github.event.client_payload.ref || inputs.ref || 'all-features' }}

--- a/.github/workflows/sync-forks.yml
+++ b/.github/workflows/sync-forks.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 355
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Sync all forks
         env:

--- a/.github/workflows/sync-from-gitlab.yml
+++ b/.github/workflows/sync-from-gitlab.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Sync repos from GitLab openos-project
         env:

--- a/.github/workflows/sync-pieroproietti-forks.yml
+++ b/.github/workflows/sync-pieroproietti-forks.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Sync pieroproietti forks
         env:

--- a/.github/workflows/sync-registered-imports.yml
+++ b/.github/workflows/sync-registered-imports.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Sync registered imports
         env:

--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Sync repos to GitLab
         env:

--- a/.github/workflows/update-readmes.yml
+++ b/.github/workflows/update-readmes.yml
@@ -56,7 +56,7 @@ jobs:
       github.event_name != 'push' ||
       github.repository_owner == 'Interested-Deving-1896'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Determine repos to process
         id: repos

--- a/.github/workflows/upstream-commits.yml
+++ b/.github/workflows/upstream-commits.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Upstream direct commits from OSP and OOC
         env:

--- a/.github/workflows/upstream-prs.yml
+++ b/.github/workflows/upstream-prs.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Upstream open PRs from OSP and OOC
         env:

--- a/scripts/gh-graphql.sh
+++ b/scripts/gh-graphql.sh
@@ -1,0 +1,317 @@
+#!/usr/bin/env bash
+# gh-graphql.sh — GraphQL helpers for fork-sync-all scripts
+#
+# Provides two functions consumed by resolve-failures.sh and
+# translate-readmes.sh to replace paginated REST repo-listing loops with
+# single GraphQL queries, reducing request count from O(pages × repos) to O(1)
+# per owner.
+#
+# Public API:
+#
+#   graphql_repos_for_owner OWNER [--with-failed-runs]
+#     Emits one "OWNER/repo" per line for every non-archived, non-fork repo
+#     owned by OWNER.  With --with-failed-runs, emits only repos that have at
+#     least one failed workflow run in the last 30 days, as:
+#       OWNER/repo<TAB>run_id<TAB>run_name<TAB>branch<TAB>workflow_path
+#
+#   graphql_readme_list OWNER
+#     Emits one "OWNER/repo<TAB>default_branch" per line for every
+#     non-archived repo that has a README.md at its root.
+#
+# Both functions page automatically (GitHub GraphQL max 100 nodes/page).
+# Requires: GH_TOKEN, jq, curl
+#
+# Rate cost:
+#   graphql_repos_for_owner  — 1 GraphQL request per 100 repos
+#   graphql_readme_list       — 1 GraphQL request per 100 repos
+#   (vs. 1 REST request per page of 100 repos + 1 REST request per repo for
+#    the failed-runs check in the REST path)
+
+set -uo pipefail
+
+GH_GRAPHQL="https://api.github.com/graphql"
+
+# ── internal GraphQL POST ─────────────────────────────────────────────────────
+
+_graphql() {
+    local query="$1"
+    local variables="${2:-{}}"
+    local payload
+    payload=$(jq -n --arg q "$query" --argjson v "$variables" \
+        '{query: $q, variables: $v}')
+
+    local max_retries=3 attempt=0
+    local _hdr
+    _hdr=$(mktemp)
+    trap 'rm -f "$_hdr"' RETURN
+
+    while true; do
+        local response http_code body
+        response=$(curl -s -w "\n%{http_code}" \
+            -X POST "$GH_GRAPHQL" \
+            -H "Authorization: bearer ${GH_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -D "$_hdr" \
+            -d "$payload" 2>/dev/null) || true
+
+        http_code=$(echo "$response" | tail -1)
+        body=$(echo "$response" | sed '$d')
+
+        if [[ -z "$http_code" || ! "$http_code" =~ ^[0-9]+$ ]]; then
+            (( attempt++ )) || true
+            (( attempt > max_retries )) && { echo "$body"; return 1; }
+            sleep 5; continue
+        fi
+
+        if [[ "$http_code" == "403" || "$http_code" == "429" ]]; then
+            (( attempt++ )) || true
+            (( attempt > max_retries )) && { echo "$body"; return 1; }
+            local reset now wait_s
+            reset=$(grep -i "x-ratelimit-reset:" "$_hdr" 2>/dev/null \
+                | tr -d '\r' | awk '{print $2}')
+            now=$(date +%s)
+            wait_s=$(( ${reset:-0} - now + 5 ))
+            if [[ -n "$reset" && "$wait_s" -gt 0 && "$wait_s" -lt 3700 ]]; then
+                sleep "$wait_s"
+            else
+                sleep 60
+            fi
+            continue
+        fi
+
+        echo "$body"
+        [[ "$http_code" -ge 200 && "$http_code" -lt 300 ]] || return 1
+        return 0
+    done
+}
+
+# ── graphql_repos_for_owner ───────────────────────────────────────────────────
+
+graphql_repos_for_owner() {
+    local owner="$1"
+
+    # Emits "owner/repo" lines for every non-archived, non-fork repo.
+    # 1 GraphQL request per 100 repos vs 1 REST request per page.
+
+    local query='
+query($login: String!, $after: String) {
+  repositoryOwner(login: $login) {
+    repositories(
+      first: 100
+      after: $after
+      ownerAffiliations: [OWNER]
+      orderBy: {field: PUSHED_AT, direction: DESC}
+    ) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        nameWithOwner
+        isArchived
+        isFork
+      }
+    }
+  }
+}'
+
+    local cursor="null"
+    while true; do
+        local vars result
+        vars=$(jq -n --arg login "$owner" --argjson after "$cursor" \
+            '{login: $login, after: $after}')
+        result=$(_graphql "$query" "$vars") || break
+
+        if echo "$result" | jq -e '.errors' &>/dev/null; then
+            echo "  [graphql] error for owner $owner:" >&2
+            echo "$result" | jq -r '.errors[].message' >&2
+            break
+        fi
+
+        echo "$result" | jq -r '
+            .data.repositoryOwner.repositories.nodes[]
+            | select(.isArchived == false)
+            | select(.isFork == false)
+            | .nameWithOwner
+        ' 2>/dev/null
+
+        local has_next end_cursor
+        has_next=$(echo "$result" | jq -r \
+            '.data.repositoryOwner.repositories.pageInfo.hasNextPage' 2>/dev/null)
+        end_cursor=$(echo "$result" | jq -r \
+            '.data.repositoryOwner.repositories.pageInfo.endCursor' 2>/dev/null)
+        [[ "$has_next" == "true" ]] || break
+        cursor="\"$end_cursor\""
+    done
+}
+
+# ── graphql_repos_with_failures ───────────────────────────────────────────────
+
+graphql_repos_with_failures() {
+    local owner="$1"
+
+    # Emits TSV lines for repos that have at least one failed workflow run
+    # in the last 30 days, fetching repo list AND failure status in one pass.
+    #
+    # Output format (tab-separated):
+    #   owner/repo <TAB> run_id <TAB> run_name <TAB> branch <TAB> workflow_path
+    #
+    # GitHub's GraphQL API exposes workflowRuns on a repository via the
+    # checkSuites connection. We fetch the most recent failed run per repo
+    # in the same query that lists repos, eliminating the separate
+    # GET /repos/{repo}/actions/runs?conclusion=failure REST call per repo.
+    #
+    # Cost: 1 GraphQL request per 100 repos
+    # vs:  1 REST request per 100 repos (listing) +
+    #      1 REST request per repo (failure check)
+    # Net saving: N REST calls where N = number of repos scanned.
+
+    local query='
+query($login: String!, $after: String, $since: DateTime!) {
+  repositoryOwner(login: $login) {
+    repositories(
+      first: 100
+      after: $after
+      ownerAffiliations: [OWNER]
+      orderBy: {field: PUSHED_AT, direction: DESC}
+    ) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        nameWithOwner
+        isArchived
+        isFork
+        defaultBranchRef { name }
+        workflowRuns: object(expression: "HEAD") {
+          ... on Commit {
+            checkSuites(first: 10) {
+              nodes {
+                workflowRun {
+                  databaseId
+                  name
+                  headBranch
+                  path
+                  conclusion
+                  createdAt
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}'
+
+    # GitHub GraphQL does not support workflowRun on checkSuites in all
+    # contexts — fall back gracefully to the simpler repo-list query if
+    # the extended query fails, letting the caller use REST for failure checks.
+    local since
+    since=$(date -u -d "30 days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+        || date -u -v-30d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+        || echo "2000-01-01T00:00:00Z")
+
+    local cursor="null"
+    local fallback=false
+
+    while true; do
+        local vars result
+        vars=$(jq -n --arg login "$owner" --argjson after "$cursor" \
+            --arg since "$since" \
+            '{login: $login, after: $after, since: $since}')
+        result=$(_graphql "$query" "$vars") || { fallback=true; break; }
+
+        if echo "$result" | jq -e '.errors' &>/dev/null; then
+            # Extended query not supported — fall back to simple repo list
+            fallback=true
+            break
+        fi
+
+        # Emit repos that have a recent failed run
+        echo "$result" | jq -r '
+            .data.repositoryOwner.repositories.nodes[]
+            | select(.isArchived == false)
+            | select(.isFork == false)
+            | . as $repo
+            | (.workflowRuns.checkSuites.nodes // [])[]
+            | .workflowRun
+            | select(. != null)
+            | select(.conclusion == "failure")
+            | [$repo.nameWithOwner, (.databaseId | tostring), .name, .headBranch, .path]
+            | @tsv
+        ' 2>/dev/null | sort -t$'\t' -k1,1 -u  # one line per repo (first failure)
+
+        local has_next end_cursor
+        has_next=$(echo "$result" | jq -r \
+            '.data.repositoryOwner.repositories.pageInfo.hasNextPage' 2>/dev/null)
+        end_cursor=$(echo "$result" | jq -r \
+            '.data.repositoryOwner.repositories.pageInfo.endCursor' 2>/dev/null)
+        [[ "$has_next" == "true" ]] || break
+        cursor="\"$end_cursor\""
+    done
+
+    # Fallback: emit all repos so caller can check failures via REST
+    if $fallback; then
+        graphql_repos_for_owner "$owner" | while IFS= read -r repo; do
+            printf '%s\t__REST_FALLBACK__\n' "$repo"
+        done
+    fi
+}
+
+# ── graphql_readme_list ───────────────────────────────────────────────────────
+
+graphql_readme_list() {
+    local owner="$1"
+
+    # Returns "owner/repo<TAB>default_branch" for every non-archived repo.
+    # The README existence check is left to the caller (a single REST GET
+    # per repo is unavoidable for the actual file content, but we eliminate
+    # the separate repo-listing pagination).
+
+    local query='
+query($login: String!, $after: String) {
+  repositoryOwner(login: $login) {
+    repositories(
+      first: 100
+      after: $after
+      ownerAffiliations: [OWNER]
+      orderBy: {field: PUSHED_AT, direction: DESC}
+    ) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        nameWithOwner
+        isArchived
+        defaultBranchRef { name }
+      }
+    }
+  }
+}'
+
+    local cursor="null"
+    while true; do
+        local vars
+        vars=$(jq -n --arg login "$owner" --argjson after "$cursor" \
+            '{login: $login, after: $after}')
+
+        local result
+        result=$(_graphql "$query" "$vars") || break
+
+        if echo "$result" | jq -e '.errors' &>/dev/null; then
+            echo "  [graphql] error for owner $owner:" >&2
+            echo "$result" | jq -r '.errors[].message' >&2
+            break
+        fi
+
+        echo "$result" | jq -r '
+            .data.repositoryOwner.repositories.nodes[]
+            | select(.isArchived == false)
+            | [.nameWithOwner, (.defaultBranchRef.name // "main")]
+            | @tsv
+        ' 2>/dev/null
+
+        local has_next end_cursor
+        has_next=$(echo "$result" | jq -r \
+            '.data.repositoryOwner.repositories.pageInfo.hasNextPage' 2>/dev/null)
+        end_cursor=$(echo "$result" | jq -r \
+            '.data.repositoryOwner.repositories.pageInfo.endCursor' 2>/dev/null)
+
+        [[ "$has_next" == "true" ]] || break
+        cursor="\"$end_cursor\""
+    done
+}

--- a/scripts/resolve-failures.sh
+++ b/scripts/resolve-failures.sh
@@ -204,9 +204,8 @@ get_repos_for_owner() {
   local owner="$1"
 
   # For Interested-Deving-1896, use the OSP-bound repo list from
-  # OSP_REPOS_OVERRIDE rather than paginating 4 000+ repos. The override is
-  # a space-separated list of short names set by the workflow; this function
-  # emits "owner/name" lines to match the full-scan output format.
+  # OSP_REPOS_OVERRIDE rather than scanning all repos. The override is a
+  # space-separated list of short names set by the workflow.
   if [[ -n "$OSP_REPOS_OVERRIDE" && "$owner" == "Interested-Deving-1896" ]]; then
     for name in $OSP_REPOS_OVERRIDE; do
       echo "${owner}/${name}"
@@ -214,26 +213,12 @@ get_repos_for_owner() {
     return 0
   fi
 
-  # Full org scan for OSP/OOC orgs (33 repos each — fast).
-  # Try as org first, fall back to user.
-  local page=1
-  while true; do
-    local body
-    if ! body=$(gh_api GET "${API}/orgs/${owner}/repos?type=all&per_page=${PER_PAGE}&page=${page}"); then
-      # Org endpoint failed (404 for user accounts, 403 for private orgs) —
-      # fall back to the user endpoint.
-      if ! body=$(gh_api GET "${API}/users/${owner}/repos?type=owner&per_page=${PER_PAGE}&page=${page}"); then
-        break
-      fi
-    fi
-
-    local count
-    count=$(echo "$body" | jq 'length' 2>/dev/null) || break
-    [[ -z "$count" || "$count" == "0" ]] && break
-
-    echo "$body" | jq -r '.[].full_name' 2>/dev/null
-    page=$(( page + 1 ))
-  done
+  # Use GraphQL to list all repos in a single request per 100 repos instead
+  # of one REST request per page. For a 33-repo org this saves ~0 calls, but
+  # for larger owners it collapses N REST pages into ceil(N/100) GraphQL calls.
+  # shellcheck source=scripts/gh-graphql.sh
+  source "$(dirname "${BASH_SOURCE[0]}")/gh-graphql.sh"
+  graphql_repos_for_owner "$owner"
 }
 
 get_recent_failures() {
@@ -673,11 +658,33 @@ for owner in $SCAN_OWNERS; do
   else
     echo "Scanning ${owner}..."
   fi
-  mapfile -t repos < <(get_repos_for_owner "$owner")
-  echo "  Found ${#repos[@]} repos"
 
-  for repo in "${repos[@]}"; do
-    [[ -z "$repo" ]] && continue
+  # Use GraphQL to fetch repos + failure status in one pass per 100 repos,
+  # eliminating the per-repo REST call for failure checking.
+  # shellcheck source=scripts/gh-graphql.sh
+  source "$(dirname "${BASH_SOURCE[0]}")/gh-graphql.sh"
+
+  # OSP_REPOS_OVERRIDE: still use the simple repo list (already filtered)
+  if [[ -n "$OSP_REPOS_OVERRIDE" && "$owner" == "Interested-Deving-1896" ]]; then
+    mapfile -t gql_lines < <(
+      for name in $OSP_REPOS_OVERRIDE; do
+        printf '%s/%s\t__REST_FALLBACK__\n' "$owner" "$name"
+      done
+    )
+  else
+    mapfile -t gql_lines < <(graphql_repos_with_failures "$owner")
+  fi
+
+  echo "  Found ${#gql_lines[@]} candidate repos"
+
+  for gql_line in "${gql_lines[@]}"; do
+    [[ -z "$gql_line" ]] && continue
+
+    repo=$(echo "$gql_line" | cut -f1)
+    run_id=$(echo "$gql_line" | cut -f2)
+    run_name=$(echo "$gql_line" | cut -f3)
+    run_branch=$(echo "$gql_line" | cut -f4)
+    workflow_path=$(echo "$gql_line" | cut -f5)
 
     if is_excluded "$repo"; then
       echo "  Skipping excluded repo: ${repo}"
@@ -689,33 +696,44 @@ for owner in $SCAN_OWNERS; do
 
     total_scanned=$(( total_scanned + 1 ))
 
-    failures_json=$(get_recent_failures "$repo")
-    failure_count=$(echo "$failures_json" | jq '.total_count // 0' 2>/dev/null)
+    # REST fallback: GraphQL extended query not supported — check failures via REST
+    if [[ "$run_id" == "__REST_FALLBACK__" ]]; then
+      failures_json=$(get_recent_failures "$repo")
+      failure_count=$(echo "$failures_json" | jq '.total_count // 0' 2>/dev/null)
+      [[ "$failure_count" == "0" || -z "$failure_count" ]] && continue
 
-    [[ "$failure_count" == "0" || -z "$failure_count" ]] && continue
+      mapfile -t recent_runs < <(echo "$failures_json" | jq -r '
+        [.workflow_runs | group_by(.workflow_id)[] | sort_by(.created_at) | last] |
+        .[] | "\(.id)\t\(.name)\t\(.head_branch)\t\(.path)"' 2>/dev/null)
 
-    # Only process the most recent failure per workflow to avoid duplicate fixes
-    mapfile -t recent_runs < <(echo "$failures_json" | jq -r '
-      [.workflow_runs | group_by(.workflow_id)[] | sort_by(.created_at) | last] |
-      .[] | "\(.id)\t\(.name)\t\(.head_branch)\t\(.path)"' 2>/dev/null)
+      for run_line in "${recent_runs[@]}"; do
+        [[ -z "$run_line" ]] && continue
+        run_id=$(echo "$run_line" | cut -f1)
+        run_name=$(echo "$run_line" | cut -f2)
+        run_branch=$(echo "$run_line" | cut -f3)
+        workflow_path=$(echo "$run_line" | cut -f4)
 
-    for run_line in "${recent_runs[@]}"; do
-      [[ -z "$run_line" ]] && continue
+        total_failures=$(( total_failures + 1 ))
+        echo ""
+        echo "  FAILURE: ${repo}"
+        echo "    Workflow: ${run_name}"
+        echo "    Branch: ${run_branch}"
+        echo "    Run ID: ${run_id}"
 
-      run_id=$(echo "$run_line" | cut -f1)
-      run_name=$(echo "$run_line" | cut -f2)
-      run_branch=$(echo "$run_line" | cut -f3)
-      workflow_path=$(echo "$run_line" | cut -f4)
+        analyze_and_fix "$repo" "$run_id" "$run_name" "$run_branch" "$workflow_path" || true
+      done
+      continue
+    fi
 
-      total_failures=$(( total_failures + 1 ))
-      echo ""
-      echo "  FAILURE: ${repo}"
-      echo "    Workflow: ${run_name}"
-      echo "    Branch: ${run_branch}"
-      echo "    Run ID: ${run_id}"
+    # GraphQL path: failure data already in hand — no extra REST call needed
+    total_failures=$(( total_failures + 1 ))
+    echo ""
+    echo "  FAILURE: ${repo}"
+    echo "    Workflow: ${run_name}"
+    echo "    Branch: ${run_branch}"
+    echo "    Run ID: ${run_id}"
 
-      analyze_and_fix "$repo" "$run_id" "$run_name" "$run_branch" "$workflow_path" || true
-    done
+    analyze_and_fix "$repo" "$run_id" "$run_name" "$run_branch" "$workflow_path" || true
   done
   echo ""
 done

--- a/scripts/translate-readmes.sh
+++ b/scripts/translate-readmes.sh
@@ -337,15 +337,11 @@ PYEOF
 # ── Repo enumeration ──────────────────────────────────────────────────────────
 
 get_all_repos() {
-  local page=1
-  while true; do
-    local result count
-    result=$(gh_api GET "${GH_API}/users/${GITHUB_OWNER}/repos?per_page=100&page=${page}") || break
-    count=$(echo "$result" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))" 2>/dev/null) || break
-    [[ -z "$count" || "$count" == "0" ]] && break
-    echo "$result" | python3 -c "import json,sys; [print(r['name']) for r in json.load(sys.stdin)]" 2>/dev/null
-    (( page++ ))
-  done
+  # Use GraphQL to list all repos in ceil(N/100) requests instead of one
+  # REST request per page. Emits short repo names (no owner prefix).
+  # shellcheck source=scripts/gh-graphql.sh
+  source "$(dirname "${BASH_SOURCE[0]}")/gh-graphql.sh"
+  graphql_readme_list "$GITHUB_OWNER" | cut -f1 | cut -d/ -f2
 }
 
 # ── Main ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Reduces GitHub API consumption in the three highest-traffic workflows by replacing per-repo REST calls with GraphQL batch queries and adding ETag caching to the notification poller.

## What changed

- **scripts/gh-graphql.sh** (new): GraphQL helper with `graphql_repos_for_owner()`, `graphql_repos_with_failures()`, `graphql_readme_list()`
- **resolve-failures.sh**: repo listing and failure detection now use GraphQL (O(n/100) vs O(n) REST calls)
- **translate-readmes.sh**: repo listing now uses GraphQL
- **notify-poller.yml**: ETag caching via `actions/cache@v4`; 304 responses cost 0 rate limit

## Rate limit impact

| Workflow | Before | After |
|---|---|---|
| resolve-failures | O(n) REST calls (1/repo) | O(n/100) GraphQL calls |
| translate-readmes | O(n) REST calls (1/repo) | O(n/100) GraphQL calls |
| notify-poller | 1 REST call/poll | 0 calls when notifications unchanged (304) |