### PR TITLE
feat: AGENTS.md, audit skill, bug fixes, and chain cherry-picks

### DIFF
--- a/.github/workflows/translate-readmes.yml
+++ b/.github/workflows/translate-readmes.yml
@@ -22,6 +22,16 @@ on:
   workflow_run:
     workflows:
       - "Update READMEs"
+      - "Add Mirror Repo"
+      - "Import Repository"
+      - "Clone Org"
+      - "Merge Repos into Monorepo"
+      - "Sync All Forks"
+      - "Sync Registered Imports"
+      - "Sync from GitLab"
+      - "Sync pieroproietti Forks"
+      - "Sync Upstream Sources"
+      - "Sync penguins-eggs docs to penguins-eggs-book"
     types: [completed]
   workflow_dispatch:
     inputs:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -147,6 +147,15 @@ upstream-prs:
     - if: '$CI_PIPELINE_SOURCE == "schedule" && $CADENCE == "daily"'
     - when: manual
 
+# ── Resolve failures (scheduled) ─────────────────────────────────────────────
+resolve-failures:
+  stage: maintain
+  script:
+    - bash scripts/resolve-failures.sh
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $CADENCE == "daily"'
+    - when: manual
+
 # ── Sync upstream mirrors (scheduled weekly) ──────────────────────────────────
 # Pulls latest commits from GitHub into openos-project/upstream-mirrors.
 # Requires CI variable: GITLAB_TOKEN (api + write_repository scope, masked).

--- a/.ona/skills/fork-sync-all-audit.md
+++ b/.ona/skills/fork-sync-all-audit.md
@@ -1,0 +1,172 @@
+---
+name: fork-sync-all-audit
+description: >
+  Audit and fix fork-sync-all GitHub Actions workflows for correctness,
+  consistency, and completeness. Use when asked to audit fork-sync-all,
+  fix workflow bugs, review CI, check workflow triggers, or improve the
+  mirror/sync infrastructure.
+  Triggers on "audit fork-sync-all", "fix workflows", "workflow audit",
+  "mirror chain audit", "sync workflow", "fork-sync audit".
+---
+
+# fork-sync-all Audit Skill
+
+## Overview
+
+`fork-sync-all` is the central infrastructure repo for `Interested-Deving-1896`.
+It contains:
+- **Workflows** (`.github/workflows/`) — 40+ GitHub Actions workflows for
+  mirroring, syncing, README generation, token rotation, and CI hygiene
+- **Scripts** (`scripts/`) — bash/python scripts called by workflows
+- **Config** (`config/`) — YAML config files for template consumers, GitLab
+  subgroups, overlay manifests, etc.
+
+The repo acts as a **template** that propagates files to consumer repos via
+`sync-template.sh` / `sync-template.yml`.
+
+---
+
+## Audit Checklist
+
+### 1. workflow_run trigger name mismatches
+The most common silent bug. `workflow_run` triggers match on the workflow's
+`name:` field, not its filename.
+
+```bash
+# Find all workflow_run triggers
+grep -rn 'workflow_run' .github/workflows/ | grep 'workflows:'
+
+# Cross-check each referenced name against actual workflow name: fields
+grep -rh '^name:' .github/workflows/ | sort
+```
+**Known instance:** `update-readmes.yml` and `translate-readmes.yml` both
+referenced `"sync-from-gitlab"` but the actual workflow name is
+`"Sync from GitLab"` — causing both post-GitLab-sync passes to be silently dead.
+
+### 2. DRY_RUN / REPO_FILTER input consistency
+Every workflow that iterates over repos should expose:
+```yaml
+inputs:
+  dry_run:
+    description: 'Print actions without making changes'
+    type: boolean
+    default: false
+  repo_filter:
+    description: 'Substring match on repo name (blank = all)'
+    type: string
+    default: ''
+```
+`repo_filter` must be a **substring match** (`[[ "$repo" == *"$REPO_FILTER"* ]]`),
+not an exact match or regex. Check all scripts that iterate repos.
+
+### 3. Script input propagation
+Workflow env vars must be passed through to scripts. Common pattern:
+```yaml
+env:
+  DRY_RUN: ${{ inputs.dry_run }}
+  REPO_FILTER: ${{ inputs.repo_filter }}
+```
+Scripts read `${DRY_RUN:-false}` and `${REPO_FILTER:-}`.
+
+### 4. Retry logic on API calls
+All `curl` calls to GitHub/GitLab APIs should use `--retry 3 --retry-delay 5`.
+Workflows that call scripts in a loop should have `continue-on-error: true`
+on the step or handle failures gracefully.
+
+### 5. Cron schedule stagger
+Multiple workflows should not all run at `:00`. Stagger by 5–10 minutes to
+avoid API rate limit collisions:
+```yaml
+# Good — staggered
+- cron: '0 2 * * *'   # workflow A
+- cron: '10 2 * * *'  # workflow B
+- cron: '20 2 * * *'  # workflow C
+```
+
+### 6. Template consumer registry
+`config/template-consumers.yml` lists repos that receive automatic template
+updates. Check:
+- All active consumer repos are listed
+- Each has the correct `profile` (`full` | `mirror` | `infra-core` | `standalone`)
+- `enabled: true` for repos that should receive updates
+- `skip_osp_setup: true` for repos that don't participate in the OSP mirror chain
+
+Profiles defined in `config/template-manifest.yml`:
+| Profile | Contents |
+|---|---|
+| `full` | Everything (default) |
+| `mirror` | Mirror/sync suite + infra; excludes fork-sync-all-only files |
+| `infra-core` | CI hygiene only (PR automation, token rotation, branch cleanup) |
+| `standalone` | Minimal: PR automation + token rotation only |
+
+### 7. GitLab subgroup assignments
+`config/gitlab-subgroups.yml` maps GitHub repos to GitLab subgroups for the
+OSP mirror chain. Validate with:
+```bash
+python3 scripts/validate-gitlab-subgroups.py
+```
+The CI job `validate-config` runs this on every push.
+
+### 8. Mirror artifact workflow inputs
+`mirror-artifacts.yml` requires `source_repo` and `artifact_name` inputs.
+Check that callers pass both. The workflow should fail fast if either is empty.
+
+### 9. Token health
+`token-health.yml` runs on a schedule and checks PAT expiry. Verify:
+- The schedule is set (not commented out)
+- `rotate-token.yml` is triggered when health check fails
+- `GH_TOKEN` secret is set in the repo
+
+---
+
+## Template sync workflow
+
+`sync-template.sh` has three modes:
+
+| Mode | Trigger | What it does |
+|---|---|---|
+| `CREATE` | Manual | Creates new repo + pushes template + OSP setup |
+| `INJECT` | Manual | Copies template into existing repos (skips existing files unless `FORCE=true`) |
+| `PROPAGATE` | Push to main | Reads `template-consumers.yml`, syncs all enabled consumers |
+
+Always-excluded paths (never overwritten in consumers):
+`README.md`, `registered-imports.json`, `dep-graph/`, `.git/`, `.ona/`
+
+Per-consumer overrides in `template-consumers.yml`:
+```yaml
+- name: my-repo
+  profile: infra-core
+  exclude_paths:
+    - .github/workflows/update-readmes.yml
+  include_paths:
+    - .github/workflows/rotate-token.yml
+  force: true
+```
+
+---
+
+## Commit conventions
+
+```
+fix: <pass>-pass audit — <short summary>
+
+- <workflow>: <what was wrong and what was fixed>
+
+Co-authored-by: Ona <no-reply@ona.com>
+```
+
+Branch naming: `fix/<description>` or `feat/<description>`
+
+---
+
+## Anti-patterns
+
+- Do NOT use exact string match for `REPO_FILTER` — must be substring
+  (`*"$filter"*`) so partial names work
+- Do NOT schedule all workflows at `:00` — stagger to avoid rate limits
+- Do NOT reference workflow filenames in `workflow_run` triggers — use the
+  `name:` field value
+- Do NOT add repos to `template-consumers.yml` with `enabled: true` before
+  verifying the repo exists and has the correct branch structure
+- Do NOT set `force: true` globally in `template-consumers.yml` — it will
+  overwrite repo-specific customisations on every push to main

--- a/.ona/skills/fork-sync-all-audit.md
+++ b/.ona/skills/fork-sync-all-audit.md
@@ -1,156 +1,193 @@
 ---
 name: fork-sync-all-audit
 description: >
-  Audit and fix fork-sync-all GitHub Actions workflows for correctness,
-  consistency, and completeness. Use when asked to audit fork-sync-all,
-  fix workflow bugs, review CI, check workflow triggers, or improve the
-  mirror/sync infrastructure.
+  Audit and fix fork-sync-all GitHub Actions workflows, scripts, and config
+  for correctness, consistency, and completeness. Use when asked to audit
+  fork-sync-all, fix workflow bugs, review CI, check workflow triggers,
+  improve the mirror/sync infrastructure, or work on arch repo creation.
   Triggers on "audit fork-sync-all", "fix workflows", "workflow audit",
-  "mirror chain audit", "sync workflow", "fork-sync audit".
+  "mirror chain audit", "sync workflow", "fork-sync audit", "arch repos",
+  "kernel repos", "patchset branches".
 ---
 
 # fork-sync-all Audit Skill
 
 ## Overview
 
-`fork-sync-all` is the central infrastructure repo for `Interested-Deving-1896`.
-It contains:
-- **Workflows** (`.github/workflows/`) — 40+ GitHub Actions workflows for
-  mirroring, syncing, README generation, token rotation, and CI hygiene
-- **Scripts** (`scripts/`) — bash/python scripts called by workflows
-- **Config** (`config/`) — YAML config files for template consumers, GitLab
-  subgroups, overlay manifests, etc.
+`fork-sync-all` is the template source and sync orchestrator for a three-org
+GitHub mirror chain:
 
-The repo acts as a **template** that propagates files to consumer repos via
-`sync-template.sh` / `sync-template.yml`.
+```
+Interested-Deving-1896  ──►  OpenOS-Project-OSP  ──►  OpenOS-Project-Ecosystem-OOC
+        ▲                                                         │
+        └─────────── upstream-commits / upstream-prs ────────────┘
+```
+
+Key directories:
+- `.github/workflows/` — 40+ GitHub Actions workflows
+- `scripts/` — bash/python scripts called by workflows
+- `config/` — YAML config for template consumers, GitLab subgroups, manifests
+- `.ona/skills/` — Ona agent skills for this repo and KPort
+- `AGENTS.md` — agent guidance (propagates to all mirror/infra-core consumers)
+- `AGENTS-IMPROVEMENT-SPEC.md` — working defect tracker (propagates to consumers)
+
+Always read `AGENTS.md` first — it has the rate limit patterns, template
+propagation rules, arch repo structure, and commit conventions.
 
 ---
 
-## Audit Checklist
-
-### 1. workflow_run trigger name mismatches
-The most common silent bug. `workflow_run` triggers match on the workflow's
-`name:` field, not its filename.
+## Before starting any audit
 
 ```bash
-# Find all workflow_run triggers
-grep -rn 'workflow_run' .github/workflows/ | grep 'workflows:'
+# 1. Check rate limit — all bulk operations need this
+gh api rate_limit --jq '.resources.core | "remaining: \(.remaining)/\(.limit)  resets: \(.reset | todate)"'
 
-# Cross-check each referenced name against actual workflow name: fields
-grep -rh '^name:' .github/workflows/ | sort
-```
-**Known instance:** `update-readmes.yml` and `translate-readmes.yml` both
-referenced `"sync-from-gitlab"` but the actual workflow name is
-`"Sync from GitLab"` — causing both post-GitLab-sync passes to be silently dead.
+# 2. Run validators — must pass before and after any changes
+python3 -m pytest tests/ -v
+python3 scripts/validate-template-config.py
+python3 scripts/validate-registered-imports.py
+python3 scripts/validate-workflow-guards.py
 
-### 2. DRY_RUN / REPO_FILTER input consistency
-Every workflow that iterates over repos should expose:
-```yaml
-inputs:
-  dry_run:
-    description: 'Print actions without making changes'
-    type: boolean
-    default: false
-  repo_filter:
-    description: 'Substring match on repo name (blank = all)'
-    type: string
-    default: ''
-```
-`repo_filter` must be a **substring match** (`[[ "$repo" == *"$REPO_FILTER"* ]]`),
-not an exact match or regex. Check all scripts that iterate repos.
-
-### 3. Script input propagation
-Workflow env vars must be passed through to scripts. Common pattern:
-```yaml
-env:
-  DRY_RUN: ${{ inputs.dry_run }}
-  REPO_FILTER: ${{ inputs.repo_filter }}
-```
-Scripts read `${DRY_RUN:-false}` and `${REPO_FILTER:-}`.
-
-### 4. Retry logic on API calls
-All `curl` calls to GitHub/GitLab APIs should use `--retry 3 --retry-delay 5`.
-Workflows that call scripts in a loop should have `continue-on-error: true`
-on the step or handle failures gracefully.
-
-### 5. Cron schedule stagger
-Multiple workflows should not all run at `:00`. Stagger by 5–10 minutes to
-avoid API rate limit collisions:
-```yaml
-# Good — staggered
-- cron: '0 2 * * *'   # workflow A
-- cron: '10 2 * * *'  # workflow B
-- cron: '20 2 * * *'  # workflow C
+# 3. Check all workflow_run trigger names match actual workflow name: fields
+python3 - <<'EOF'
+import re, glob
+actual = {}
+for f in glob.glob(".github/workflows/*.yml") + glob.glob(".github/workflows/*.yaml"):
+    with open(f) as fh:
+        for line in fh:
+            m = re.match(r'^name:\s*(.+)', line)
+            if m: actual[m.group(1).strip()] = f; break
+for tf in sorted(glob.glob(".github/workflows/*.yml")):
+    with open(tf) as fh: content = fh.read()
+    in_block = False
+    for line in content.splitlines():
+        if 'workflow_run:' in line: in_block = True
+        if in_block and 'types:' in line: in_block = False
+        if in_block:
+            m = re.search(r'- "([^"]+)"', line)
+            if m and m.group(1) not in actual:
+                print(f"BROKEN: {tf}: \"{m.group(1)}\"")
+EOF
 ```
 
-### 6. Template consumer registry
+---
+
+## Audit checklist
+
+### 1. `workflow_run` trigger name mismatches
+
+GitHub matches `workflow_run` on the `name:` field, not the filename.
+The check above finds all broken references. As of 2026-05-27 all references
+are verified clean — run the check again after any workflow rename.
+
+### 2. `DRY_RUN` / `REPO_FILTER` input consistency
+
+All 12 bulk-mutation scripts correctly declare and gate on these vars.
+Pattern to verify:
+
+```bash
+for s in scripts/*.sh; do
+  dry=$(grep -c 'DRY_RUN="\${DRY_RUN' "$s" 2>/dev/null || echo 0)
+  gate=$(grep -c 'DRY_RUN.*==.*true' "$s" 2>/dev/null || echo 0)
+  [[ "$dry" -eq 0 ]] && echo "MISSING DRY_RUN decl: $s"
+  [[ "$dry" -gt 0 && "$gate" -eq 0 ]] && echo "MISSING DRY_RUN gate: $s"
+done
+```
+
+### 3. Retry logic on API calls
+
+All `api_get` / `gh_get` functions must retry on 403/429. Reference pattern
+from `scripts/create-arch-repos.py` `gh_api()`. Scripts verified clean as of
+2026-05-27: `cleanup-branches.sh`, `upstream-prs.sh`,
+`sync-btrfs-devel-branches.sh`, `mirror-releases.sh`, `mirror-orgs.sh`.
+
+Quick check:
+```bash
+for s in scripts/*.sh; do
+  curl_bare=$(grep -cE 'curl.*--fail[^-]|curl -sf ' "$s" 2>/dev/null || echo 0)
+  [[ "$curl_bare" -gt 0 ]] && echo "BARE CURL (no retry): $s ($curl_bare sites)"
+done
+```
+
+### 4. Template consumer registry
+
 `config/template-consumers.yml` lists repos that receive automatic template
-updates. Check:
-- All active consumer repos are listed
-- Each has the correct `profile` (`full` | `mirror` | `infra-core` | `standalone`)
-- `enabled: true` for repos that should receive updates
-- `skip_osp_setup: true` for repos that don't participate in the OSP mirror chain
+updates. Profiles defined in `config/template-manifest.yml`:
 
-Profiles defined in `config/template-manifest.yml`:
 | Profile | Contents |
 |---|---|
-| `full` | Everything (default) |
+| `full` | Everything |
 | `mirror` | Mirror/sync suite + infra; excludes fork-sync-all-only files |
 | `infra-core` | CI hygiene only (PR automation, token rotation, branch cleanup) |
 | `standalone` | Minimal: PR automation + token rotation only |
 
-### 7. GitLab subgroup assignments
-`config/gitlab-subgroups.yml` maps GitHub repos to GitLab subgroups for the
-OSP mirror chain. Validate with:
+Always-excluded paths (never written to consumers) — defined in
+`scripts/sync-template.sh` `EXCLUDED_PATHS`:
+`README.md`, `registered-imports.json`, `dep-graph/`, `.git/`, `.ona/`,
+`DOCS/`, `tests/`, `scripts/validate-*.py`, fork-sync-all-specific workflows.
+
+`AGENTS.md` and `AGENTS-IMPROVEMENT-SPEC.md` **are** propagated to
+`mirror` and `infra-core` consumers.
+
+### 5. Cron schedule stagger
+
+Verified clean as of 2026-05-27 — no two heavy workflows share the same
+minute slot. Current schedule:
+
+| Slot | Workflow |
+|---|---|
+| `:00` | `mirror-releases.yml` |
+| `:10` | `mirror-artifacts.yml` |
+| `:30` | `mirror-osp-to-gitlab.yml`, `upstream-prs.yml` |
+| `:45` | `setup-osp-mirrors.yml` |
+| `:47` | `upstream-commits.yml` |
+| `:55` | `sync-registered-imports.yml` |
+| Daily `05:50` | `reconcile-org-refs.yml` |
+
+### 6. GitLab subgroup assignments
+
+`config/gitlab-subgroups.yml` maps GitHub repos to GitLab subgroups.
+Validate with:
 ```bash
 python3 scripts/validate-gitlab-subgroups.py
 ```
-The CI job `validate-config` runs this on every push.
 
-### 8. Mirror artifact workflow inputs
-`mirror-artifacts.yml` requires `source_repo` and `artifact_name` inputs.
-Check that callers pass both. The workflow should fail fast if either is empty.
+### 7. `mirror-to-osp.sh` default branch gate
 
-### 9. Token health
-`token-health.yml` runs on a schedule and checks PAT expiry. Verify:
-- The schedule is set (not commented out)
-- `rotate-token.yml` is triggered when health check fails
-- `GH_TOKEN` secret is set in the repo
+Fixed 2026-05-27 — uses `default_branch` from repo metadata instead of
+hardcoded `main`. Repos with `master` default branch (e.g. `penguins-eggs`)
+are no longer silently skipped.
+
+### 8. Token expiry (time-sensitive)
+
+From `scripts/token-monitor.sh` — rotate before these dates:
+- `OSP-ORG Mirror Token` — **2026-06-28**
+- `sync-mirror-watchdog` — **2026-07-03**
 
 ---
 
-## Template sync workflow
+## Arch repo infrastructure
 
-`sync-template.sh` has three modes:
+10 CPU architectures × 35 repos each = 350 repos total across 3 tiers.
+See `AGENTS.md` for the full breakdown and creation commands.
 
-| Mode | Trigger | What it does |
-|---|---|---|
-| `CREATE` | Manual | Creates new repo + pushes template + OSP setup |
-| `INJECT` | Manual | Copies template into existing repos (skips existing files unless `FORCE=true`) |
-| `PROPAGATE` | Push to main | Reads `template-consumers.yml`, syncs all enabled consumers |
+Scripts:
+- `scripts/create-arch-repos.py` — creates repos for one or more archs
+- `scripts/run-tier1-arm64.sh` / `run-tier2.sh` / `run-tier3.sh` — tier runners
+- `scripts/run-all-tiers.sh` — full orchestration with rate limit handling
+- `scripts/push-kernel-content.sh` — pushes Linux v6.9 to kernel-base repos
+- `scripts/seed-patchset-branches.sh` — seeds 270 patchset branches
 
-Always-excluded paths (never overwritten in consumers):
-`README.md`, `registered-imports.json`, `dep-graph/`, `.git/`, `.ona/`
-
-Per-consumer overrides in `template-consumers.yml`:
-```yaml
-- name: my-repo
-  profile: infra-core
-  exclude_paths:
-    - .github/workflows/update-readmes.yml
-  include_paths:
-    - .github/workflows/rotate-token.yml
-  force: true
-```
+Kernel clone at `/workspaces/linux-kernel` (v6.9, 1.8GB).
 
 ---
 
 ## Commit conventions
 
 ```
-fix: <pass>-pass audit — <short summary>
+fix: <short summary>
 
-- <workflow>: <what was wrong and what was fixed>
+- <file>: <what was wrong and what was fixed>
 
 Co-authored-by: Ona <no-reply@ona.com>
 ```
@@ -161,12 +198,16 @@ Branch naming: `fix/<description>` or `feat/<description>`
 
 ## Anti-patterns
 
-- Do NOT use exact string match for `REPO_FILTER` — must be substring
-  (`*"$filter"*`) so partial names work
-- Do NOT schedule all workflows at `:00` — stagger to avoid rate limits
 - Do NOT reference workflow filenames in `workflow_run` triggers — use the
   `name:` field value
+- Do NOT use exact string match for `REPO_FILTER` — must be substring
+  (`*"$filter"*`) so partial names work
+- Do NOT schedule two heavy workflows at the same minute slot
 - Do NOT add repos to `template-consumers.yml` with `enabled: true` before
   verifying the repo exists and has the correct branch structure
-- Do NOT set `force: true` globally in `template-consumers.yml` — it will
-  overwrite repo-specific customisations on every push to main
+- Do NOT set `force: true` globally in `template-consumers.yml` — overwrites
+  repo-specific customisations on every push to main
+- Do NOT run arch repo creation without checking rate limit first —
+  350 repos × ~3 API calls each = ~1050 calls minimum
+- Do NOT push to kernel-base repos before the kernel clone at
+  `/workspaces/linux-kernel` is complete

--- a/.ona/skills/kport-audit.md
+++ b/.ona/skills/kport-audit.md
@@ -1,0 +1,230 @@
+---
+name: kport-audit
+description: >
+  Audit and fix KPort pacscripts for completeness, correctness, and consistency.
+  Use when asked to audit KPort, fix pacscript fields, fill sha256sums, bump
+  versions, fill depends=(), fix GPU/CPU tiers, or clean up URLs.
+  Triggers on "audit KPort", "fix pacscripts", "fill sha256", "bump version",
+  "fill depends", "kport audit", "pacscript audit".
+---
+
+# KPort Audit Skill
+
+## Overview
+
+KPort pacscripts live under `packages/` (production) and `overlays/`
+(arch-specific or community packages). Each pacscript is a bash file with
+standard Pacstall fields plus KPort-specific fields (`KNEON_CHANNEL`,
+`KGPU_MIN`, `KCPU_MIN`, `KUSE`, `KSLOT`).
+
+The audit workflow runs in rounds. Each round scans for a class of issues,
+fixes them, commits, and opens a PR. Merge each PR before starting the next.
+
+---
+
+## Audit Checklist
+
+Run these checks in order. All use `find packages/ overlays/ -name "*.pacscript"`.
+
+### 1. SKIP / placeholder sha256sums
+```bash
+# Remaining SKIP placeholders
+find packages/ overlays/ -name "*.pacscript" | xargs grep -l '"SKIP"'
+
+# Fake hashes (repeating byte pattern)
+find packages/ overlays/ -name "*.pacscript" | \
+  xargs grep -rn '"[a-f0-9]\{64\}"' | \
+  awk -F'"' '{print $2}' | sort | uniq -d
+```
+Fix with `scripts/kport/fill-sha256.sh --dir <dir>`. The script expands
+`${pkgver}`/`${pkgname}` in URLs before fetching. For overlays, patch manually:
+```bash
+curl -sL "<url>" | sha256sum
+# then edit the pacscript directly
+```
+
+### 2. Missing required KPort fields
+```bash
+find packages/ overlays/ -name "*.pacscript" | xargs grep -L 'KNEON_CHANNEL'
+find packages/ overlays/ -name "*.pacscript" | xargs grep -L 'KGPU_MIN'
+find packages/ overlays/ -name "*.pacscript" | xargs grep -L 'KCPU_MIN'
+find packages/ overlays/ -name "*.pacscript" | xargs grep -L 'KUSE'
+```
+**Intentional omissions:**
+- `KCPU_MIN`: pure data/icon/doc packages (`kf6-*-icon-theme`, `qt6-doc`,
+  `qt6-translations`, `kdeedu-data`)
+- `KUSE`: pure data/build-tools with no test suite (`lxqt-build-tools`,
+  `lxqt-menu-data`, `lxqt-themes`)
+
+Standard values:
+- `KNEON_CHANNEL`: `"stable"` | `"unstable"` | `"nightly"`
+- `KGPU_MIN`: `"gpu-none"` | `"gpu-sw"` | `"gpu-gl2"` | `"gpu-vk12"`
+- `KCPU_MIN`: `"x86-64-v1"` | `"x86-64-v2"` | `"x86-64-v3"` | `"aarch64-baseline"` | `"i686-baseline"`
+- `KUSE`: array of USE flags, e.g. `("-test")` to disable tests
+
+### 3. Stub depends=()
+```bash
+find packages/ overlays/ -name "*.pacscript" | \
+  xargs grep -l 'Populate after a test build\|No named runtime deps'
+```
+Fill from the KDE Neon apt index:
+```bash
+# Download once — jammy index covers most KF6/Plasma/Gear packages
+curl -sL "https://archive.neon.kde.org/user/dists/jammy/main/binary-amd64/Packages.gz" \
+  | gunzip > /tmp/neon-packages.txt
+
+# Noble index for newer packages (libpyside6, qt6-interfaceframework, etc.)
+curl -sL "https://archive.neon.kde.org/unstable/dists/noble/main/binary-amd64/Packages.gz" \
+  | gunzip > /tmp/neon-noble-packages.txt
+```
+Look up each package by its KPort `pkgname` — Neon uses the same names for
+most packages. Known renames:
+
+| KPort name | Neon package name |
+|---|---|
+| `kf6-kactivities` | `plasma-activities` |
+| `kf6-kactivities-stats` | `plasma-activities-stats` |
+| `kf6-kwayland` | `kwayland` |
+| `kf6-plasma-framework` | `libplasma6` |
+
+Filter out pure system libs (`libc6`, `libstdc++6`, `libgcc-s1`, `zlib1g`).
+Keep named system libs and all KPort-managed packages.
+
+**Malformed block patterns to watch for:**
+
+1. `).` + stub comment + bare `)` — real deps were filled but stub comment
+   left as a dangling tail. Fix with:
+   ```python
+   re.sub(r'\)\.\n(?:  #[^\n]*\n)+\)', ')', content)
+   ```
+
+2. Unclosed `depends=(` with comment but no closing `)` — the blank line
+   before `makedepends=(` acts as implicit end. Fix:
+   ```python
+   re.sub(r'^(depends=\()\n(?:  #[^\n]*\n)+\n', make_block(deps) + '\n\n', content, flags=re.M)
+   ```
+
+Pure data/header packages with no runtime deps: use `depends=()` (empty,
+closed). Examples: `kdeedu-data`, `plasma-wayland-protocols`, `libastro1`.
+
+### 4. Version drift
+```bash
+# Check version spread per category
+find packages/plasma/ -name "*.pacscript" | xargs grep 'pkgver=' | \
+  awk -F'"' '{print $2}' | sort -Vu
+
+find packages/frameworks/ -name "*.pacscript" | xargs grep 'pkgver=' | \
+  awk -F'"' '{print $2}' | sort -Vu
+
+find packages/qt6/ -name "*.pacscript" | xargs grep 'pkgver=' | \
+  awk -F'"' '{print $2}' | sort -Vu
+```
+Packages within the same upstream release train should share a version.
+Outliers with independent versioning (intentional):
+- `libpolkit-qt6-1-1` (0.201.x), `kf6-kirigami-addons` (1.x),
+  `kf6-ktextaddons` (2.x), `qt6-phonon` (4.x), `qtcreator` (19.x),
+  `plasma-wayland-protocols` (1.x), `kf6-oxygen-icon-theme` (6.1.0 is latest)
+
+Verify tarballs exist before bumping:
+```bash
+curl -sI "https://download.kde.org/stable/plasma/<ver>/<name>-<ver>.tar.xz" | head -3
+```
+KDE download URL patterns:
+- Plasma: `https://download.kde.org/stable/plasma/<ver>/<name>-<ver>.tar.xz`
+- Frameworks: `https://download.kde.org/stable/frameworks/<maj.min>/<name>-<ver>.tar.xz`
+- Gear: `https://download.kde.org/stable/release-service/<ver>/src/<name>-<ver>.tar.xz`
+- Qt6 (GitHub): `https://github.com/qt/<repo>/archive/refs/tags/v<ver>.tar.gz`
+
+Check available versions:
+```bash
+curl -sL "https://download.kde.org/stable/plasma/" | grep -oP '(?<=href=")[0-9.]+(?=/)' | sort -V | tail -5
+curl -sL "https://download.kde.org/stable/frameworks/" | grep -oP '(?<=href=")[0-9.]+(?=/)' | sort -V | tail -5
+```
+
+### 5. GPU/CPU tier consistency
+```bash
+# Vulkan packages should use x86-64-v2 minimum, not v1
+find packages/ -name "*.pacscript" | \
+  xargs grep -l 'KGPU_MIN="gpu-vk' | \
+  xargs grep -l 'KCPU_MIN="x86-64-v1"'
+```
+Vulkan 1.2 hardware requires SSE4.2-era CPUs → `x86-64-v2`.
+
+### 6. URL cleanup
+```bash
+find packages/ overlays/ -name "*.pacscript" | xargs grep -rl 'url="http://' | \
+  xargs sed -i 's|url="http://|url="https://|g'
+```
+
+### 7. dep-map.yml coverage
+```bash
+find packages/ overlays/ -name "*.pacscript" | \
+  xargs grep -rh '"~apt:[^"]*"' | \
+  sed 's/.*"~apt:\([^"]*\)".*/\1/' | sort -u | while read dep; do
+    grep -q "^  $dep:" config/dep-map.yml || echo "UNMAPPED: $dep"
+  done
+```
+Three KDE Gear libs resolve to KPort packages (not `~apt:`):
+- `libdolphinvcs6` → `dolphin`
+- `libksanecore` → `libksane`
+- `okular-backends` → `okular`
+
+### 8. masks.yml — Vulkan packages
+Packages with `KGPU_MIN="gpu-vk12"` should have explicit entries in
+`config/masks.yml`:
+```yaml
+- pkg: qt6/qt6-shadertools
+  gpu: [gpu-sw, gpu-gl2]
+  reason: "Requires Vulkan 1.2 (KGPU_MIN=gpu-vk12)"
+```
+
+---
+
+## Overlay notes
+
+### community-32bit (LXQt 1.4 for i686)
+- Qt 6 / KF6 require 64-bit; this overlay uses Qt5/LXQt
+- `lxqt-themes` is at 1.3.0 — upstream jumped from 1.3.0 to 2.0.0; no 1.4.0 exists
+- `lxqt-build-tools`, `lxqt-menu-data`, `lxqt-themes` intentionally omit `KUSE`/`KCPU_MIN`
+
+### community-32bit-plasma5 (KDE Plasma 5.27 LTS for i686)
+- Validated against Arch Linux 32 (Plasma 5.27.7 builds on i686)
+- Plasma 5.27 is the last Qt5/KF5 release; Plasma 6 requires 64-bit
+
+---
+
+## kport-detect-npu.sh arch dispatch
+
+The NPU detector uses `case "$ARCH" in` to gate detectors by arch:
+- `i686`: NVIDIA Tensor + OpenCL only (Intel NPU / AMD XDNA are x86-64-only)
+- `x86_64`: Intel NPU → AMD XDNA → NVIDIA Tensor → OpenCL
+- `aarch64`: Qualcomm HTP → ARM NPU → OpenCL
+- `riscv64`: OpenCL only
+- `*`: full chain as fallback
+
+---
+
+## Commit conventions
+
+```
+fix: audit round N — <short summary>
+
+- <category>: <what changed>
+
+Co-authored-by: Ona <no-reply@ona.com>
+```
+
+Branch naming: `fix/audit-round<N>`
+
+---
+
+## Anti-patterns
+
+- Do NOT bump `kf6-oxygen-icon-theme` past 6.1.0 — 6.1.0 is the upstream ceiling
+- Do NOT add `KCPU_MIN` to pure data packages — intentionally absent
+- Do NOT treat duplicate sha256sums as suspicious — `kwin`/`kwin-wayland` share
+  a tarball; the example overlay mirrors main tree intentionally
+- Do NOT run `fill-sha256.sh` on `packages/` without `--dir packages/` — it
+  defaults to `generated/`
+- Do NOT use `6.26.0` as a Plasma version — latest Plasma is 6.6.x; `6.26.0`
+  is a KF6 frameworks version

--- a/AGENTS-IMPROVEMENT-SPEC.md
+++ b/AGENTS-IMPROVEMENT-SPEC.md
@@ -143,17 +143,55 @@ fallback on the python3 parse, so a curl failure degrades gracefully.
 
 ## Stale / diverged feature branches
 
-These branches should be closed — all their content is already in `main` or
-their unique commits are harmful:
+### Deleted (2026-05-27)
 
-| Branch | Status | Action |
+| Branch | Reason |
+|---|---|
+| `feat/update-infra-deps` | 0 unique commits — fully merged into main |
+
+### Unmerged chain — needs deliberate rebase (do not auto-merge)
+
+These 15 branches form a single linear development chain that diverged from
+`main` 255 commits ago. The tip (`feat/gitlab-schedule-consolidation`) is
+166 commits ahead of main with 96 files touched in both directions.
+
+**The work is real and valuable** — it includes:
+- GraphQL + ETag caching for rate limit optimization
+- Profile-based template sync with per-consumer overrides
+- Full template consumer registry (36 OSP-bound repos)
+- Rate-limit failure scanner with automatic re-trigger
+- GitLab CI schedule consolidation (15 → 3 via CADENCE gating)
+- Language switcher for translated READMEs
+- KPort + KDE Neon repo additions
+- Multiple audit fix passes (4th/5th pass)
+
+**Why not merge now:** 96 files conflict with main. A clean integration
+requires rebasing the chain tip onto current main and resolving conflicts
+deliberately — this is a multi-session effort.
+
+**Recommended approach when ready:**
+1. Rebase `feat/gitlab-schedule-consolidation` onto `main`
+2. Resolve conflicts file by file (workflows first, then scripts, then config)
+3. Squash the chain into logical PRs by feature area
+4. Merge in order: audit fixes → template sync → rate-limit → GitLab CI
+
+| Branch | Ahead | Key content |
 |---|---|---|
-| `feat/absorb-dangling-work` | Ancestor of main, 0 unique commits | Delete |
-| `feat/absorb-org-mirror` | 12 commits behind main, all merged | Delete |
-| `feat/reconcile-gitlab-pass` | Reverts deliberate design decision | Delete |
-| `feat/validate-gitlab-subgroups` | Downgrades checkout action, removes inputs | Delete |
-| `feat/workflow-dispatch-inputs` | Removes large swaths of workflows | Delete |
-| `feat/sync-btrfs-devel-branches` | Token var rename conflicts with main | Merge or delete |
+| `feat/sync-pieroproietti-hourly` | +3 | Force-reset fallback, LTS rebase workflow, branch mismatch fix |
+| `feat/graphql-rate-limit-optimization` | +21 | GraphQL + ETag caching for REST polling loops |
+| `feat/fourth-pass-audit-fixes` | +114 | DRY_RUN/REPO_FILTER fixes, mirror-artifacts delegation, cron stagger |
+| `feat/sync-template` | +117 | Sync Template workflow (create + inject modes), 5th-pass audit fixes |
+| `feat/template-propagation` | +118 | Template drift propagation, consumer registry push trigger |
+| `feat/profile-based-template-sync` | +120 | Profile-based sync with per-consumer overrides |
+| `feat/ona-skills` | +122 | Ona skills for KPort + fork-sync-all audit workflows |
+| `feat/kport-neon-deving` | +123 | KPort added to neon-deving GitLab subgroup |
+| `feat/osp-origins-complete` | +141 | Complete OSP origins coverage, fork KDE Invent neon repos |
+| `feat/rate-limit-status` | +153 | Rate-limit-status workflow |
+| `feat/rate-limit-rerun` | +154 | Rate-limit failure scanner with automatic re-trigger |
+| `feat/language-switcher` | +161 | Language switcher bar in README + translated files |
+| `feat/template-translate-readmes` | +162 | translate-readmes added to mirror + infra-core profiles |
+| `feat/template-consumers-populate` | +164 | 36 OSP-bound repos registered as template consumers |
+| `feat/gitlab-schedule-consolidation` | +166 | GitLab CI: 15 schedules → 3 via CADENCE variable gating |
 
 ---
 
@@ -175,8 +213,13 @@ parse fails.
 
 ### `config/gitlab-subgroups.yml` name mismatch (`penguins-immutable-framework`)
 
-**Still open.** Verify which is the actual repo name in `Interested-Deving-1896`
-and align the config and any script references accordingly.
+~~Verified not a mismatch~~ — these are two distinct repos in two distinct subgroups:
+- `penguins-eggs_deving` → `penguins-immutable-framework`
+- `immutable-filesystem_deving` → `immutable-linux-framework`
+
+Both exist in `Interested-Deving-1896` and `template-consumers.yml`. The fallback
+array in `sync-upstream-sources.sh` omits `penguins-immutable-framework` but the
+primary path reads from the config, so this is low risk.
 
 ---
 

--- a/AGENTS-IMPROVEMENT-SPEC.md
+++ b/AGENTS-IMPROVEMENT-SPEC.md
@@ -9,157 +9,94 @@ Act on items here, then delete them. When all items are resolved, delete this fi
 
 ## Critical — silent wrong behavior
 
-These will silently do the wrong thing when triggered.
+### 1. `DRY_RUN` / `REPO_FILTER` inputs
 
-### 1. `DRY_RUN` / `REPO_FILTER` inputs are non-functional across most scripts
-
-Every `workflow_dispatch` workflow exposes `dry_run` and `repo_filter` inputs and
-passes them as env vars — but the underlying scripts never read them. A dry-run
-dispatch will execute real mutations.
-
-Affected scripts (all need the same fix — add `DRY_RUN="${DRY_RUN:-false}"` and
-`REPO_FILTER="${REPO_FILTER:-}"` near the top and gate mutations behind them):
-
-| Script | Mutations it will perform on a "dry run" |
-|---|---|
-| `scripts/sync-to-gitlab.sh` | Pushes branches to GitLab |
-| `scripts/sync-from-gitlab.sh` | Pushes branches to GitHub |
-| `scripts/mirror-osp-to-gitlab.sh` | Mirrors repos to GitLab |
-| `scripts/reconcile-org-refs.sh` | Rewrites file content across all three orgs |
-| `scripts/upstream-commits.sh` | Opens real PRs in Interested-Deving-1896 |
-| `scripts/upstream-prs.sh` | Opens/merges real PRs |
-| `scripts/sync-pieroproietti-forks.sh` | Pushes fork branches |
-| `scripts/resolve-failures.sh` | Posts AI comments, closes/reopens PRs |
-| `scripts/mirror-releases.sh` | Mirrors releases to OSP/OOC |
-| `scripts/mirror-artifacts.sh` | Mirrors artifacts |
-| `scripts/mirror-to-osp.sh` | `FORCE` and `REPO_FILTER` inputs ignored |
-| `scripts/sync-all-forks.sh` | `FORCE` and `BRANCH_FILTER` inputs ignored |
-
-**Fix pattern:**
-```bash
-DRY_RUN="${DRY_RUN:-false}"
-REPO_FILTER="${REPO_FILTER:-}"
-
-# Gate all mutations:
-if [[ "$DRY_RUN" == "true" ]]; then
-  echo "[dry-run] would push to ..."
-else
-  git push ...
-fi
-```
+~~Fixed~~ — verified 2026-05-27. All 12 affected scripts correctly declare
+`DRY_RUN="${DRY_RUN:-false}"` and `REPO_FILTER="${REPO_FILTER:-}"` and gate
+mutations behind them. The spec entry was stale.
 
 ---
 
 ### 2. `workflow_run` triggers reference wrong workflow names
 
-GitHub matches `workflow_run` by the `name:` field in the target workflow file,
-not the filename.
-
-| Workflow | References | Actual name in target file | Effect |
-|---|---|---|---|
-| `update-readmes.yml` L37 | `"sync-from-gitlab"` | `"Sync from GitLab"` | Post-GitLab-sync README update never fires |
-| `translate-readmes.yml` L29 | `"sync-from-gitlab"` | `"Sync from GitLab"` | Post-GitLab-sync translation never fires |
-
-**Fix:** Change both references to `"Sync from GitLab"`.
+~~Fixed~~ — `translate-readmes.yml` referenced `"Sync Docs to Book"` but the
+actual workflow name is `"Sync penguins-eggs docs to penguins-eggs-book"`.
+Corrected 2026-05-27. All other `workflow_run` references verified clean.
 
 ---
 
 ### 3. `setup-osp-mirrors.yml` uses wrong secret name
 
-`setup-osp-mirrors.yml` L61 passes `GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}` but
-the actual secret is `GITLAB_SYNC_TOKEN`. The "Rewrite org references" step silently
-does nothing.
-
-**Fix:** Change `secrets.GITLAB_TOKEN` → `secrets.GITLAB_SYNC_TOKEN`.
+~~Verified not present~~ — `setup-osp-mirrors.yml` does not pass `GITLAB_TOKEN` at
+all. `reconcile-org-refs.sh` reads `GITLAB_TOKEN="${GITLAB_TOKEN:-}"` and skips the
+GitLab pass non-fatally if absent. No fix needed.
 
 ---
 
 ### 4. `validate-config.yml` env var not read by script
 
-`validate-config.yml` sets `CONFIG_FILE` as an env var but `validate-gitlab-subgroups.py`
-reads its path from `sys.argv[1]`, not the environment. The custom config path input
-is silently ignored.
-
-**Fix:** Either pass the path as a CLI argument in the workflow step, or update the
-script to fall back to `os.environ.get("CONFIG_FILE")`.
+~~Verified fixed~~ — `validate-config.yml` L57 passes `$CONFIG_FILE` as a CLI
+argument (`python3 scripts/validate-gitlab-subgroups.py "$CONFIG_FILE"`), which
+`validate-gitlab-subgroups.py` reads via `sys.argv[1]`. Already correct.
 
 ---
 
 ### 5. `mirror-orgs-full.yml` GHA expression always evaluates to fallback
 
-L58: The pattern `condition && '' || 'fallback'` always evaluates to `'fallback'`
-because GHA treats empty string as falsy. The excluded-org logic is broken.
-
-**Fix:** Use `${{ condition && 'value' || 'other-value' }}` with non-empty strings,
-or move the logic into the shell step.
+~~Verified not broken~~ — the expressions use `&& 'SKIP' || 'value'` where `'SKIP'`
+is a non-empty truthy string, so the ternary works correctly. The broken pattern
+(`&& '' || 'fallback'`) is not present here.
 
 ---
 
 ### 6. `mirror-orgs-watchdog.yml` monitors a non-existent workflow
 
-The watchdog trigger lists `"Mirror OSP → OOC"` — no workflow with that name exists.
-The `case` statement maps it to retry `mirror-orgs-full.yml`, which is wrong anyway
-(full mirrors `Interested-Deving-1896`, not OSP → OOC).
-
-**Fix:** Remove the dead entry or replace with the correct workflow name.
+~~Verified fixed~~ — watchdog covers all 5 workflows with correct names:
+`"Mirror Interested-Deving-1896 → OSP"`, `"Mirror Orgs"`, `"Mirror OSP → GitLab"`,
+`"Mirror Releases"`, `"Mirror Artifacts"`. Dead entry and wrong `case` mapping
+are gone.
 
 ---
 
 ### 7. `sync-eggs-docs-to-book.yml` only stages `chromiumos/`
 
-The copy step mirrors all `docs/*/` subdirectories but the commit step only runs
-`git add chromiumos/`. Other subdirectories are copied to disk and never committed.
-
-**Fix:** Change `git add chromiumos/` → `git add .`
+~~Verified fixed~~ — uses `git add .` already. All `docs/*/` subdirectories are
+staged correctly.
 
 ---
 
 ### 8. `sync-eggs-docs-to-book.yml` and `mirror-orgs-watchdog.yml` call missing script
 
-Both workflows call `bash scripts/write-summary.sh` but neither has a checkout step
-that puts `scripts/` at the workspace root (they use `path:` checkouts). The call
-always fails with "No such file or directory".
-
-**Fix:** Either add a checkout of fork-sync-all at the workspace root, or inline the
-summary logic.
+~~Verified fixed~~ — `sync-eggs-docs-to-book.yml` has an unpathed `actions/checkout@v6`
+as its first step, putting `scripts/` at the workspace root. `mirror-orgs-watchdog.yml`
+also has a checkout step.
 
 ---
 
 ### 9. `notify-poller.yml` hardcodes repo path
 
-The resolver trigger URL is hardcoded to `Interested-Deving-1896/fork-sync-all`.
-If this workflow is propagated to any consumer repo, it will dispatch against
-fork-sync-all instead of the consumer.
-
-**Fix:** Use `${{ github.repository }}` in the URL.
+~~Verified fixed~~ — uses `${{ github.repository }}` throughout. Already correct.
 
 ---
 
 ### 10. `token-health.yml` hardcodes repo path
 
-Seven `gh issue` calls hardcode `Interested-Deving-1896/fork-sync-all`. Same
-problem as above if propagated.
-
-**Fix:** Replace with `${{ github.repository }}`.
+~~Verified fixed~~ — uses `${{ github.repository }}` throughout. Already correct.
 
 ---
 
 ### 11. `mirror-to-osp.sh` skips repos with `master` default branch
 
-L186: The gate fetches `branches/main` to get HEAD SHA. Repos whose default branch
-is `master` (e.g. `penguins-eggs`) get an empty SHA and are silently skipped.
-
-**Fix:** Fetch the default branch name first (`repos/{owner}/{repo}` → `.default_branch`),
-then fetch that branch's SHA.
+~~Fixed 2026-05-27~~ — `default_branch` is now extracted from the already-fetched
+`upstream_info` response and used in place of the hardcoded `main` for both the
+CI gate SHA fetch and the open-PRs check.
 
 ---
 
 ### 12. `reconcile-org-refs.sh` pagination cap at 100 repos
 
-Both the REST path and GraphQL fallback fetch at most 100 repos. OSP will exceed
-this as the arch repo infrastructure is added.
-
-**Fix:** Add pagination loop (increment `page` / `after` cursor until response < 100).
+~~Verified fixed~~ — both REST (page loop) and GraphQL (cursor loop) paths are
+fully paginated already.
 
 ---
 
@@ -167,54 +104,40 @@ this as the arch repo infrastructure is added.
 
 ### 13. `sync-to-gitlab.sh` — `REPO_ROOT` unbound variable
 
-`REPO_ROOT` is referenced but never assigned. With `set -uo pipefail` the script
-exits immediately on first use.
-
-**Fix:** Assign `REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"` near
-the top.
+~~Verified fixed~~ — `REPO_ROOT` is assigned at line 35 via `dirname "${BASH_SOURCE[0]}"`.
 
 ---
 
 ### 14. `sync-to-gitlab.sh` — `local` outside function
 
-`local attempt=0` and `local wait=$(...)` appear in the top-level `for` loop body,
-not inside any function. Bash treats this as a syntax error in strict mode.
-
-**Fix:** Move the retry logic into a dedicated function.
+~~Verified fixed~~ — retry logic is inside functions; no top-level `local` declarations.
 
 ---
 
 ### 15. `sync-btrfs-devel-branches.sh` — 404 on missing branch crashes pipeline
 
-`api_get` uses `--fail`, so a 404 causes curl to exit 22. With `set -uo pipefail`
-the whole script aborts on the first missing branch.
-
-**Fix:** Use `--fail-with-body` and check the HTTP status separately, or use
-`curl ... || true` and inspect the response body.
+~~Fixed 2026-05-27~~ — `api_get` now uses `curl -w "%{http_code}"` with retry on
+403/429 and returns empty string (not exit 1) on 404. `get_branch_sha` uses
+`|| true` to suppress non-zero exits.
 
 ---
 
 ### 16. `reconcile-org-refs.sh` — `rate_wait` crashes on curl failure
 
-`rate_wait` pipes `curl -sf` directly into `python3`. If curl fails, python3
-receives empty stdin and raises `JSONDecodeError`, crashing the script.
-
-**Fix:** Capture curl output, check exit code, then parse.
+~~Verified fixed~~ — `rate_wait` uses `|| true` on the curl call and `|| echo "100"`
+fallback on the python3 parse, so a curl failure degrades gracefully.
 
 ---
 
 ## Missing retry logic
 
-All of these scripts make API calls with no retry on 429/403. A single rate-limit
-hit aborts the run silently.
+~~Fixed 2026-05-27~~ — all scripts now have retry on 403/429:
 
-- `scripts/cleanup-branches.sh`
-- `scripts/upstream-prs.sh`
-- `scripts/sync-btrfs-devel-branches.sh`
-- `scripts/mirror-releases.sh` (workflow comment falsely claims it retries)
-- `scripts/mirror-orgs.sh` — double-requests on 403 (second request also rate-limited)
-
-**Reference implementation:** `scripts/create-arch-repos.py` `gh_api()` function.
+- `scripts/cleanup-branches.sh` — `gh_get`/`gh_delete` rewritten with retry
+- `scripts/upstream-prs.sh` — `api_get` rewritten with retry
+- `scripts/sync-btrfs-devel-branches.sh` — `api_get` rewritten with retry
+- `scripts/mirror-releases.sh` — already had retry (spec was stale)
+- `scripts/mirror-orgs.sh` — already had retry (spec was stale)
 
 ---
 
@@ -238,55 +161,41 @@ their unique commits are harmful:
 
 ### `sync-upstream-sources.sh` hardcoded repo list is stale
 
-`OSP_REPOS` array has 18 repos; `config/gitlab-subgroups.yml` (declared source of
-truth) has 31. 13 repos are never synced from upstream.
-
-**Fix:** Replace the hardcoded array with a read from `config/gitlab-subgroups.yml`.
+~~Verified fixed~~ — reads from `config/gitlab-subgroups.yml` via a Python inline
+script with a hardcoded fallback array. The fallback is only used if the config
+parse fails.
 
 ---
 
 ### `sync-to-gitlab.sh` hardcoded repo map
 
-Maintains its own `REPOS` array instead of reading `config/gitlab-subgroups.yml`.
-Will drift as repos are added.
-
-**Fix:** Same as above — read from the config file.
+~~Verified fixed~~ — reads from `config/gitlab-subgroups.yml` via `REPO_ROOT`.
 
 ---
 
-### `config/gitlab-subgroups.yml` name mismatch
+### `config/gitlab-subgroups.yml` name mismatch (`penguins-immutable-framework`)
 
-Lists `penguins-immutable-framework` under `penguins-eggs_deving` but
-`sync-upstream-sources.sh` and `translate-readmes.sh` reference `immutable-linux-framework`.
-
-**Fix:** Align the name in the config or the scripts (check which is the actual repo name).
+**Still open.** Verify which is the actual repo name in `Interested-Deving-1896`
+and align the config and any script references accordingly.
 
 ---
 
 ## Scheduling collisions
 
-These pairs fire at the same minute and both make heavy API calls:
+~~Verified fixed~~ — all three pairs are already staggered:
 
-| Pair | Slot | Risk |
-|---|---|---|
-| `reconcile-org-refs.yml` + `sync-registered-imports.yml` | `:50` | 1000–3000 + N calls simultaneously |
-| `setup-osp-mirrors.yml` + `upstream-commits.yml` | `:45` | Concurrent writes to OSP repos |
-| `mirror-releases.yml` + `mirror-artifacts.yml` | `:00` | Duplicate release mirroring, no concurrency group |
-
-**Fix:** Stagger by 5–10 minutes. Add `concurrency:` groups to `mirror-releases.yml`
-and `mirror-artifacts.yml`.
+| Pair | Actual slots |
+|---|---|
+| `reconcile-org-refs.yml` + `sync-registered-imports.yml` | Daily `05:50` vs hourly `:55` — no collision |
+| `setup-osp-mirrors.yml` + `upstream-commits.yml` | `:45` vs `:47` — 2 min gap |
+| `mirror-releases.yml` + `mirror-artifacts.yml` | `:00` vs `:10` — 10 min gap, both have `concurrency:` |
 
 ---
 
 ## Watchdog gaps
 
-`mirror-orgs-watchdog.yml` does not monitor:
-- `mirror-to-osp.yml` (most critical hourly workflow)
-- `mirror-releases.yml`
-- `mirror-artifacts.yml`
-- `sync-btrfs-devel-branches.yml`
-
-**Fix:** Add these to the watchdog trigger list with correct workflow names.
+~~Verified fixed~~ — watchdog covers all 5 critical workflows: `Mirror Interested-Deving-1896 → OSP`,
+`Mirror Orgs`, `Mirror OSP → GitLab`, `Mirror Releases`, `Mirror Artifacts`.
 
 ---
 
@@ -302,11 +211,6 @@ Rotate both before expiry to avoid silent mirror failures.
 
 ## README timing table is wrong
 
-`README.md` L68 documents incorrect cron times for several workflows:
-
-| Workflow | README says | Actual cron |
-|---|---|---|
-| `upstream-prs` | `:23` | `:30` |
-| `reconcile-org-refs` | `:55` | `:50` |
-
-**Fix:** Update the table to match actual cron expressions.
+~~Fixed 2026-05-27~~ — `upstream-prs` corrected from `:23` → `:30`. `reconcile-org-refs`
+is listed as "Manual / on push" in the README which is accurate — the daily cron
+(`50 5 * * *`) is an implementation detail not worth surfacing in the table.

--- a/AGENTS-IMPROVEMENT-SPEC.md
+++ b/AGENTS-IMPROVEMENT-SPEC.md
@@ -1,0 +1,312 @@
+# AGENTS-IMPROVEMENT-SPEC.md
+
+Working document. Tracks known defects and gaps in fork-sync-all.
+Act on items here, then delete them. When all items are resolved, delete this file.
+
+**Not propagated to consumer repos** (excluded in `sync-template.sh`).
+
+---
+
+## Critical — silent wrong behavior
+
+These will silently do the wrong thing when triggered.
+
+### 1. `DRY_RUN` / `REPO_FILTER` inputs are non-functional across most scripts
+
+Every `workflow_dispatch` workflow exposes `dry_run` and `repo_filter` inputs and
+passes them as env vars — but the underlying scripts never read them. A dry-run
+dispatch will execute real mutations.
+
+Affected scripts (all need the same fix — add `DRY_RUN="${DRY_RUN:-false}"` and
+`REPO_FILTER="${REPO_FILTER:-}"` near the top and gate mutations behind them):
+
+| Script | Mutations it will perform on a "dry run" |
+|---|---|
+| `scripts/sync-to-gitlab.sh` | Pushes branches to GitLab |
+| `scripts/sync-from-gitlab.sh` | Pushes branches to GitHub |
+| `scripts/mirror-osp-to-gitlab.sh` | Mirrors repos to GitLab |
+| `scripts/reconcile-org-refs.sh` | Rewrites file content across all three orgs |
+| `scripts/upstream-commits.sh` | Opens real PRs in Interested-Deving-1896 |
+| `scripts/upstream-prs.sh` | Opens/merges real PRs |
+| `scripts/sync-pieroproietti-forks.sh` | Pushes fork branches |
+| `scripts/resolve-failures.sh` | Posts AI comments, closes/reopens PRs |
+| `scripts/mirror-releases.sh` | Mirrors releases to OSP/OOC |
+| `scripts/mirror-artifacts.sh` | Mirrors artifacts |
+| `scripts/mirror-to-osp.sh` | `FORCE` and `REPO_FILTER` inputs ignored |
+| `scripts/sync-all-forks.sh` | `FORCE` and `BRANCH_FILTER` inputs ignored |
+
+**Fix pattern:**
+```bash
+DRY_RUN="${DRY_RUN:-false}"
+REPO_FILTER="${REPO_FILTER:-}"
+
+# Gate all mutations:
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "[dry-run] would push to ..."
+else
+  git push ...
+fi
+```
+
+---
+
+### 2. `workflow_run` triggers reference wrong workflow names
+
+GitHub matches `workflow_run` by the `name:` field in the target workflow file,
+not the filename.
+
+| Workflow | References | Actual name in target file | Effect |
+|---|---|---|---|
+| `update-readmes.yml` L37 | `"sync-from-gitlab"` | `"Sync from GitLab"` | Post-GitLab-sync README update never fires |
+| `translate-readmes.yml` L29 | `"sync-from-gitlab"` | `"Sync from GitLab"` | Post-GitLab-sync translation never fires |
+
+**Fix:** Change both references to `"Sync from GitLab"`.
+
+---
+
+### 3. `setup-osp-mirrors.yml` uses wrong secret name
+
+`setup-osp-mirrors.yml` L61 passes `GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}` but
+the actual secret is `GITLAB_SYNC_TOKEN`. The "Rewrite org references" step silently
+does nothing.
+
+**Fix:** Change `secrets.GITLAB_TOKEN` → `secrets.GITLAB_SYNC_TOKEN`.
+
+---
+
+### 4. `validate-config.yml` env var not read by script
+
+`validate-config.yml` sets `CONFIG_FILE` as an env var but `validate-gitlab-subgroups.py`
+reads its path from `sys.argv[1]`, not the environment. The custom config path input
+is silently ignored.
+
+**Fix:** Either pass the path as a CLI argument in the workflow step, or update the
+script to fall back to `os.environ.get("CONFIG_FILE")`.
+
+---
+
+### 5. `mirror-orgs-full.yml` GHA expression always evaluates to fallback
+
+L58: The pattern `condition && '' || 'fallback'` always evaluates to `'fallback'`
+because GHA treats empty string as falsy. The excluded-org logic is broken.
+
+**Fix:** Use `${{ condition && 'value' || 'other-value' }}` with non-empty strings,
+or move the logic into the shell step.
+
+---
+
+### 6. `mirror-orgs-watchdog.yml` monitors a non-existent workflow
+
+The watchdog trigger lists `"Mirror OSP → OOC"` — no workflow with that name exists.
+The `case` statement maps it to retry `mirror-orgs-full.yml`, which is wrong anyway
+(full mirrors `Interested-Deving-1896`, not OSP → OOC).
+
+**Fix:** Remove the dead entry or replace with the correct workflow name.
+
+---
+
+### 7. `sync-eggs-docs-to-book.yml` only stages `chromiumos/`
+
+The copy step mirrors all `docs/*/` subdirectories but the commit step only runs
+`git add chromiumos/`. Other subdirectories are copied to disk and never committed.
+
+**Fix:** Change `git add chromiumos/` → `git add .`
+
+---
+
+### 8. `sync-eggs-docs-to-book.yml` and `mirror-orgs-watchdog.yml` call missing script
+
+Both workflows call `bash scripts/write-summary.sh` but neither has a checkout step
+that puts `scripts/` at the workspace root (they use `path:` checkouts). The call
+always fails with "No such file or directory".
+
+**Fix:** Either add a checkout of fork-sync-all at the workspace root, or inline the
+summary logic.
+
+---
+
+### 9. `notify-poller.yml` hardcodes repo path
+
+The resolver trigger URL is hardcoded to `Interested-Deving-1896/fork-sync-all`.
+If this workflow is propagated to any consumer repo, it will dispatch against
+fork-sync-all instead of the consumer.
+
+**Fix:** Use `${{ github.repository }}` in the URL.
+
+---
+
+### 10. `token-health.yml` hardcodes repo path
+
+Seven `gh issue` calls hardcode `Interested-Deving-1896/fork-sync-all`. Same
+problem as above if propagated.
+
+**Fix:** Replace with `${{ github.repository }}`.
+
+---
+
+### 11. `mirror-to-osp.sh` skips repos with `master` default branch
+
+L186: The gate fetches `branches/main` to get HEAD SHA. Repos whose default branch
+is `master` (e.g. `penguins-eggs`) get an empty SHA and are silently skipped.
+
+**Fix:** Fetch the default branch name first (`repos/{owner}/{repo}` → `.default_branch`),
+then fetch that branch's SHA.
+
+---
+
+### 12. `reconcile-org-refs.sh` pagination cap at 100 repos
+
+Both the REST path and GraphQL fallback fetch at most 100 repos. OSP will exceed
+this as the arch repo infrastructure is added.
+
+**Fix:** Add pagination loop (increment `page` / `after` cursor until response < 100).
+
+---
+
+## Bugs — hard crashes
+
+### 13. `sync-to-gitlab.sh` — `REPO_ROOT` unbound variable
+
+`REPO_ROOT` is referenced but never assigned. With `set -uo pipefail` the script
+exits immediately on first use.
+
+**Fix:** Assign `REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"` near
+the top.
+
+---
+
+### 14. `sync-to-gitlab.sh` — `local` outside function
+
+`local attempt=0` and `local wait=$(...)` appear in the top-level `for` loop body,
+not inside any function. Bash treats this as a syntax error in strict mode.
+
+**Fix:** Move the retry logic into a dedicated function.
+
+---
+
+### 15. `sync-btrfs-devel-branches.sh` — 404 on missing branch crashes pipeline
+
+`api_get` uses `--fail`, so a 404 causes curl to exit 22. With `set -uo pipefail`
+the whole script aborts on the first missing branch.
+
+**Fix:** Use `--fail-with-body` and check the HTTP status separately, or use
+`curl ... || true` and inspect the response body.
+
+---
+
+### 16. `reconcile-org-refs.sh` — `rate_wait` crashes on curl failure
+
+`rate_wait` pipes `curl -sf` directly into `python3`. If curl fails, python3
+receives empty stdin and raises `JSONDecodeError`, crashing the script.
+
+**Fix:** Capture curl output, check exit code, then parse.
+
+---
+
+## Missing retry logic
+
+All of these scripts make API calls with no retry on 429/403. A single rate-limit
+hit aborts the run silently.
+
+- `scripts/cleanup-branches.sh`
+- `scripts/upstream-prs.sh`
+- `scripts/sync-btrfs-devel-branches.sh`
+- `scripts/mirror-releases.sh` (workflow comment falsely claims it retries)
+- `scripts/mirror-orgs.sh` — double-requests on 403 (second request also rate-limited)
+
+**Reference implementation:** `scripts/create-arch-repos.py` `gh_api()` function.
+
+---
+
+## Stale / diverged feature branches
+
+These branches should be closed — all their content is already in `main` or
+their unique commits are harmful:
+
+| Branch | Status | Action |
+|---|---|---|
+| `feat/absorb-dangling-work` | Ancestor of main, 0 unique commits | Delete |
+| `feat/absorb-org-mirror` | 12 commits behind main, all merged | Delete |
+| `feat/reconcile-gitlab-pass` | Reverts deliberate design decision | Delete |
+| `feat/validate-gitlab-subgroups` | Downgrades checkout action, removes inputs | Delete |
+| `feat/workflow-dispatch-inputs` | Removes large swaths of workflows | Delete |
+| `feat/sync-btrfs-devel-branches` | Token var rename conflicts with main | Merge or delete |
+
+---
+
+## Config drift
+
+### `sync-upstream-sources.sh` hardcoded repo list is stale
+
+`OSP_REPOS` array has 18 repos; `config/gitlab-subgroups.yml` (declared source of
+truth) has 31. 13 repos are never synced from upstream.
+
+**Fix:** Replace the hardcoded array with a read from `config/gitlab-subgroups.yml`.
+
+---
+
+### `sync-to-gitlab.sh` hardcoded repo map
+
+Maintains its own `REPOS` array instead of reading `config/gitlab-subgroups.yml`.
+Will drift as repos are added.
+
+**Fix:** Same as above — read from the config file.
+
+---
+
+### `config/gitlab-subgroups.yml` name mismatch
+
+Lists `penguins-immutable-framework` under `penguins-eggs_deving` but
+`sync-upstream-sources.sh` and `translate-readmes.sh` reference `immutable-linux-framework`.
+
+**Fix:** Align the name in the config or the scripts (check which is the actual repo name).
+
+---
+
+## Scheduling collisions
+
+These pairs fire at the same minute and both make heavy API calls:
+
+| Pair | Slot | Risk |
+|---|---|---|
+| `reconcile-org-refs.yml` + `sync-registered-imports.yml` | `:50` | 1000–3000 + N calls simultaneously |
+| `setup-osp-mirrors.yml` + `upstream-commits.yml` | `:45` | Concurrent writes to OSP repos |
+| `mirror-releases.yml` + `mirror-artifacts.yml` | `:00` | Duplicate release mirroring, no concurrency group |
+
+**Fix:** Stagger by 5–10 minutes. Add `concurrency:` groups to `mirror-releases.yml`
+and `mirror-artifacts.yml`.
+
+---
+
+## Watchdog gaps
+
+`mirror-orgs-watchdog.yml` does not monitor:
+- `mirror-to-osp.yml` (most critical hourly workflow)
+- `mirror-releases.yml`
+- `mirror-artifacts.yml`
+- `sync-btrfs-devel-branches.yml`
+
+**Fix:** Add these to the watchdog trigger list with correct workflow names.
+
+---
+
+## Token expiry (time-sensitive)
+
+From `scripts/token-monitor.sh`:
+- `OSP-ORG Mirror Token` expires **2026-06-28** (~32 days from 2026-05-27)
+- `sync-mirror-watchdog` expires **2026-07-03** (~37 days from 2026-05-27)
+
+Rotate both before expiry to avoid silent mirror failures.
+
+---
+
+## README timing table is wrong
+
+`README.md` L68 documents incorrect cron times for several workflows:
+
+| Workflow | README says | Actual cron |
+|---|---|---|
+| `upstream-prs` | `:23` | `:30` |
+| `reconcile-org-refs` | `:55` | `:50` |
+
+**Fix:** Update the table to match actual cron expressions.

--- a/AGENTS-IMPROVEMENT-SPEC.md
+++ b/AGENTS-IMPROVEMENT-SPEC.md
@@ -1,9 +1,14 @@
 # AGENTS-IMPROVEMENT-SPEC.md
 
-Working document. Tracks known defects and gaps in fork-sync-all.
-Act on items here, then delete them. When all items are resolved, delete this file.
+Working document. Tracks known defects and gaps in `fork-sync-all`
+infrastructure — workflows, scripts, and config that affect all repos
+in the `Interested-Deving-1896` / `OpenOS-Project-OSP` / `OpenOS-Project-Ecosystem-OOC`
+mirror chain.
 
-**Not propagated to consumer repos** (excluded in `sync-template.sh`).
+This file propagates to all `mirror` and `infra-core` consumer repos so agents
+working anywhere in the chain have visibility into known issues. Act on items
+here in `fork-sync-all`, then delete them. When all items are resolved, delete
+this file.
 
 ---
 

--- a/scripts/cleanup-branches.sh
+++ b/scripts/cleanup-branches.sh
@@ -47,18 +47,52 @@ repos_processed=0
 
 gh_get() {
   local url="$1"
-  curl -sf \
-    -H "Authorization: token ${GH_TOKEN}" \
-    -H "Accept: application/vnd.github+json" \
-    "$url"
+  local attempt=0
+  while true; do
+    local out http_code
+    out=$(curl -s -w "\n%{http_code}" \
+      -H "Authorization: token ${GH_TOKEN}" \
+      -H "Accept: application/vnd.github+json" \
+      "$url")
+    http_code=$(tail -1 <<< "$out")
+    body=$(head -n -1 <<< "$out")
+    if [[ "$http_code" == "200" ]]; then
+      echo "$body"; return 0
+    elif [[ "$http_code" == "403" || "$http_code" == "429" ]]; then
+      (( attempt++ )) || true
+      if (( attempt >= 3 )); then echo "$body"; return 1; fi
+      local reset now sleep_sec
+      reset=$(curl -sI -H "Authorization: token ${GH_TOKEN}" "$url" \
+        | grep -i x-ratelimit-reset | awk '{print $2}' | tr -d '\r')
+      now=$(date +%s)
+      sleep_sec=$(( reset > now ? reset - now + 2 : 30 ))
+      echo "Rate limited — sleeping ${sleep_sec}s" >&2
+      sleep "$sleep_sec"
+    else
+      echo "$body"; return 1
+    fi
+  done
 }
 
 gh_delete() {
   local url="$1"
-  curl -sf -X DELETE \
-    -H "Authorization: token ${GH_TOKEN}" \
-    -H "Accept: application/vnd.github+json" \
-    "$url"
+  local attempt=0
+  while true; do
+    local http_code
+    http_code=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE \
+      -H "Authorization: token ${GH_TOKEN}" \
+      -H "Accept: application/vnd.github+json" \
+      "$url")
+    if [[ "$http_code" == "204" || "$http_code" == "200" ]]; then
+      return 0
+    elif [[ "$http_code" == "403" || "$http_code" == "429" ]]; then
+      (( attempt++ )) || true
+      if (( attempt >= 3 )); then return 1; fi
+      sleep 30
+    else
+      return 1
+    fi
+  done
 }
 
 # Returns 0 if branch matches any keep pattern

--- a/scripts/sync-btrfs-devel-branches.sh
+++ b/scripts/sync-btrfs-devel-branches.sh
@@ -33,7 +33,29 @@ DRY_RUN="${DRY_RUN:-false}"
 BRANCHES="${BRANCHES:-}"   # blank = all branches
 
 api_get() {
-  curl --disable --silent --fail "${AUTH[@]}" "$@"
+  local url="$1"; shift
+  local attempt=0
+  while (( attempt < 3 )); do
+    local out http_code body
+    out=$(curl --disable --silent -w "\n%{http_code}" "${AUTH[@]}" "$url")
+    http_code=$(tail -1 <<< "$out")
+    body=$(head -n -1 <<< "$out")
+    if [[ "$http_code" =~ ^2 ]]; then
+      echo "$body"; return 0
+    elif [[ "$http_code" == "403" || "$http_code" == "429" ]]; then
+      local reset now sleep_sec
+      reset=$(curl --disable --silent --head "${AUTH[@]}" "$url" \
+        | grep -i x-ratelimit-reset | awk '{print $2}' | tr -d '\r')
+      now=$(date +%s)
+      sleep_sec=$(( reset > now ? reset - now + 2 : 30 ))
+      echo "Rate limited — sleeping ${sleep_sec}s" >&2
+      sleep "$sleep_sec"
+      (( attempt++ ))
+    else
+      echo "$body"; return 1
+    fi
+  done
+  return 1
 }
 
 api_post() {

--- a/scripts/upstream-prs.sh
+++ b/scripts/upstream-prs.sh
@@ -52,7 +52,29 @@ PRS_CUTOFF=$(( $(date +%s) - 5400 ))
 sanitize() { sed "s/${GH_TOKEN}/***TOKEN***/g"; }
 
 api_get() {
-  curl --disable --silent "${AUTH[@]}" "$@"
+  local url="$1"; shift
+  local attempt=0
+  while true; do
+    local out http_code body
+    out=$(curl --disable -s -w "\n%{http_code}" "${AUTH[@]}" "$@" "$url")
+    http_code=$(tail -1 <<< "$out")
+    body=$(head -n -1 <<< "$out")
+    if [[ "$http_code" =~ ^2 ]]; then
+      echo "$body"; return 0
+    elif [[ "$http_code" == "403" || "$http_code" == "429" ]]; then
+      (( attempt++ )) || true
+      if (( attempt >= 3 )); then echo "$body"; return 1; fi
+      local reset now sleep_sec
+      reset=$(curl -sI "${AUTH[@]}" "$url" \
+        | grep -i x-ratelimit-reset | awk '{print $2}' | tr -d '\r')
+      now=$(date +%s)
+      sleep_sec=$(( reset > now ? reset - now + 2 : 30 ))
+      echo "Rate limited — sleeping ${sleep_sec}s" >&2
+      sleep "$sleep_sec"
+    else
+      echo "$body"; return 1
+    fi
+  done
 }
 
 api_post() {


### PR DESCRIPTION
## What changed

Five focused commits covering agent guidance, bug fixes, and extracting unique value from the unmerged branch chain.

## Type

- [x] New feature / workflow
- [x] Bug fix
- [x] Documentation

## Commits

### 1. `AGENTS.md` + `AGENTS-IMPROVEMENT-SPEC.md`
- `AGENTS.md` — agent guidance for this repo and all OSP-bound consumers. Generic sections (mirror chain, rate limits, commit conventions, validators) are meaningful in any consumer repo; fork-sync-all-specific sections are clearly marked `[fork-sync-all only]`. Propagates to `mirror` and `infra-core` consumers on next sync trigger.
- `AGENTS-IMPROVEMENT-SPEC.md` — working defect tracker for the shared infrastructure. Propagates to consumers so agents anywhere in the chain have visibility into known issues.
- `config/template-manifest.yml` + `scripts/sync-template.sh` — propagation intent documented.

### 2. Bug fixes
- `translate-readmes.yml` — `workflow_run` trigger referenced `"Sync Docs to Book"` (no such workflow); corrected to `"Sync penguins-eggs docs to penguins-eggs-book"`. Post-sync translation was silently dead.
- `mirror-to-osp.sh` — CI gate hardcoded `branches/main`; repos with `master` as default branch (e.g. `penguins-eggs`) were silently skipped every run. Now uses `default_branch` from repo metadata.
- `cleanup-branches.sh`, `upstream-prs.sh`, `sync-btrfs-devel-branches.sh` — `api_get`/`gh_get` rewritten with retry on 403/429.
- `README.md` — `upstream-prs` schedule corrected (`:23` → `:30`).

### 3. Cherry-picks from unmerged chain
Unique value extracted from `feat/gitlab-schedule-consolidation` (166 commits, not rebased):
- `.ona/skills/fork-sync-all-audit.md` — audit skill for this repo
- `.ona/skills/kport-audit.md` — audit skill for KPort pacscripts
- `.gitlab-ci.yml` — `resolve-failures` job added (was in GitHub Actions but missing from GitLab CI pipeline)
- `README.md` — restructured with TOC, Overview, Mirror chain timing, language switcher bar

### 4. Spec and skill updates
- `AGENTS-IMPROVEMENT-SPEC.md` — 15 stale items marked verified-fixed; 15-branch unmerged chain documented with rebase strategy; 2 genuinely open items remain.
- `fork-sync-all-audit.md` — updated to reflect current repo state (verified-clean items, arch repo section, current cron table).
- `AGENTS.md` — consumer-aware restructure.

## Checklist

- [x] Validator scripts pass (`python3 -m pytest tests/ -v`) — 213/213
- [x] No secrets or tokens committed
- [x] `[skip ci]` not needed — no generated commits