### PR TITLE
feat: add pre-mirror CI gate, mirror integrity checks, and post-flush verification

### DIFF
--- a/.github/workflows/full-chain-flush.yml
+++ b/.github/workflows/full-chain-flush.yml
@@ -12,15 +12,20 @@ name: Full Chain Flush
 #   3d. Inject badges
 #   3e. LTS README standardisation (OSP repos)
 #   4.  Reconcile org refs in I-D-1896   (pre-mirror cleanup)
-#   5.  Mirror I-D-1896 -> OSP
-#   6.  Reconcile org refs in OSP        (post-mirror-to-OSP)
-#   7.  Mirror OSP -> OOC
-#   8.  Reconcile org refs in OOC        (post-mirror-to-OOC)
-#   9.  Check OSP-bound CI + trigger resolver
-#   10. Mirror OSP -> GitLab             (GitLab last)
-#   11. Reconcile org refs in GitLab     (post-mirror-to-GitLab)
-#   12. Sync GitLab -> I-D-1896
-#   13. Reconcile org refs in I-D-1896   (post-GitLab-sync cleanup)
+#   5.  Pre-mirror CI gate               (block if OSP-bound repos are red)
+#   6.  Mirror I-D-1896 -> OSP
+#   7.  Verify mirror integrity          (id-1896-to-osp SHA check)
+#   8.  Reconcile org refs in OSP        (post-mirror-to-OSP)
+#   9.  Mirror OSP -> OOC
+#   10. Verify mirror integrity          (osp-to-ooc SHA check)
+#   11. Reconcile org refs in OOC        (post-mirror-to-OOC)
+#   12. Check OSP-bound CI + trigger resolver
+#   13. Mirror OSP -> GitLab             (GitLab last)
+#   14. Verify mirror integrity          (osp-to-gitlab SHA check)
+#   15. Reconcile org refs in GitLab     (post-mirror-to-GitLab)
+#   16. Sync GitLab -> I-D-1896
+#   17. Reconcile org refs in I-D-1896   (post-GitLab-sync cleanup)
+#   18. Post-flush verification          (end-to-end health check)
 
 on:
   schedule:
@@ -86,7 +91,7 @@ jobs:
               title: "Full Chain Flush"
               subtitle: "Starting pipeline"
               type: "segmented_progress"
-              number_of_steps: 13
+              number_of_steps: 18
               current_step: 0
             action:
               title: "Open Run"
@@ -111,7 +116,7 @@ jobs:
               title: "Full Chain Flush"
               subtitle: "Stage 1 done — Sync registered imports"
               type: "segmented_progress"
-              number_of_steps: 13
+              number_of_steps: 18
               current_step: 1
 
       # ── Stage 2: Sync registered imports ─────────────────────────────────
@@ -132,7 +137,7 @@ jobs:
               title: "Full Chain Flush"
               subtitle: "Stage 2 done — Create/Update READMEs"
               type: "segmented_progress"
-              number_of_steps: 13
+              number_of_steps: 18
               current_step: 2
 
       # ── Stage 3: READMEs + badges + LTS ──────────────────────────────────
@@ -178,7 +183,7 @@ jobs:
               title: "Full Chain Flush"
               subtitle: "Stage 3 done — Reconcile I-D-1896"
               type: "segmented_progress"
-              number_of_steps: 13
+              number_of_steps: 18
               current_step: 3
 
       # ── Stage 4: Reconcile I-D-1896 before mirroring out ─────────────────
@@ -197,15 +202,16 @@ jobs:
           payload: |
             content_state:
               title: "Full Chain Flush"
-              subtitle: "Stage 4 done — Mirror I-D-1896 → OSP"
+              subtitle: "Stage 4 done — Pre-mirror CI gate"
               type: "segmented_progress"
-              number_of_steps: 13
+              number_of_steps: 18
               current_step: 4
 
-      # ── Stage 5: Mirror I-D-1896 → OSP ───────────────────────────────────
-      - name: "Stage 5: Mirror I-D-1896 -> OSP"
+      # ── Stage 5: Pre-mirror CI gate ───────────────────────────────────────
+      - name: "Stage 5: Pre-mirror CI gate"
+        if: ${{ inputs.dry_run != true }}
         run: |
-          bash scripts/dispatch-and-wait.sh mirror-to-osp.yml 90
+          bash scripts/dispatch-and-wait.sh pre-mirror-ci-gate.yml 90 '{"dry_run":"false","repo_filter":"","block_on_fail":"true"}'
           rc=$?; [[ $rc -eq 2 ]] && echo "Stage cancelled by queue-manager — continuing." || exit $rc
 
       - name: "ActivitySmith: stage 5 done"
@@ -218,15 +224,15 @@ jobs:
           payload: |
             content_state:
               title: "Full Chain Flush"
-              subtitle: "Stage 5 done — Reconcile OSP"
+              subtitle: "Stage 5 done — Mirror I-D-1896 → OSP"
               type: "segmented_progress"
-              number_of_steps: 13
+              number_of_steps: 18
               current_step: 5
 
-      # ── Stage 6: Reconcile OSP after mirror ──────────────────────────────
-      - name: "Stage 6: Reconcile org refs (OSP)"
+      # ── Stage 6: Mirror I-D-1896 → OSP ───────────────────────────────────
+      - name: "Stage 6: Mirror I-D-1896 -> OSP"
         run: |
-          bash scripts/dispatch-and-wait.sh reconcile-org-refs.yml 55 '{"dry_run":"false","orgs":"osp-only","repo_filter":"","force_reconcile":"false"}'
+          bash scripts/dispatch-and-wait.sh mirror-to-osp.yml 90
           rc=$?; [[ $rc -eq 2 ]] && echo "Stage cancelled by queue-manager — continuing." || exit $rc
 
       - name: "ActivitySmith: stage 6 done"
@@ -239,15 +245,15 @@ jobs:
           payload: |
             content_state:
               title: "Full Chain Flush"
-              subtitle: "Stage 6 done — Mirror OSP → OOC"
+              subtitle: "Stage 6 done — Verify I-D-1896 → OSP integrity"
               type: "segmented_progress"
-              number_of_steps: 13
+              number_of_steps: 18
               current_step: 6
 
-      # ── Stage 7: Mirror OSP → OOC ─────────────────────────────────────────
-      - name: "Stage 7: Mirror OSP -> OOC"
+      # ── Stage 7: Verify I-D-1896 → OSP integrity ─────────────────────────
+      - name: "Stage 7: Verify mirror integrity (id-1896-to-osp)"
         run: |
-          bash scripts/dispatch-and-wait.sh mirror-osp-to-ooc.yaml 90
+          bash scripts/dispatch-and-wait.sh verify-mirror-integrity.yml 45 '{"mirror_pair":"id-1896-to-osp","repo_filter":"","block_on_mismatch":"false"}'
           rc=$?; [[ $rc -eq 2 ]] && echo "Stage cancelled by queue-manager — continuing." || exit $rc
 
       - name: "ActivitySmith: stage 7 done"
@@ -260,15 +266,15 @@ jobs:
           payload: |
             content_state:
               title: "Full Chain Flush"
-              subtitle: "Stage 7 done — Reconcile OOC"
+              subtitle: "Stage 7 done — Reconcile OSP"
               type: "segmented_progress"
-              number_of_steps: 13
+              number_of_steps: 18
               current_step: 7
 
-      # ── Stage 8: Reconcile OOC after mirror ──────────────────────────────
-      - name: "Stage 8: Reconcile org refs (OOC)"
+      # ── Stage 8: Reconcile OSP after mirror ──────────────────────────────
+      - name: "Stage 8: Reconcile org refs (OSP)"
         run: |
-          bash scripts/dispatch-and-wait.sh reconcile-org-refs.yml 55 '{"dry_run":"false","orgs":"ooc-only","repo_filter":"","force_reconcile":"false"}'
+          bash scripts/dispatch-and-wait.sh reconcile-org-refs.yml 55 '{"dry_run":"false","orgs":"osp-only","repo_filter":"","force_reconcile":"false"}'
           rc=$?; [[ $rc -eq 2 ]] && echo "Stage cancelled by queue-manager — continuing." || exit $rc
 
       - name: "ActivitySmith: stage 8 done"
@@ -281,16 +287,15 @@ jobs:
           payload: |
             content_state:
               title: "Full Chain Flush"
-              subtitle: "Stage 8 done — Check OSP CI"
+              subtitle: "Stage 8 done — Mirror OSP → OOC"
               type: "segmented_progress"
-              number_of_steps: 13
+              number_of_steps: 18
               current_step: 8
 
-      # ── Stage 9: Check OSP-bound CI (GitHub OSP) ─────────────────────────
-      - name: "Stage 9: Check OSP-bound CI + trigger resolver"
-        if: ${{ inputs.dry_run != true }}
+      # ── Stage 9: Mirror OSP → OOC ─────────────────────────────────────────
+      - name: "Stage 9: Mirror OSP -> OOC"
         run: |
-          bash scripts/dispatch-and-wait.sh check-osp-ci.yml 90 '{"dry_run":"false","repo_filter":""}'
+          bash scripts/dispatch-and-wait.sh mirror-osp-to-ooc.yaml 90
           rc=$?; [[ $rc -eq 2 ]] && echo "Stage cancelled by queue-manager — continuing." || exit $rc
 
       - name: "ActivitySmith: stage 9 done"
@@ -303,17 +308,15 @@ jobs:
           payload: |
             content_state:
               title: "Full Chain Flush"
-              subtitle: "Stage 9 done — Mirror OSP → GitLab"
+              subtitle: "Stage 9 done — Verify OSP → OOC integrity"
               type: "segmented_progress"
-              number_of_steps: 13
+              number_of_steps: 18
               current_step: 9
 
-      # ── GitLab mirroring (last) ───────────────────────────────────────────
-
-      # ── Stage 10: Mirror OSP → GitLab ────────────────────────────────────
-      - name: "Stage 10: Mirror OSP -> GitLab"
+      # ── Stage 10: Verify OSP → OOC integrity ─────────────────────────────
+      - name: "Stage 10: Verify mirror integrity (osp-to-ooc)"
         run: |
-          bash scripts/dispatch-and-wait.sh mirror-osp-to-gitlab.yml 90
+          bash scripts/dispatch-and-wait.sh verify-mirror-integrity.yml 45 '{"mirror_pair":"osp-to-ooc","repo_filter":"","block_on_mismatch":"false"}'
           rc=$?; [[ $rc -eq 2 ]] && echo "Stage cancelled by queue-manager — continuing." || exit $rc
 
       - name: "ActivitySmith: stage 10 done"
@@ -326,15 +329,15 @@ jobs:
           payload: |
             content_state:
               title: "Full Chain Flush"
-              subtitle: "Stage 10 done — Reconcile GitLab"
+              subtitle: "Stage 10 done — Reconcile OOC"
               type: "segmented_progress"
-              number_of_steps: 13
+              number_of_steps: 18
               current_step: 10
 
-      # ── Stage 11: Reconcile GitLab after mirror ───────────────────────────
-      - name: "Stage 11: Reconcile org refs (GitLab)"
+      # ── Stage 11: Reconcile OOC after mirror ─────────────────────────────
+      - name: "Stage 11: Reconcile org refs (OOC)"
         run: |
-          bash scripts/dispatch-and-wait.sh reconcile-org-refs.yml 55 '{"dry_run":"false","orgs":"gitlab-only","repo_filter":"","force_reconcile":"false"}'
+          bash scripts/dispatch-and-wait.sh reconcile-org-refs.yml 55 '{"dry_run":"false","orgs":"ooc-only","repo_filter":"","force_reconcile":"false"}'
           rc=$?; [[ $rc -eq 2 ]] && echo "Stage cancelled by queue-manager — continuing." || exit $rc
 
       - name: "ActivitySmith: stage 11 done"
@@ -347,15 +350,16 @@ jobs:
           payload: |
             content_state:
               title: "Full Chain Flush"
-              subtitle: "Stage 11 done — Sync GitLab → I-D-1896"
+              subtitle: "Stage 11 done — Check OSP CI"
               type: "segmented_progress"
-              number_of_steps: 13
+              number_of_steps: 18
               current_step: 11
 
-      # ── Stage 12: Sync GitLab → I-D-1896 ─────────────────────────────────
-      - name: "Stage 12: Sync GitLab -> I-D-1896"
+      # ── Stage 12: Check OSP-bound CI (GitHub OSP) ────────────────────────
+      - name: "Stage 12: Check OSP-bound CI + trigger resolver"
+        if: ${{ inputs.dry_run != true }}
         run: |
-          bash scripts/dispatch-and-wait.sh sync-from-gitlab.yml 30
+          bash scripts/dispatch-and-wait.sh check-osp-ci.yml 90 '{"dry_run":"false","repo_filter":""}'
           rc=$?; [[ $rc -eq 2 ]] && echo "Stage cancelled by queue-manager — continuing." || exit $rc
 
       - name: "ActivitySmith: stage 12 done"
@@ -368,15 +372,17 @@ jobs:
           payload: |
             content_state:
               title: "Full Chain Flush"
-              subtitle: "Stage 12 done — Final reconcile I-D-1896"
+              subtitle: "Stage 12 done — Mirror OSP → GitLab"
               type: "segmented_progress"
-              number_of_steps: 13
+              number_of_steps: 18
               current_step: 12
 
-      # ── Stage 13: Final reconcile I-D-1896 after GitLab sync ─────────────
-      - name: "Stage 13: Reconcile org refs (I-D-1896 post-GitLab sync)"
+      # ── GitLab mirroring (last) ───────────────────────────────────────────
+
+      # ── Stage 13: Mirror OSP → GitLab ────────────────────────────────────
+      - name: "Stage 13: Mirror OSP -> GitLab"
         run: |
-          bash scripts/dispatch-and-wait.sh reconcile-org-refs.yml 55 '{"dry_run":"false","orgs":"id-1896-only","repo_filter":"","force_reconcile":"false"}'
+          bash scripts/dispatch-and-wait.sh mirror-osp-to-gitlab.yml 90
           rc=$?; [[ $rc -eq 2 ]] && echo "Stage cancelled by queue-manager — continuing." || exit $rc
 
       - name: "ActivitySmith: stage 13 done"
@@ -389,10 +395,100 @@ jobs:
           payload: |
             content_state:
               title: "Full Chain Flush"
-              subtitle: "Stage 13 done — Pipeline complete"
+              subtitle: "Stage 13 done — Verify OSP → GitLab integrity"
               type: "segmented_progress"
-              number_of_steps: 13
+              number_of_steps: 18
               current_step: 13
+
+      # ── Stage 14: Verify OSP → GitLab integrity ──────────────────────────
+      - name: "Stage 14: Verify mirror integrity (osp-to-gitlab)"
+        run: |
+          bash scripts/dispatch-and-wait.sh verify-mirror-integrity.yml 45 '{"mirror_pair":"osp-to-gitlab","repo_filter":"","block_on_mismatch":"false"}'
+          rc=$?; [[ $rc -eq 2 ]] && echo "Stage cancelled by queue-manager — continuing." || exit $rc
+
+      - name: "ActivitySmith: stage 14 done"
+        if: ${{ always() && steps.activity.outputs.live_activity_id != '' }}
+        uses: ActivitySmithHQ/activitysmith-github-action@v1
+        with:
+          action: update_live_activity
+          api-key: ${{ secrets.ACTIVITYSMITH_API_KEY }}
+          live-activity-id: ${{ steps.activity.outputs.live_activity_id }}
+          payload: |
+            content_state:
+              title: "Full Chain Flush"
+              subtitle: "Stage 14 done — Reconcile GitLab"
+              type: "segmented_progress"
+              number_of_steps: 18
+              current_step: 14
+
+      # ── Stage 15: Reconcile GitLab after mirror ───────────────────────────
+      - name: "Stage 15: Reconcile org refs (GitLab)"
+        run: |
+          bash scripts/dispatch-and-wait.sh reconcile-org-refs.yml 55 '{"dry_run":"false","orgs":"gitlab-only","repo_filter":"","force_reconcile":"false"}'
+          rc=$?; [[ $rc -eq 2 ]] && echo "Stage cancelled by queue-manager — continuing." || exit $rc
+
+      - name: "ActivitySmith: stage 15 done"
+        if: ${{ always() && steps.activity.outputs.live_activity_id != '' }}
+        uses: ActivitySmithHQ/activitysmith-github-action@v1
+        with:
+          action: update_live_activity
+          api-key: ${{ secrets.ACTIVITYSMITH_API_KEY }}
+          live-activity-id: ${{ steps.activity.outputs.live_activity_id }}
+          payload: |
+            content_state:
+              title: "Full Chain Flush"
+              subtitle: "Stage 15 done — Sync GitLab → I-D-1896"
+              type: "segmented_progress"
+              number_of_steps: 18
+              current_step: 15
+
+      # ── Stage 16: Sync GitLab → I-D-1896 ─────────────────────────────────
+      - name: "Stage 16: Sync GitLab -> I-D-1896"
+        run: |
+          bash scripts/dispatch-and-wait.sh sync-from-gitlab.yml 30
+          rc=$?; [[ $rc -eq 2 ]] && echo "Stage cancelled by queue-manager — continuing." || exit $rc
+
+      - name: "ActivitySmith: stage 16 done"
+        if: ${{ always() && steps.activity.outputs.live_activity_id != '' }}
+        uses: ActivitySmithHQ/activitysmith-github-action@v1
+        with:
+          action: update_live_activity
+          api-key: ${{ secrets.ACTIVITYSMITH_API_KEY }}
+          live-activity-id: ${{ steps.activity.outputs.live_activity_id }}
+          payload: |
+            content_state:
+              title: "Full Chain Flush"
+              subtitle: "Stage 16 done — Final reconcile I-D-1896"
+              type: "segmented_progress"
+              number_of_steps: 18
+              current_step: 16
+
+      # ── Stage 17: Final reconcile I-D-1896 after GitLab sync ─────────────
+      - name: "Stage 17: Reconcile org refs (I-D-1896 post-GitLab sync)"
+        run: |
+          bash scripts/dispatch-and-wait.sh reconcile-org-refs.yml 55 '{"dry_run":"false","orgs":"id-1896-only","repo_filter":"","force_reconcile":"false"}'
+          rc=$?; [[ $rc -eq 2 ]] && echo "Stage cancelled by queue-manager — continuing." || exit $rc
+
+      - name: "ActivitySmith: stage 17 done"
+        if: ${{ always() && steps.activity.outputs.live_activity_id != '' }}
+        uses: ActivitySmithHQ/activitysmith-github-action@v1
+        with:
+          action: update_live_activity
+          api-key: ${{ secrets.ACTIVITYSMITH_API_KEY }}
+          live-activity-id: ${{ steps.activity.outputs.live_activity_id }}
+          payload: |
+            content_state:
+              title: "Full Chain Flush"
+              subtitle: "Stage 17 done — Post-flush verification"
+              type: "segmented_progress"
+              number_of_steps: 18
+              current_step: 17
+
+      # ── Stage 18: Post-flush verification ────────────────────────────────
+      - name: "Stage 18: Post-flush verification"
+        run: |
+          bash scripts/dispatch-and-wait.sh post-flush-prep.yml 60 '{"repo_filter":"","block_on_failure":"false"}'
+          rc=$?; [[ $rc -eq 2 ]] && echo "Stage cancelled by queue-manager — continuing." || exit $rc
 
       # ── ActivitySmith: end Live Activity + push notification on failure ────
       - name: "ActivitySmith: pipeline complete"
@@ -405,10 +501,10 @@ jobs:
           payload: |
             content_state:
               title: "Full Chain Flush"
-              subtitle: "All 13 stages complete"
+              subtitle: "All 18 stages complete"
               type: "segmented_progress"
-              number_of_steps: 13
-              current_step: 13
+              number_of_steps: 18
+              current_step: 18
               auto_dismiss_minutes: 5
 
       - name: "ActivitySmith: pipeline failed"
@@ -423,8 +519,8 @@ jobs:
               title: "Full Chain Flush failed"
               subtitle: "Check Actions for details"
               type: "segmented_progress"
-              number_of_steps: 13
-              current_step: 13
+              number_of_steps: 18
+              current_step: 18
             action:
               title: "Open Run"
               type: "open_url"

--- a/.github/workflows/post-flush-prep.yml
+++ b/.github/workflows/post-flush-prep.yml
@@ -1,0 +1,88 @@
+name: Post-Flush Verification
+
+# End-to-end verification after a full-chain-flush completes. Runs four checks:
+#
+#   1. Mirror integrity — SHA comparison across all three mirror pairs
+#   2. CI status       — checks GitHub CI on I-D-1896 OSP-bound repos
+#   3. Quota health    — reports remaining quota after the flush
+#   4. Queue health    — checks for stuck/elevated workflow queues
+#
+# Called by full-chain-flush.yml as the final stage (stage 14). Can also be
+# run standalone after any manual mirror operation.
+
+on:
+  workflow_dispatch:
+    inputs:
+      repo_filter:
+        description: "Check only repos matching this substring (blank = all)"
+        required: false
+        default: ""
+        type: string
+      block_on_failure:
+        description: "Fail this workflow if critical checks fail"
+        required: false
+        default: false
+        type: boolean
+  workflow_call:
+    inputs:
+      repo_filter:
+        type: string
+        default: ""
+      block_on_failure:
+        type: boolean
+        default: false
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: post-flush-prep
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Post-Flush Verification
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+      GITLAB_TOKEN: ${{ secrets.GITLAB_SYNC_TOKEN }}
+      REPO: ${{ github.repository }}
+
+    steps:
+      - name: Quota pre-flight
+        id: quota
+        run: |
+          remaining=$(curl -sf \
+            -H "Authorization: token ${GH_TOKEN}" \
+            "https://api.github.com/rate_limit" \
+            | python3 -c "import sys,json; print(json.load(sys.stdin)['resources']['core']['remaining'])" \
+            || echo 0)
+          echo "remaining=${remaining}" >> "$GITHUB_OUTPUT"
+          if [[ "${remaining}" -lt 300 ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Quota too low (${remaining} < 300) — skipping post-flush verification."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        if: steps.quota.outputs.skip == 'false'
+        uses: actions/checkout@v6
+
+      - name: Run post-flush verification
+        if: steps.quota.outputs.skip == 'false'
+        env:
+          REPO_FILTER: ${{ inputs.repo_filter || '' }}
+          BLOCK_ON_FAILURE: ${{ inputs.block_on_failure || 'false' }}
+          BUDGET_MINUTES: "50"
+          MIN_QUOTA: "300"
+        run: bash scripts/post-flush-prep.sh
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/pre-mirror-ci-gate.yml
+++ b/.github/workflows/pre-mirror-ci-gate.yml
@@ -1,0 +1,99 @@
+name: Pre-Mirror CI Gate
+
+# Checks CI status on all OSP-bound repos in Interested-Deving-1896 before
+# they are mirrored outward to OSP. Dispatches resolve-failures.yml for any
+# red repos, waits, then re-checks. Blocks the mirror if repos are still
+# failing after the resolver runs (configurable via block_on_fail).
+#
+# Called by full-chain-flush.yml between stage 4 (reconcile I-D-1896) and
+# stage 5 (mirror I-D-1896 → OSP). Can also be run standalone.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Report failures without dispatching resolver"
+        required: false
+        default: false
+        type: boolean
+      repo_filter:
+        description: "Check only repos matching this substring (blank = all)"
+        required: false
+        default: ""
+        type: string
+      block_on_fail:
+        description: "Fail this workflow if repos are still red after resolver"
+        required: false
+        default: true
+        type: boolean
+  workflow_call:
+    inputs:
+      dry_run:
+        type: boolean
+        default: false
+      repo_filter:
+        type: string
+        default: ""
+      block_on_fail:
+        type: boolean
+        default: true
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: pre-mirror-ci-gate
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    name: Pre-Mirror CI Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+      REPO: ${{ github.repository }}
+
+    steps:
+      - name: Quota pre-flight
+        id: quota
+        run: |
+          remaining=$(curl -sf \
+            -H "Authorization: token ${GH_TOKEN}" \
+            "https://api.github.com/rate_limit" \
+            | python3 -c "import sys,json; print(json.load(sys.stdin)['resources']['core']['remaining'])" \
+            || echo 0)
+          echo "remaining=${remaining}" >> "$GITHUB_OUTPUT"
+          if [[ "${remaining}" -lt 800 ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Quota too low (${remaining} < 800) — skipping pre-mirror CI gate."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        if: steps.quota.outputs.skip == 'false'
+        uses: actions/checkout@v6
+
+      - name: Run pre-mirror CI gate
+        if: steps.quota.outputs.skip == 'false'
+        id: gate
+        env:
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          REPO_FILTER: ${{ inputs.repo_filter || '' }}
+          BLOCK_ON_FAIL: ${{ inputs.block_on_fail || 'true' }}
+          BUDGET_MINUTES: "80"
+          MIN_QUOTA: "800"
+        run: |
+          source scripts/includes/quota-instrument.sh
+          qi_begin
+          bash scripts/pre-mirror-ci-gate.sh
+          qi_end
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/verify-mirror-integrity.yml
+++ b/.github/workflows/verify-mirror-integrity.yml
@@ -1,0 +1,101 @@
+name: Verify Mirror Integrity
+
+# Compares default-branch HEAD SHAs between source and destination for all
+# OSP-bound repos after a mirror stage completes. Reports mismatches as
+# warnings. Set block_on_mismatch=true to make mismatches a hard failure.
+#
+# Supports three mirror pairs:
+#   id-1896-to-osp  — Interested-Deving-1896 → OpenOS-Project-OSP
+#   osp-to-ooc      — OpenOS-Project-OSP → OpenOS-Project-Ecosystem-OOC
+#   osp-to-gitlab   — OpenOS-Project-OSP → gitlab.com/openos-project
+#
+# Called by full-chain-flush.yml after each mirror stage. Can also be run
+# standalone for ad-hoc integrity checks.
+
+on:
+  workflow_dispatch:
+    inputs:
+      mirror_pair:
+        description: "Mirror pair to verify"
+        required: true
+        type: choice
+        options:
+          - id-1896-to-osp
+          - osp-to-ooc
+          - osp-to-gitlab
+      repo_filter:
+        description: "Check only repos matching this substring (blank = all)"
+        required: false
+        default: ""
+        type: string
+      block_on_mismatch:
+        description: "Fail this workflow if any SHA mismatches are found"
+        required: false
+        default: false
+        type: boolean
+  workflow_call:
+    inputs:
+      mirror_pair:
+        type: string
+        required: true
+      repo_filter:
+        type: string
+        default: ""
+      block_on_mismatch:
+        type: boolean
+        default: false
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: verify-mirror-integrity-${{ inputs.mirror_pair || 'manual' }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Verify ${{ inputs.mirror_pair }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+      GITLAB_TOKEN: ${{ secrets.GITLAB_SYNC_TOKEN }}
+
+    steps:
+      - name: Quota pre-flight
+        id: quota
+        run: |
+          remaining=$(curl -sf \
+            -H "Authorization: token ${GH_TOKEN}" \
+            "https://api.github.com/rate_limit" \
+            | python3 -c "import sys,json; print(json.load(sys.stdin)['resources']['core']['remaining'])" \
+            || echo 0)
+          echo "remaining=${remaining}" >> "$GITHUB_OUTPUT"
+          if [[ "${remaining}" -lt 400 ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Quota too low (${remaining} < 400) — skipping integrity check."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        if: steps.quota.outputs.skip == 'false'
+        uses: actions/checkout@v6
+
+      - name: Verify mirror integrity
+        if: steps.quota.outputs.skip == 'false'
+        env:
+          MIRROR_PAIR: ${{ inputs.mirror_pair }}
+          REPO_FILTER: ${{ inputs.repo_filter || '' }}
+          BLOCK_ON_MISMATCH: ${{ inputs.block_on_mismatch || 'false' }}
+          BUDGET_MINUTES: "35"
+          MIN_QUOTA: "400"
+        run: bash scripts/verify-mirror-integrity.sh
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/config/workflow-priority-tiers.yml
+++ b/config/workflow-priority-tiers.yml
@@ -61,6 +61,8 @@ tiers:
     tier: 2
   - name: "Full Chain Flush"
     tier: 2
+  - name: "Pre-Mirror CI Gate"
+    tier: 2
   - name: "Sync to GitLab Variant"
     tier: 2
   - name: "Sync from GitLab"
@@ -114,6 +116,10 @@ tiers:
   - name: "Generate Book Pages"
     tier: 3
   - name: "Deploy Book"
+    tier: 3
+  - name: "Verify Mirror Integrity"
+    tier: 3
+  - name: "Post-Flush Verification"
     tier: 3
   - name: "Setup Dashboard Variables"
     tier: 3

--- a/config/workflow-quota-costs.yml
+++ b/config/workflow-quota-costs.yml
@@ -676,3 +676,27 @@ workflows:
   cost_high: 200
   basis: code-audit
   synopsis: Bare-clones every repo in OpenOS-Project-OSP and git push --mirror into OpenOS-Project-Ecosystem-OOC, completing the second hop of the three-org mirror chain.
+- name: Pre-Mirror CI Gate
+  min_quota: 800
+  cost_low: 50
+  cost_mid: 150
+  cost_high: 300
+  basis: code-audit
+  notes: 2 REST calls per OSP-bound repo (HEAD SHA + check-runs) × ~49 repos = ~100 calls per pass. Two passes if resolver runs.
+  synopsis: Checks CI status on all OSP-bound repos in Interested-Deving-1896 before mirroring. Dispatches resolve-failures for red repos, waits, then re-checks. Blocks the mirror if repos are still failing.
+- name: Verify Mirror Integrity
+  min_quota: 400
+  cost_low: 50
+  cost_mid: 100
+  cost_high: 150
+  basis: code-audit
+  notes: 2 REST calls per repo (source HEAD + dest HEAD) × ~49 repos = ~100 calls. GitLab pair uses GitLab API (no GitHub quota).
+  synopsis: Compares default-branch HEAD SHAs between source and destination for all OSP-bound repos after a mirror stage. Reports mismatches as warnings; configurable hard-fail mode.
+- name: Post-Flush Verification
+  min_quota: 300
+  cost_low: 150
+  cost_mid: 350
+  cost_high: 600
+  basis: code-audit
+  notes: Runs all three integrity checks (id-1896-to-osp, osp-to-ooc, osp-to-gitlab) plus CI check on ~49 repos plus queue/quota queries. High end assumes all checks run fully.
+  synopsis: End-to-end health check after full-chain-flush — mirror integrity across all three pairs, CI status on I-D-1896 OSP-bound repos, quota health, and workflow queue health.

--- a/config/workflow-sync.yml
+++ b/config/workflow-sync.yml
@@ -336,6 +336,12 @@ github_only:
     reason: Sets VITE_* repository variables for infra-dashboard build — GitHub Actions variables API only
   - workflow_file: pre-flush-prep.yml
     reason: Pre-flight for full-chain-flush — clears queue, merges PRs, validates config, dispatches flush
+  - workflow_file: pre-mirror-ci-gate.yml
+    reason: Checks CI on I-D-1896 OSP-bound repos before mirroring; dispatches resolver for red repos
+  - workflow_file: verify-mirror-integrity.yml
+    reason: Compares HEAD SHAs between source and destination after each mirror stage
+  - workflow_file: post-flush-prep.yml
+    reason: End-to-end verification after full-chain-flush — mirror integrity, CI status, quota, queue health
   - workflow_file: full-chain-flush.yml
     reason: Orchestrates the full mirror + README + sync chain — GitHub Actions only
   - workflow_file: critical-deploy.yml

--- a/scripts/post-flush-prep.sh
+++ b/scripts/post-flush-prep.sh
@@ -1,0 +1,319 @@
+#!/usr/bin/env bash
+#
+# post-flush-prep.sh
+#
+# End-to-end verification after a full-chain-flush completes. Runs a suite
+# of checks to confirm the system is in a healthy state:
+#
+#   Check 1 — Mirror integrity (all three pairs)
+#             Compares HEAD SHAs between source and destination for all
+#             OSP-bound repos across all three mirror pairs.
+#
+#   Check 2 — CI status on OSP-bound repos
+#             Checks GitHub CI status on Interested-Deving-1896 OSP-bound
+#             repos. Reports any repos that are still red after the flush.
+#
+#   Check 3 — Quota health
+#             Reports remaining quota and warns if below a safe threshold.
+#
+#   Check 4 — Workflow queue health
+#             Checks for any queued or in-progress runs that may indicate
+#             a stuck workflow.
+#
+# Outputs a structured summary to GITHUB_STEP_SUMMARY.
+# Exits non-zero only if BLOCK_ON_FAILURE=true and critical checks fail.
+#
+# Required env vars:
+#   GH_TOKEN           — PAT with repo + actions:read scope
+#   REPO               — owner/repo of fork-sync-all
+#
+# Optional env vars:
+#   GITLAB_TOKEN       — for GitLab integrity check (skipped if absent)
+#   BLOCK_ON_FAILURE   — "true" to exit 1 on any critical failure (default: false)
+#   REPO_FILTER        — substring filter on repo name (default: all)
+#   BUDGET_MINUTES     — time budget in minutes (default: 45)
+#   MIN_QUOTA          — skip if quota below this (default: 300)
+
+set -uo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+: "${REPO:?REPO is required}"
+
+BLOCK_ON_FAILURE="${BLOCK_ON_FAILURE:-false}"
+REPO_FILTER="${REPO_FILTER:-}"
+MIN_QUOTA="${MIN_QUOTA:-300}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+source "${SCRIPT_DIR}/includes/budget.sh"
+source "${SCRIPT_DIR}/includes/gh-api.sh"
+
+budget_init
+
+# ── Logging ───────────────────────────────────────────────────────────────────
+info()  { echo "[post-flush-prep] $*" >&2; }
+warn()  { echo "[post-flush-prep] ⚠️  $*" >&2; }
+ok()    { echo "[post-flush-prep] ✓ $*" >&2; }
+fail()  { echo "[post-flush-prep] ✗ $*" >&2; }
+header(){ echo "" >&2; echo "[post-flush-prep] ── $* ──" >&2; }
+
+# ── Quota pre-flight ──────────────────────────────────────────────────────────
+_quota_json=$(curl -sf \
+  -H "Authorization: token ${GH_TOKEN}" \
+  "https://api.github.com/rate_limit" 2>/dev/null || echo '{}')
+_quota_remaining=$(echo "$_quota_json" | python3 -c \
+  "import sys,json; d=json.load(sys.stdin); print(d.get('resources',{}).get('core',{}).get('remaining',0))" \
+  2>/dev/null || echo 0)
+_quota_reset=$(echo "$_quota_json" | python3 -c \
+  "import sys,json,datetime; d=json.load(sys.stdin); \
+   ts=d.get('resources',{}).get('core',{}).get('reset',0); \
+   print(datetime.datetime.utcfromtimestamp(ts).strftime('%H:%M UTC') if ts else 'unknown')" \
+  2>/dev/null || echo 'unknown')
+
+if (( _quota_remaining < MIN_QUOTA )); then
+  warn "Quota too low (${_quota_remaining} < ${MIN_QUOTA}) — skipping post-flush verification."
+  exit 0
+fi
+info "Quota: ${_quota_remaining} remaining (resets ${_quota_reset})"
+
+# ── Load OSP-bound repo list ──────────────────────────────────────────────────
+CONFIG="${REPO_ROOT}/config/gitlab-subgroups.yml"
+if [[ ! -f "$CONFIG" ]]; then
+  warn "config/gitlab-subgroups.yml not found — skipping."
+  exit 0
+fi
+
+mapfile -t OSP_REPOS < <(python3 - "$CONFIG" <<'PYEOF'
+import yaml, sys
+data = yaml.safe_load(open(sys.argv[1]))
+repos = []
+for sg in (data.get("subgroups") or {}).values():
+    repos.extend(sg.get("repos") or [])
+for r in sorted(set(repos)):
+    print(r)
+PYEOF
+)
+
+TOTAL_REPOS="${#OSP_REPOS[@]}"
+info "OSP-bound repos: ${TOTAL_REPOS}"
+
+# ── Tracking ──────────────────────────────────────────────────────────────────
+declare -A CHECK_STATUS=()
+declare -A CHECK_DETAILS=()
+CRITICAL_FAILURES=0
+
+# ── Check 1: Mirror integrity ─────────────────────────────────────────────────
+header "Check 1: Mirror integrity"
+
+run_integrity_check() {
+  local pair="$1"
+  local src_org="$2"
+  local dst_org="$3"
+  local dst_backend="$4"
+
+  local mismatch=0
+  local missing=0
+  local ok_count=0
+  local issues=()
+
+  for repo in "${OSP_REPOS[@]}"; do
+    budget_check "$repo" || break
+    [[ -n "$REPO_FILTER" && "$repo" != *"$REPO_FILTER"* ]] && continue
+
+    # Source SHA
+    local src_sha
+    src_sha=$(gh_get "https://api.github.com/repos/${src_org}/${repo}/commits/HEAD" \
+      | python3 -c "import sys,json; print(json.load(sys.stdin).get('sha',''))" \
+      2>/dev/null || echo "")
+    [[ -z "$src_sha" ]] && continue
+
+    # Destination SHA
+    local dst_sha=""
+    if [[ "$dst_backend" == "github" ]]; then
+      dst_sha=$(gh_get "https://api.github.com/repos/${dst_org}/${repo}/commits/HEAD" \
+        | python3 -c "import sys,json; print(json.load(sys.stdin).get('sha',''))" \
+        2>/dev/null || echo "")
+    elif [[ "$dst_backend" == "gitlab" && -n "${GITLAB_TOKEN:-}" ]]; then
+      local gl_path
+      gl_path=$(python3 - "$repo" "$CONFIG" <<'PYEOF'
+import yaml, sys
+repo = sys.argv[1]
+config_path = sys.argv[2]
+data = yaml.safe_load(open(config_path))
+subgroups = data.get("subgroups", {}) or {}
+default_sg = data.get("default_subgroup", "ops")
+for sg_name, sg in subgroups.items():
+    if repo in (sg.get("repos") or []):
+        path = sg.get("path") or f"openos-project/{sg_name}"
+        print(f"{path}/{repo}")
+        sys.exit(0)
+print(f"openos-project/{default_sg}/{repo}")
+PYEOF
+)
+      local encoded_path
+      encoded_path=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1],''))" "$gl_path")
+      dst_sha=$(curl -sf \
+        -H "Authorization: Bearer ${GITLAB_TOKEN}" \
+        "https://gitlab.com/api/v4/projects/${encoded_path}/repository/commits?per_page=1" \
+        2>/dev/null \
+        | python3 -c "import sys,json; d=json.load(sys.stdin); print(d[0]['id'] if d else '')" \
+        2>/dev/null || echo "")
+    fi
+
+    if [[ -z "$dst_sha" ]]; then
+      issues+=("MISSING:${repo}")
+      (( missing++ )) || true
+    elif [[ "${src_sha:0:12}" != "${dst_sha:0:12}" ]]; then
+      issues+=("MISMATCH:${repo}:src=${src_sha:0:12}:dst=${dst_sha:0:12}")
+      (( mismatch++ )) || true
+    else
+      (( ok_count++ )) || true
+    fi
+  done
+
+  local total_issues=$(( mismatch + missing ))
+  if [[ $total_issues -eq 0 ]]; then
+    ok "  ${pair}: ${ok_count} repos in sync"
+    CHECK_STATUS["integrity_${pair}"]="OK"
+  else
+    warn "  ${pair}: ${mismatch} mismatch(es), ${missing} missing"
+    CHECK_STATUS["integrity_${pair}"]="WARN"
+    CHECK_DETAILS["integrity_${pair}"]="${issues[*]:-}"
+  fi
+}
+
+run_integrity_check "id-1896-to-osp" "Interested-Deving-1896" "OpenOS-Project-OSP" "github"
+run_integrity_check "osp-to-ooc" "OpenOS-Project-OSP" "OpenOS-Project-Ecosystem-OOC" "github"
+if [[ -n "${GITLAB_TOKEN:-}" ]]; then
+  run_integrity_check "osp-to-gitlab" "OpenOS-Project-OSP" "openos-project" "gitlab"
+else
+  warn "  osp-to-gitlab: GITLAB_TOKEN not set — skipped"
+  CHECK_STATUS["integrity_osp-to-gitlab"]="SKIP"
+fi
+
+# ── Check 2: CI status on I-D-1896 OSP-bound repos ───────────────────────────
+header "Check 2: CI status on I-D-1896 OSP-bound repos"
+
+CI_FAILING=()
+for repo in "${OSP_REPOS[@]}"; do
+  budget_check "$repo" || break
+  [[ -n "$REPO_FILTER" && "$repo" != *"$REPO_FILTER"* ]] && continue
+
+  sha=$(gh_get "https://api.github.com/repos/Interested-Deving-1896/${repo}/commits/HEAD" \
+    | python3 -c "import sys,json; print(json.load(sys.stdin).get('sha',''))" \
+    2>/dev/null || echo "")
+  [[ -z "$sha" ]] && continue
+
+  check_result=$(gh_get \
+    "https://api.github.com/repos/Interested-Deving-1896/${repo}/commits/${sha}/check-runs?per_page=100" \
+    | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+runs=d.get('check_runs',[])
+failing=[r['name'] for r in runs if r.get('conclusion') in ('failure','action_required','timed_out')]
+print('FAIL' if failing else 'OK')
+" 2>/dev/null || echo "OK")
+
+  if [[ "$check_result" == "FAIL" ]]; then
+    CI_FAILING+=("$repo")
+  fi
+done
+
+if [[ ${#CI_FAILING[@]} -eq 0 ]]; then
+  ok "  All ${TOTAL_REPOS} OSP-bound repos are green"
+  CHECK_STATUS["ci_status"]="OK"
+else
+  warn "  ${#CI_FAILING[@]} repo(s) still failing: ${CI_FAILING[*]}"
+  CHECK_STATUS["ci_status"]="WARN"
+  CHECK_DETAILS["ci_status"]="${CI_FAILING[*]}"
+fi
+
+# ── Check 3: Quota health ─────────────────────────────────────────────────────
+header "Check 3: Quota health"
+
+_quota_after=$(curl -sf \
+  -H "Authorization: token ${GH_TOKEN}" \
+  "https://api.github.com/rate_limit" 2>/dev/null \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['resources']['core']['remaining'])" \
+  2>/dev/null || echo 0)
+
+if (( _quota_after >= 1000 )); then
+  ok "  Quota: ${_quota_after} remaining — healthy"
+  CHECK_STATUS["quota"]="OK"
+elif (( _quota_after >= 300 )); then
+  warn "  Quota: ${_quota_after} remaining — low but functional"
+  CHECK_STATUS["quota"]="WARN"
+else
+  warn "  Quota: ${_quota_after} remaining — critically low"
+  CHECK_STATUS["quota"]="WARN"
+fi
+
+# ── Check 4: Workflow queue health ────────────────────────────────────────────
+header "Check 4: Workflow queue health"
+
+queued_count=$(gh_get \
+  "https://api.github.com/repos/${REPO}/actions/runs?status=queued&per_page=100" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin).get('total_count',0))" \
+  2>/dev/null || echo 0)
+
+in_progress_count=$(gh_get \
+  "https://api.github.com/repos/${REPO}/actions/runs?status=in_progress&per_page=100" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin).get('total_count',0))" \
+  2>/dev/null || echo 0)
+
+if (( queued_count <= 5 && in_progress_count <= 3 )); then
+  ok "  Queue: ${queued_count} queued, ${in_progress_count} in-progress — healthy"
+  CHECK_STATUS["queue"]="OK"
+else
+  warn "  Queue: ${queued_count} queued, ${in_progress_count} in-progress — elevated"
+  CHECK_STATUS["queue"]="WARN"
+fi
+
+# ── Final summary ─────────────────────────────────────────────────────────────
+header "Post-flush verification summary"
+
+WARN_COUNT=0
+for key in "${!CHECK_STATUS[@]}"; do
+  status="${CHECK_STATUS[$key]}"
+  detail="${CHECK_DETAILS[$key]:-}"
+  case "$status" in
+    OK)   ok "  ${key}: OK" ;;
+    WARN) warn "  ${key}: WARN${detail:+ — ${detail}}"; (( WARN_COUNT++ )) || true ;;
+    SKIP) info "  ${key}: SKIP" ;;
+  esac
+done
+
+# Write structured summary to GITHUB_STEP_SUMMARY
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  {
+    echo "## Post-Flush Verification"
+    echo ""
+    echo "| Check | Status | Detail |"
+    echo "|-------|--------|--------|"
+    for key in integrity_id-1896-to-osp integrity_osp-to-ooc integrity_osp-to-gitlab ci_status quota queue; do
+      status="${CHECK_STATUS[$key]:-N/A}"
+      detail="${CHECK_DETAILS[$key]:-—}"
+      icon="✅"
+      [[ "$status" == "WARN" ]] && icon="⚠️"
+      [[ "$status" == "SKIP" ]] && icon="⏭️"
+      echo "| ${key} | ${icon} ${status} | ${detail} |"
+    done
+    echo ""
+    echo "**Quota after flush:** ${_quota_after} remaining (resets ${_quota_reset})"
+  } >> "$GITHUB_STEP_SUMMARY"
+fi
+
+info ""
+if [[ "$WARN_COUNT" -eq 0 ]]; then
+  ok "All post-flush checks passed."
+else
+  warn "${WARN_COUNT} check(s) reported warnings."
+fi
+
+if [[ "$BLOCK_ON_FAILURE" == "true" && "$CRITICAL_FAILURES" -gt 0 ]]; then
+  fail "Blocking: ${CRITICAL_FAILURES} critical failure(s)."
+  exit 1
+fi
+
+exit 0

--- a/scripts/pre-mirror-ci-gate.sh
+++ b/scripts/pre-mirror-ci-gate.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+#
+# pre-mirror-ci-gate.sh
+#
+# Checks CI status on all OSP-bound repos in Interested-Deving-1896 before
+# they are mirrored outward. Dispatches resolve-failures.yml for any red repos,
+# waits for it to finish, then re-checks. Exits non-zero if repos are still
+# failing after the resolver runs.
+#
+# Required env vars:
+#   GH_TOKEN       — PAT with repo + actions:write scope (SYNC_TOKEN)
+#   REPO           — owner/repo of fork-sync-all (for dispatch-and-wait)
+#
+# Optional env vars:
+#   DRY_RUN        — "true" to report without dispatching resolver (default: false)
+#   REPO_FILTER    — substring filter on repo name (default: all)
+#   BLOCK_ON_FAIL  — "true" to exit 1 if repos still red after resolver (default: true)
+#   BUDGET_MINUTES — time budget in minutes (default: 55)
+#   MIN_QUOTA      — skip if quota below this (default: 800)
+
+set -uo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+: "${REPO:?REPO is required}"
+
+DRY_RUN="${DRY_RUN:-false}"
+REPO_FILTER="${REPO_FILTER:-}"
+BLOCK_ON_FAIL="${BLOCK_ON_FAIL:-true}"
+MIN_QUOTA="${MIN_QUOTA:-800}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+source "${SCRIPT_DIR}/includes/budget.sh"
+source "${SCRIPT_DIR}/includes/gh-api.sh"
+source "${SCRIPT_DIR}/includes/quota-instrument.sh"
+
+budget_init
+
+# ── Logging ───────────────────────────────────────────────────────────────────
+info() { echo "[pre-mirror-ci-gate] $*" >&2; }
+warn() { echo "[pre-mirror-ci-gate] ⚠️  $*" >&2; }
+ok()   { echo "[pre-mirror-ci-gate] ✓ $*" >&2; }
+fail() { echo "[pre-mirror-ci-gate] ✗ $*" >&2; }
+
+# ── Quota pre-flight ──────────────────────────────────────────────────────────
+_quota_remaining=$(curl -sf \
+  -H "Authorization: token ${GH_TOKEN}" \
+  "https://api.github.com/rate_limit" 2>/dev/null \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['resources']['core']['remaining'])" \
+  2>/dev/null || echo 0)
+
+if (( _quota_remaining < MIN_QUOTA )); then
+  warn "Quota too low (${_quota_remaining} < ${MIN_QUOTA}) — skipping pre-mirror CI gate."
+  exit 0
+fi
+info "Quota: ${_quota_remaining} remaining"
+
+# ── Load OSP-bound repo list from config ─────────────────────────────────────
+CONFIG="${REPO_ROOT}/config/gitlab-subgroups.yml"
+if [[ ! -f "$CONFIG" ]]; then
+  warn "config/gitlab-subgroups.yml not found — skipping."
+  exit 0
+fi
+
+mapfile -t OSP_REPOS < <(python3 - "$CONFIG" <<'PYEOF'
+import yaml, sys
+data = yaml.safe_load(open(sys.argv[1]))
+repos = []
+for sg in (data.get("subgroups") or {}).values():
+    repos.extend(sg.get("repos") or [])
+for r in sorted(set(repos)):
+    print(r)
+PYEOF
+)
+
+info "OSP-bound repos to check: ${#OSP_REPOS[@]}"
+
+# ── CI check function ─────────────────────────────────────────────────────────
+# Returns a space-separated list of failing repo names (short names only)
+check_ci_status() {
+  local owner="$1"
+  local -a repos=("${@:2}")
+  local failing=()
+
+  for repo in "${repos[@]}"; do
+    budget_check "$repo" || break
+    [[ -n "$REPO_FILTER" && "$repo" != *"$REPO_FILTER"* ]] && continue
+
+    # Get default branch HEAD SHA
+    local default_branch sha
+    default_branch=$(gh_get "https://api.github.com/repos/${owner}/${repo}" \
+      | python3 -c "import sys,json; print(json.load(sys.stdin).get('default_branch','main'))" \
+      2>/dev/null || echo "main")
+    sha=$(gh_get "https://api.github.com/repos/${owner}/${repo}/commits/${default_branch}" \
+      | python3 -c "import sys,json; print(json.load(sys.stdin).get('sha',''))" \
+      2>/dev/null || echo "")
+
+    [[ -z "$sha" ]] && continue
+
+    # Check runs
+    local check_result
+    check_result=$(gh_get \
+      "https://api.github.com/repos/${owner}/${repo}/commits/${sha}/check-runs?per_page=100" \
+      | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+runs=d.get('check_runs',[])
+failing=[r['name'] for r in runs if r.get('conclusion') in ('failure','action_required','timed_out')]
+print('FAIL' if failing else 'OK')
+" 2>/dev/null || echo "OK")
+
+    if [[ "$check_result" == "FAIL" ]]; then
+      warn "  FAIL: ${owner}/${repo}"
+      failing+=("$repo")
+    else
+      ok "  OK:   ${owner}/${repo}"
+    fi
+  done
+
+  echo "${failing[*]:-}"
+}
+
+# ── Pass 1: initial check ─────────────────────────────────────────────────────
+info ""
+info "Pass 1: checking CI status on I-D-1896 OSP-bound repos..."
+qi_begin
+
+FAILING_REPOS=$(check_ci_status "Interested-Deving-1896" "${OSP_REPOS[@]}")
+FAILING_COUNT=$(echo "$FAILING_REPOS" | tr ' ' '\n' | grep -c '\S' || true)
+
+qi_end
+
+info ""
+info "Pass 1 result: ${FAILING_COUNT} failing repo(s)"
+
+if [[ "$FAILING_COUNT" -eq 0 ]]; then
+  ok "All OSP-bound repos are green — safe to mirror."
+  exit 0
+fi
+
+info "Failing repos: ${FAILING_REPOS}"
+
+# ── Dispatch resolver ─────────────────────────────────────────────────────────
+if [[ "$DRY_RUN" == "true" ]]; then
+  warn "DRY RUN — would dispatch resolve-failures.yml for: ${FAILING_REPOS}"
+  [[ "$BLOCK_ON_FAIL" == "true" ]] && exit 1 || exit 0
+fi
+
+info ""
+info "Dispatching resolve-failures.yml for failing repos..."
+REPO_FILTER_ARG="${FAILING_REPOS// /|}"
+
+bash "${SCRIPT_DIR}/dispatch-and-wait.sh" resolve-failures.yml 120 \
+  "{\"dry_run\":\"false\",\"repo_filter\":\"${REPO_FILTER_ARG}\",\"scan_owners\":\"Interested-Deving-1896\",\"watchdog_repo\":\"\"}"
+rc=$?
+if [[ $rc -eq 2 ]]; then
+  warn "Resolver was cancelled by queue-manager — proceeding to re-check."
+elif [[ $rc -ne 0 ]]; then
+  warn "Resolver failed or timed out — proceeding to re-check anyway."
+fi
+
+# ── Pass 2: re-check after resolver ──────────────────────────────────────────
+info ""
+info "Pass 2: re-checking CI status after resolver..."
+
+# Give CI a moment to register new runs
+sleep 30
+
+FAILING_REPOS_2=$(check_ci_status "Interested-Deving-1896" "${OSP_REPOS[@]}")
+FAILING_COUNT_2=$(echo "$FAILING_REPOS_2" | tr ' ' '\n' | grep -c '\S' || true)
+
+info ""
+info "Pass 2 result: ${FAILING_COUNT_2} failing repo(s)"
+
+if [[ "$FAILING_COUNT_2" -eq 0 ]]; then
+  ok "All OSP-bound repos are green after resolver — safe to mirror."
+  exit 0
+fi
+
+warn "Still failing after resolver: ${FAILING_REPOS_2}"
+
+if [[ "$BLOCK_ON_FAIL" == "true" ]]; then
+  fail "Blocking mirror — ${FAILING_COUNT_2} repo(s) still red after resolver."
+  exit 1
+else
+  warn "BLOCK_ON_FAIL=false — continuing despite ${FAILING_COUNT_2} failing repo(s)."
+  exit 0
+fi

--- a/scripts/verify-mirror-integrity.sh
+++ b/scripts/verify-mirror-integrity.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+#
+# verify-mirror-integrity.sh
+#
+# Compares default-branch HEAD SHAs between a source org and a destination org
+# for all OSP-bound repos. Reports mismatches as warnings. Does not fail by
+# default — use BLOCK_ON_MISMATCH=true to make mismatches a hard failure.
+#
+# Supports three mirror pairs:
+#   id-1896-to-osp    — Interested-Deving-1896 → OpenOS-Project-OSP
+#   osp-to-ooc        — OpenOS-Project-OSP → OpenOS-Project-Ecosystem-OOC
+#   osp-to-gitlab     — OpenOS-Project-OSP → gitlab.com/openos-project (uses GitLab API)
+#
+# Required env vars:
+#   GH_TOKEN           — PAT with repo read scope
+#   MIRROR_PAIR        — one of: id-1896-to-osp | osp-to-ooc | osp-to-gitlab
+#
+# Optional env vars:
+#   GITLAB_TOKEN       — required only for osp-to-gitlab pair
+#   REPO_FILTER        — substring filter on repo name (default: all)
+#   BLOCK_ON_MISMATCH  — "true" to exit 1 on any mismatch (default: false)
+#   BUDGET_MINUTES     — time budget in minutes (default: 30)
+#   MIN_QUOTA          — skip if quota below this (default: 400)
+
+set -uo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+: "${MIRROR_PAIR:?MIRROR_PAIR is required (id-1896-to-osp|osp-to-ooc|osp-to-gitlab)}"
+
+REPO_FILTER="${REPO_FILTER:-}"
+BLOCK_ON_MISMATCH="${BLOCK_ON_MISMATCH:-false}"
+MIN_QUOTA="${MIN_QUOTA:-400}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+source "${SCRIPT_DIR}/includes/budget.sh"
+source "${SCRIPT_DIR}/includes/gh-api.sh"
+
+budget_init
+
+# ── Logging ───────────────────────────────────────────────────────────────────
+info()  { echo "[verify-mirror-integrity] $*" >&2; }
+warn()  { echo "[verify-mirror-integrity] ⚠️  $*" >&2; }
+ok()    { echo "[verify-mirror-integrity] ✓ $*" >&2; }
+fail()  { echo "[verify-mirror-integrity] ✗ $*" >&2; }
+
+# ── Validate MIRROR_PAIR ──────────────────────────────────────────────────────
+case "$MIRROR_PAIR" in
+  id-1896-to-osp|osp-to-ooc|osp-to-gitlab) ;;
+  *)
+    fail "Unknown MIRROR_PAIR '${MIRROR_PAIR}'. Must be one of: id-1896-to-osp, osp-to-ooc, osp-to-gitlab"
+    exit 1
+    ;;
+esac
+
+# ── Quota pre-flight ──────────────────────────────────────────────────────────
+_quota_remaining=$(curl -sf \
+  -H "Authorization: token ${GH_TOKEN}" \
+  "https://api.github.com/rate_limit" 2>/dev/null \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['resources']['core']['remaining'])" \
+  2>/dev/null || echo 0)
+
+if (( _quota_remaining < MIN_QUOTA )); then
+  warn "Quota too low (${_quota_remaining} < ${MIN_QUOTA}) — skipping integrity check."
+  exit 0
+fi
+info "Quota: ${_quota_remaining} remaining"
+
+# ── Load OSP-bound repo list ──────────────────────────────────────────────────
+CONFIG="${REPO_ROOT}/config/gitlab-subgroups.yml"
+if [[ ! -f "$CONFIG" ]]; then
+  warn "config/gitlab-subgroups.yml not found — skipping."
+  exit 0
+fi
+
+mapfile -t OSP_REPOS < <(python3 - "$CONFIG" <<'PYEOF'
+import yaml, sys
+data = yaml.safe_load(open(sys.argv[1]))
+repos = []
+for sg in (data.get("subgroups") or {}).values():
+    repos.extend(sg.get("repos") or [])
+for r in sorted(set(repos)):
+    print(r)
+PYEOF
+)
+
+info "OSP-bound repos to verify: ${#OSP_REPOS[@]} (pair: ${MIRROR_PAIR})"
+
+# ── Resolve source/dest orgs ──────────────────────────────────────────────────
+case "$MIRROR_PAIR" in
+  id-1896-to-osp)
+    SRC_ORG="Interested-Deving-1896"
+    DST_ORG="OpenOS-Project-OSP"
+    DST_BACKEND="github"
+    ;;
+  osp-to-ooc)
+    SRC_ORG="OpenOS-Project-OSP"
+    DST_ORG="OpenOS-Project-Ecosystem-OOC"
+    DST_BACKEND="github"
+    ;;
+  osp-to-gitlab)
+    SRC_ORG="OpenOS-Project-OSP"
+    DST_ORG="openos-project"
+    DST_BACKEND="gitlab"
+    if [[ -z "${GITLAB_TOKEN:-}" ]]; then
+      warn "GITLAB_TOKEN not set — skipping GitLab integrity check."
+      exit 0
+    fi
+    ;;
+esac
+
+# ── SHA lookup helpers ────────────────────────────────────────────────────────
+
+# Returns HEAD SHA for a GitHub repo's default branch, or empty string on error.
+github_head_sha() {
+  local org="$1" repo="$2"
+  gh_get "https://api.github.com/repos/${org}/${repo}/commits/HEAD" \
+    | python3 -c "import sys,json; print(json.load(sys.stdin).get('sha',''))" \
+    2>/dev/null || echo ""
+}
+
+# Returns HEAD SHA for a GitLab project's default branch, or empty string on error.
+# Uses the subgroup path from config to build the full project path.
+gitlab_head_sha() {
+  local repo="$1"
+  local gl_path
+  gl_path=$(python3 - "$repo" "$CONFIG" <<'PYEOF'
+import yaml, sys
+repo = sys.argv[1]
+config_path = sys.argv[2]
+data = yaml.safe_load(open(config_path))
+subgroups = data.get("subgroups", {}) or {}
+default_sg = data.get("default_subgroup", "ops")
+for sg_name, sg in subgroups.items():
+    if repo in (sg.get("repos") or []):
+        path = sg.get("path") or f"openos-project/{sg_name}"
+        print(f"{path}/{repo}")
+        sys.exit(0)
+# fallback
+print(f"openos-project/{default_sg}/{repo}")
+PYEOF
+)
+
+  local encoded_path
+  encoded_path=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1],''))" "$gl_path")
+
+  curl -sf \
+    -H "Authorization: Bearer ${GITLAB_TOKEN}" \
+    "https://gitlab.com/api/v4/projects/${encoded_path}/repository/commits?per_page=1" \
+    2>/dev/null \
+    | python3 -c "import sys,json; d=json.load(sys.stdin); print(d[0]['id'] if d else '')" \
+    2>/dev/null || echo ""
+}
+
+# ── Compare SHAs ──────────────────────────────────────────────────────────────
+MISMATCH_COUNT=0
+MISSING_COUNT=0
+OK_COUNT=0
+declare -a MISMATCHES=()
+
+for repo in "${OSP_REPOS[@]}"; do
+  budget_check "$repo" || break
+  [[ -n "$REPO_FILTER" && "$repo" != *"$REPO_FILTER"* ]] && continue
+
+  src_sha=$(github_head_sha "$SRC_ORG" "$repo")
+  if [[ -z "$src_sha" ]]; then
+    warn "  SKIP: ${SRC_ORG}/${repo} — could not resolve source SHA"
+    continue
+  fi
+
+  if [[ "$DST_BACKEND" == "github" ]]; then
+    dst_sha=$(github_head_sha "$DST_ORG" "$repo")
+  else
+    dst_sha=$(gitlab_head_sha "$repo")
+  fi
+
+  if [[ -z "$dst_sha" ]]; then
+    warn "  MISSING: ${repo} not found in ${DST_ORG}"
+    MISMATCHES+=("MISSING:${repo}")
+    (( MISSING_COUNT++ )) || true
+    continue
+  fi
+
+  # Compare first 12 chars (short SHA) — GitLab may return full SHA, GitHub too
+  src_short="${src_sha:0:12}"
+  dst_short="${dst_sha:0:12}"
+
+  if [[ "$src_short" == "$dst_short" ]]; then
+    ok "  IN SYNC: ${repo} (${src_short})"
+    (( OK_COUNT++ )) || true
+  else
+    warn "  MISMATCH: ${repo} — src=${src_short} dst=${dst_short}"
+    MISMATCHES+=("MISMATCH:${repo}:src=${src_short}:dst=${dst_short}")
+    (( MISMATCH_COUNT++ )) || true
+  fi
+done
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+TOTAL_ISSUES=$(( MISMATCH_COUNT + MISSING_COUNT ))
+
+info ""
+info "Integrity check complete (${MIRROR_PAIR}):"
+info "  In sync:  ${OK_COUNT}"
+info "  Mismatch: ${MISMATCH_COUNT}"
+info "  Missing:  ${MISSING_COUNT}"
+
+if [[ ${#MISMATCHES[@]} -gt 0 ]]; then
+  info ""
+  info "Issues:"
+  for m in "${MISMATCHES[@]}"; do
+    warn "  ${m}"
+  done
+fi
+
+# Emit structured output for GitHub Actions step summary
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  {
+    echo "## Mirror Integrity: ${MIRROR_PAIR}"
+    echo ""
+    echo "| Metric | Count |"
+    echo "|--------|-------|"
+    echo "| ✅ In sync | ${OK_COUNT} |"
+    echo "| ⚠️ Mismatch | ${MISMATCH_COUNT} |"
+    echo "| ❌ Missing | ${MISSING_COUNT} |"
+    if [[ ${#MISMATCHES[@]} -gt 0 ]]; then
+      echo ""
+      echo "### Issues"
+      echo '```'
+      for m in "${MISMATCHES[@]}"; do echo "$m"; done
+      echo '```'
+    fi
+  } >> "$GITHUB_STEP_SUMMARY"
+fi
+
+if [[ "$BLOCK_ON_MISMATCH" == "true" && "$TOTAL_ISSUES" -gt 0 ]]; then
+  fail "Blocking: ${TOTAL_ISSUES} integrity issue(s) found in ${MIRROR_PAIR}."
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## What changed

Adds three new workflows to the `full-chain-flush` pipeline, expanding it from 13 to 18 stages. The new stages add a CI gate before mirroring, SHA integrity checks after each mirror hop, and an end-to-end health check at the end.

### New workflows

**`pre-mirror-ci-gate.yml` + `scripts/pre-mirror-ci-gate.sh` (stage 5)**

Runs before the first mirror hop (I-D-1896 → OSP). Checks CI status on all OSP-bound repos in `Interested-Deving-1896`, dispatches `resolve-failures.yml` for any red repos, waits for it to finish, then re-checks. Blocks the flush if repos are still failing after the resolver runs (`block_on_fail: true` by default — set to `false` to make it advisory).

**`verify-mirror-integrity.yml` + `scripts/verify-mirror-integrity.sh` (stages 7, 10, 14)**

Reusable workflow called after each of the three mirror hops. Compares default-branch HEAD SHAs between source and destination for all OSP-bound repos. Supports all three pairs via the `mirror_pair` input:
- `id-1896-to-osp` — after stage 6
- `osp-to-ooc` — after stage 9
- `osp-to-gitlab` — after stage 13 (requires `GITLAB_SYNC_TOKEN`; skipped silently if absent)

Mismatches are soft warnings by default (`block_on_mismatch: false`). Results are written to the step summary as a table.

**`post-flush-prep.yml` + `scripts/post-flush-prep.sh` (stage 18)**

Final stage of the flush. Runs four checks and writes a structured summary table:
1. Mirror integrity across all three pairs
2. CI status on I-D-1896 OSP-bound repos
3. Quota remaining after the flush
4. Workflow queue depth (queued + in-progress counts)

Non-blocking by default (`block_on_failure: false`).

### `full-chain-flush.yml` changes

Stage count updated from 13 → 18. All ActivitySmith `segmented_progress` payloads updated to `number_of_steps: 18`. New stages inserted at the correct positions in the dependency chain.

### Config registrations

All three workflows registered in:
- `config/workflow-sync.yml` — under `github_only`
- `config/workflow-priority-tiers.yml` — `Pre-Mirror CI Gate` at tier 2 (HIGH), `Verify Mirror Integrity` and `Post-Flush Verification` at tier 3 (MEDIUM)
- `config/workflow-quota-costs.yml` — with `code-audit` cost estimates

`validate-workflow-guards.py` passes: 79 workflows, all checks clean.

## Type

- [x] New feature / workflow

## Checklist

- [x] Validator scripts pass (`python3 scripts/validate-workflow-guards.py`)
- [x] Config files validated (`python3 scripts/validate-workflow-guards.py`)
- [x] No secrets or tokens committed
- [ ] `[skip ci]` used on any auto-generated commits where appropriate