### PR TITLE
feat: sync-template fixes, devcontainer SDK, git-platform-clis, brandable backend, subtree scaffold

### DIFF
--- a/.devcontainer/automations.template.yaml
+++ b/.devcontainer/automations.template.yaml
@@ -16,5 +16,5 @@ services:
       Reduces token consumption by 60-95% on typical agent workloads.
       Use with: ANTHROPIC_BASE_URL=http://localhost:8787 or headroom wrap claude.
     commands:
-      start: headroom proxy --port 8787
+      start: headroom proxy --port 8787 --no-ccr-inject-tool
       ready: curl -sf http://localhost:8787/livez

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,14 @@
   "name": "dev",
   "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
   "features": {
+    "./features/git-platform-clis": {
+      "gh_version": "latest",
+      "glab_version": "latest",
+      "gitea_version": "latest",
+      "install_hub": false,
+      "install_bb": false,
+      "install_forgejo_cli": false
+    },
     "ghcr.io/devcontainers/features/python:1": {
       "version": "3.12"
     },

--- a/.devcontainer/devcontainer.template.json
+++ b/.devcontainer/devcontainer.template.json
@@ -17,8 +17,16 @@
   "features": {
     "ghcr.io/devcontainers/features/python:1": {
       "version": "3.12"
+    },
+    "ghcr.io/interested-deving-1896/fork-sync-all/git-platform-clis:1": {
+      "gh_version": "latest",
+      "glab_version": "latest",
+      "gitea_version": "latest",
+      "install_hub": false,
+      "install_bb": false,
+      "install_forgejo_cli": false
     }
   },
-  "postCreateCommand": "pip install --quiet 'headroom-ai[proxy,mcp]'",
+  "postCreateCommand": "pip install --quiet 'headroom-ai[proxy,mcp]==0.25.0'",
   "remoteEnv": {}
 }

--- a/.devcontainer/features/git-platform-clis/devcontainer-feature.json
+++ b/.devcontainer/features/git-platform-clis/devcontainer-feature.json
@@ -1,0 +1,39 @@
+{
+  "id": "git-platform-clis",
+  "version": "1.0.0",
+  "name": "Git Platform CLIs",
+  "description": "Installs CLIs for all major git hosting platforms: gh (GitHub), glab (GitLab), gitea (Gitea/Forgejo), tea (Gitea legacy), hub (GitHub legacy), bb (Bitbucket). Provides a unified toolbelt for cross-platform repo management from within the devcontainer.",
+  "documentationURL": "https://github.com/Interested-Deving-1896/fork-sync-all",
+  "options": {
+    "gh_version": {
+      "type": "string",
+      "default": "latest",
+      "description": "GitHub CLI version. 'latest' installs the current release."
+    },
+    "glab_version": {
+      "type": "string",
+      "default": "latest",
+      "description": "GitLab CLI version. 'latest' installs the current release."
+    },
+    "gitea_version": {
+      "type": "string",
+      "default": "latest",
+      "description": "Gitea CLI (tea) version. 'latest' installs the current release."
+    },
+    "install_hub": {
+      "type": "boolean",
+      "default": false,
+      "description": "Install hub (legacy GitHub CLI). Disabled by default — gh supersedes it."
+    },
+    "install_bb": {
+      "type": "boolean",
+      "default": false,
+      "description": "Install bb (Bitbucket CLI via pip). Disabled by default."
+    },
+    "install_forgejo_cli": {
+      "type": "boolean",
+      "default": false,
+      "description": "Install forgejo-cli (Forgejo/Gitea v1.21+ API client). Disabled by default."
+    }
+  }
+}

--- a/.devcontainer/features/git-platform-clis/install.sh
+++ b/.devcontainer/features/git-platform-clis/install.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# Installs CLIs for all major git hosting platforms.
+# Runs inside the devcontainer build context as root.
+#
+# Platforms covered:
+#   gh      — GitHub CLI (cli.github.com)
+#   glab    — GitLab CLI (gitlab.com/gitlab-org/cli)
+#   tea     — Gitea/Forgejo CLI (gitea.com/gitea/tea)
+#   hub     — Legacy GitHub CLI (optional, superseded by gh)
+#   bb      — Bitbucket CLI via pip (optional)
+#   forgejo — Forgejo CLI (optional, for Forgejo v1.21+)
+set -uo pipefail
+
+GH_VERSION="${GH_VERSION:-latest}"
+GLAB_VERSION="${GLAB_VERSION:-latest}"
+GITEA_VERSION="${GITEA_VERSION:-latest}"
+INSTALL_HUB="${INSTALL_HUB:-false}"
+INSTALL_BB="${INSTALL_BB:-false}"
+INSTALL_FORGEJO_CLI="${INSTALL_FORGEJO_CLI:-false}"
+
+ARCH=$(uname -m)
+case "$ARCH" in
+  x86_64)  ARCH_GH="amd64"; ARCH_GLAB="amd64"; ARCH_TEA="amd64" ;;
+  aarch64) ARCH_GH="arm64"; ARCH_GLAB="arm64"; ARCH_TEA="arm64" ;;
+  armv7l)  ARCH_GH="armv6"; ARCH_GLAB="arm";   ARCH_TEA="arm-6" ;;
+  *)       ARCH_GH="amd64"; ARCH_GLAB="amd64"; ARCH_TEA="amd64" ;;
+esac
+
+info()  { echo "==> [git-platform-clis] $*"; }
+warn()  { echo "==> [git-platform-clis][warn] $*" >&2; }
+ok()    { echo "    ✓ $*"; }
+skip()  { echo "    - $* (skipped)"; }
+
+# ── Ensure base deps ──────────────────────────────────────────────────────────
+info "Ensuring base dependencies..."
+apt-get update -qq 2>/dev/null || true
+apt-get install -y --no-install-recommends \
+  curl wget tar gzip unzip ca-certificates \
+  2>/dev/null || true
+
+# ── Helper: resolve 'latest' to a real version tag ───────────────────────────
+resolve_gh_release() {
+  local repo="$1"
+  curl -sf "https://api.github.com/repos/${repo}/releases/latest" \
+    | python3 -c "import json,sys; print(json.load(sys.stdin)['tag_name'])" 2>/dev/null \
+    || echo ""
+}
+
+# ── 1. gh — GitHub CLI ───────────────────────────────────────────────────────
+info "Installing gh (GitHub CLI)..."
+if command -v gh >/dev/null 2>&1 && [[ "$GH_VERSION" == "latest" ]]; then
+  ok "gh already installed: $(gh --version 2>/dev/null | head -1)"
+else
+  # Use the official apt repo for reliable installs
+  if ! command -v gh >/dev/null 2>&1; then
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg 2>/dev/null
+    chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list
+    apt-get update -qq 2>/dev/null || true
+    apt-get install -y gh 2>/dev/null || true
+  fi
+  if command -v gh >/dev/null 2>&1; then
+    ok "gh $(gh --version 2>/dev/null | head -1)"
+  else
+    warn "gh install failed — skipping"
+  fi
+fi
+
+# ── 2. glab — GitLab CLI ─────────────────────────────────────────────────────
+info "Installing glab (GitLab CLI)..."
+if command -v glab >/dev/null 2>&1 && [[ "$GLAB_VERSION" == "latest" ]]; then
+  ok "glab already installed: $(glab --version 2>/dev/null | head -1)"
+else
+  GLAB_TAG="${GLAB_VERSION}"
+  if [[ "$GLAB_TAG" == "latest" ]]; then
+    GLAB_TAG=$(resolve_gh_release "gitlab-org/cli")
+  fi
+  if [[ -n "$GLAB_TAG" ]]; then
+    GLAB_VER="${GLAB_TAG#v}"
+    GLAB_URL="https://gitlab.com/gitlab-org/cli/-/releases/${GLAB_TAG}/downloads/glab_${GLAB_VER}_linux_${ARCH_GLAB}.deb"
+    TMP=$(mktemp /tmp/glab.XXXXXX.deb)
+    if curl -fsSL "$GLAB_URL" -o "$TMP" 2>/dev/null; then
+      dpkg -i "$TMP" 2>/dev/null || apt-get install -f -y 2>/dev/null || true
+      rm -f "$TMP"
+    else
+      # Fallback: binary tarball
+      GLAB_URL="https://gitlab.com/gitlab-org/cli/-/releases/${GLAB_TAG}/downloads/glab_${GLAB_VER}_Linux_${ARCH_GLAB}.tar.gz"
+      TMP=$(mktemp /tmp/glab.XXXXXX.tar.gz)
+      if curl -fsSL "$GLAB_URL" -o "$TMP" 2>/dev/null; then
+        tar -xzf "$TMP" -C /usr/local/bin --strip-components=2 "bin/glab" 2>/dev/null \
+          || tar -xzf "$TMP" -C /usr/local/bin 2>/dev/null || true
+        rm -f "$TMP"
+      else
+        warn "glab download failed for ${GLAB_TAG} — skipping"
+      fi
+    fi
+  fi
+  if command -v glab >/dev/null 2>&1; then
+    ok "glab $(glab --version 2>/dev/null | head -1)"
+  else
+    warn "glab install failed"
+  fi
+fi
+
+# ── 3. tea — Gitea/Forgejo CLI ───────────────────────────────────────────────
+info "Installing tea (Gitea/Forgejo CLI)..."
+if command -v tea >/dev/null 2>&1 && [[ "$GITEA_VERSION" == "latest" ]]; then
+  ok "tea already installed: $(tea --version 2>/dev/null | head -1)"
+else
+  TEA_TAG="${GITEA_VERSION}"
+  if [[ "$TEA_TAG" == "latest" ]]; then
+    TEA_TAG=$(curl -sf "https://gitea.com/api/v1/repos/gitea/tea/releases?limit=1" \
+      | python3 -c "import json,sys; d=json.load(sys.stdin); print(d[0]['tag_name'] if d else '')" 2>/dev/null || echo "")
+  fi
+  if [[ -n "$TEA_TAG" ]]; then
+    TEA_VER="${TEA_TAG#v}"
+    TEA_URL="https://dl.gitea.com/tea/${TEA_VER}/tea-${TEA_VER}-linux-${ARCH_TEA}"
+    if curl -fsSL "$TEA_URL" -o /usr/local/bin/tea 2>/dev/null; then
+      chmod +x /usr/local/bin/tea
+      ok "tea $(tea --version 2>/dev/null | head -1)"
+    else
+      warn "tea download failed for ${TEA_TAG} — skipping"
+    fi
+  else
+    warn "Could not resolve tea version — skipping"
+  fi
+fi
+
+# ── 4. hub — Legacy GitHub CLI (optional) ────────────────────────────────────
+if [[ "$INSTALL_HUB" == "true" ]]; then
+  info "Installing hub (legacy GitHub CLI)..."
+  HUB_TAG=$(resolve_gh_release "mislav/hub")
+  if [[ -n "$HUB_TAG" ]]; then
+    HUB_VER="${HUB_TAG#v}"
+    HUB_URL="https://github.com/mislav/hub/releases/download/${HUB_TAG}/hub-linux-${ARCH_GH}-${HUB_VER}.tgz"
+    TMP=$(mktemp /tmp/hub.XXXXXX.tgz)
+    if curl -fsSL "$HUB_URL" -o "$TMP" 2>/dev/null; then
+      tar -xzf "$TMP" -C /tmp 2>/dev/null
+      HUB_BIN=$(find /tmp -name 'hub' -type f 2>/dev/null | head -1)
+      [[ -n "$HUB_BIN" ]] && mv "$HUB_BIN" /usr/local/bin/hub && chmod +x /usr/local/bin/hub
+      rm -f "$TMP"
+    fi
+  fi
+  command -v hub >/dev/null 2>&1 \
+    && ok "hub $(hub --version 2>/dev/null | head -1)" \
+    || warn "hub install failed"
+else
+  skip "hub (set install_hub=true to enable)"
+fi
+
+# ── 5. bb — Bitbucket CLI (optional) ─────────────────────────────────────────
+if [[ "$INSTALL_BB" == "true" ]]; then
+  info "Installing bb (Bitbucket CLI)..."
+  PIP_BIN=""
+  for p in pip3 pip pip3.12 pip3.11; do
+    command -v "$p" >/dev/null 2>&1 && PIP_BIN="$p" && break
+  done
+  if [[ -n "$PIP_BIN" ]]; then
+    "$PIP_BIN" install --quiet --break-system-packages "bitbucket-cli" 2>/dev/null \
+      || "$PIP_BIN" install --quiet "bitbucket-cli" 2>/dev/null || true
+    command -v bb >/dev/null 2>&1 \
+      && ok "bb installed" \
+      || warn "bb install failed — try: pip install bitbucket-cli"
+  else
+    warn "pip not available — cannot install bb"
+  fi
+else
+  skip "bb (set install_bb=true to enable)"
+fi
+
+# ── 6. forgejo-cli (optional) ────────────────────────────────────────────────
+if [[ "$INSTALL_FORGEJO_CLI" == "true" ]]; then
+  info "Installing forgejo-cli..."
+  FORGEJO_TAG=$(resolve_gh_release "Codeberg/forgejo-cli" 2>/dev/null || echo "")
+  if [[ -n "$FORGEJO_TAG" ]]; then
+    FORGEJO_VER="${FORGEJO_TAG#v}"
+    FORGEJO_URL="https://codeberg.org/Codeberg/forgejo-cli/releases/download/${FORGEJO_TAG}/forgejo-cli_${FORGEJO_VER}_linux_${ARCH_GH}.tar.gz"
+    TMP=$(mktemp /tmp/forgejo.XXXXXX.tar.gz)
+    if curl -fsSL "$FORGEJO_URL" -o "$TMP" 2>/dev/null; then
+      tar -xzf "$TMP" -C /usr/local/bin 2>/dev/null || true
+      rm -f "$TMP"
+    fi
+  fi
+  command -v forgejo-cli >/dev/null 2>&1 \
+    && ok "forgejo-cli installed" \
+    || warn "forgejo-cli install failed"
+else
+  skip "forgejo-cli (set install_forgejo_cli=true to enable)"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+info "Git platform CLIs installed:"
+for cli in gh glab tea hub bb forgejo-cli; do
+  if command -v "$cli" >/dev/null 2>&1; then
+    ver=$("$cli" --version 2>/dev/null | head -1 || echo "installed")
+    echo "    ✓ ${cli}: ${ver}"
+  fi
+done
+echo ""
+echo "    Authenticate with:"
+echo "      gh auth login"
+echo "      glab auth login"
+echo "      tea login add"

--- a/.github/workflows/check-shell-tools-ci.yml
+++ b/.github/workflows/check-shell-tools-ci.yml
@@ -60,6 +60,8 @@ jobs:
           TOOL_FILTER: ${{ inputs.tool_filter || '' }}
           FAIL_ON_RED: ${{ inputs.fail_on_red || 'false' }}
         run: |
+          source scripts/includes/quota-instrument.sh
+          qi_begin
           python3 - config/shell-tools-registry.yml "$TOOL_FILTER" "$FAIL_ON_RED" << 'PYEOF'
           import yaml, sys, json, urllib.request, os
 
@@ -157,7 +159,12 @@ jobs:
 
       - name: Write step summary
         if: always() && steps.quota.outputs.skip == 'false'
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
         run: |
+          qi_end
           echo "## Shell Tools CI Status" >> "$GITHUB_STEP_SUMMARY"
           echo "Run at: $(date -u '+%Y-%m-%d %H:%M UTC')" >> "$GITHUB_STEP_SUMMARY"
           echo "See job log for full table." >> "$GITHUB_STEP_SUMMARY"
+          bash scripts/write-summary.sh

--- a/.github/workflows/check-shell-tools-ci.yml
+++ b/.github/workflows/check-shell-tools-ci.yml
@@ -49,7 +49,7 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: steps.quota.outputs.skip == 'false'
 
       - name: Fetch CI status via GraphQL

--- a/.github/workflows/devcontainer-sdk.yml
+++ b/.github/workflows/devcontainer-sdk.yml
@@ -1,0 +1,157 @@
+name: Devcontainer SDK
+
+# Treats the devcontainer as a first-class API/SDK surface:
+#
+#   validate  — Verify devcontainer.json, all features, and automations
+#               templates are well-formed and internally consistent.
+#               Runs automatically on push to .devcontainer/.
+#
+#   build     — Build and push the devcontainer image to GHCR as a
+#               reusable OCI artifact. Downstream workflows can pull
+#               this image instead of rebuilding from scratch.
+#
+#   publish   — Publish devcontainer features from .devcontainer/features/
+#               to GHCR as OCI artifacts so consumers can reference them
+#               by URI (ghcr.io/ORG/REPO/FEATURE:VERSION).
+#
+# The devcontainer image acts as an SDK: it bundles all platform CLIs
+# (gh, glab, tea), Python tooling, and fork-sync-all scripts into a
+# single reproducible environment any workflow or developer can pull.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .devcontainer/**
+      - .github/workflows/devcontainer-sdk.yml
+
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'Operation mode'
+        required: true
+        type: choice
+        options: [validate, build, publish]
+        default: validate
+      dry_run:
+        description: 'Log actions without pushing images or features'
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: devcontainer-sdk-${{ inputs.mode || 'auto' }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  quota:
+    name: Quota pre-flight
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.check.outputs.skip }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check quota
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+        run: |
+          source scripts/includes/budget.sh
+          min=$(workflow_min_quota "Devcontainer SDK")
+          remaining=$(curl -sf -H "Authorization: token $GH_TOKEN" \
+            "https://api.github.com/rate_limit" | jq '.resources.core.remaining // 0')
+          if [[ "$remaining" -lt "$min" ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Quota too low ($remaining < $min) — skipping." >&2
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  validate:
+    name: Validate devcontainer
+    runs-on: ubuntu-latest
+    needs: quota
+    if: needs.quota.outputs.skip == 'false'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install dependencies
+        run: pip install pyyaml --quiet
+
+      - name: Validate devcontainer setup
+        run: python3 scripts/devcontainer-validate.py
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: '{"mode":"validate"}'
+        run: bash scripts/write-summary.sh
+
+  build:
+    name: Build devcontainer image
+    runs-on: ubuntu-latest
+    needs: [quota, validate]
+    if: needs.quota.outputs.skip == 'false' && inputs.mode == 'build'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push devcontainer image
+        id: build_image
+        env:
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: bash scripts/devcontainer-build.sh
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh
+
+  publish-features:
+    name: Publish devcontainer features to GHCR
+    runs-on: ubuntu-latest
+    needs: [quota, validate]
+    if: needs.quota.outputs.skip == 'false' && inputs.mode == 'publish'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install devcontainer CLI
+        run: npm install -g @devcontainers/cli --quiet 2>/dev/null || true
+
+      - name: Publish features
+        env:
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          REPO: ${{ github.repository }}
+        run: bash scripts/devcontainer-publish-features.sh
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/full-audit.yml
+++ b/.github/workflows/full-audit.yml
@@ -352,6 +352,126 @@ jobs:
               sys.exit(1)
           PYEOF
 
+      - name: Check 16 — new workflows registered in all config files
+        if: steps.quota.outputs.skip == 'false'
+        id: check_new_wf_registration
+        run: |
+          python3 - << 'PYEOF'
+          import yaml, glob, sys
+          costs  = yaml.safe_load(open('config/workflow-quota-costs.yml'))
+          tiers  = yaml.safe_load(open('config/workflow-priority-tiers.yml'))
+          sync   = yaml.safe_load(open('config/workflow-sync.yml'))
+          cost_names = {e['name'] for e in costs.get('workflows', [])}
+          tier_names = {e['name'] for e in tiers.get('tiers', [])}
+          synced = set()
+          for e in sync.get('github_only', []):
+              f = e if isinstance(e, str) else e.get('workflow_file', e.get('file',''))
+              if f: synced.add(f)
+          for e in sync.get('paired', []):
+              if isinstance(e, dict):
+                  f = (e.get('github') or {}).get('workflow_file','')
+                  if f: synced.add(f)
+          errors = []
+          for path in glob.glob('.github/workflows/*.yml') + glob.glob('.github/workflows/*.yaml'):
+              try:
+                  wf = yaml.safe_load(open(path))
+                  name = (wf or {}).get('name','')
+                  fname = path.split('/')[-1]
+              except Exception:
+                  continue
+              if not name: continue
+              if name not in cost_names: errors.append(f"MISSING quota-cost: '{name}' ({fname})")
+              if name not in tier_names:  errors.append(f"MISSING priority-tier: '{name}' ({fname})")
+              if fname not in synced:     errors.append(f"MISSING workflow-sync: {fname}")
+          if errors:
+              for e in errors: print(e)
+              sys.exit(1)
+          print(f"OK  all workflows registered in quota-costs, priority-tiers, workflow-sync")
+          PYEOF
+
+      - name: Check 17 — devcontainer templates wired into profiles
+        if: steps.quota.outputs.skip == 'false'
+        id: check_dc_wired
+        run: |
+          python3 - << 'PYEOF'
+          import yaml, sys
+          manifest = yaml.safe_load(open('config/template-manifest.yml'))
+          all_includes = []
+          for pname, profile in (manifest.get('profiles') or {}).items():
+              for e in (profile.get('include') or []):
+                  all_includes.append(e)
+          dc_template   = '.devcontainer/devcontainer.template.json'
+          auto_template = '.devcontainer/automations.template.yaml'
+          errors = []
+          if not any(dc_template in e for e in all_includes):
+              errors.append(f"UNWIRED: {dc_template} not in any profile include")
+          if not any(auto_template in e for e in all_includes):
+              errors.append(f"UNWIRED: {auto_template} not in any profile include")
+          if errors:
+              for e in errors: print(e)
+              sys.exit(1)
+          print("OK  devcontainer templates wired into profiles")
+          PYEOF
+
+      - name: Check 18 — onboarding dispatch_list workflows exist
+        if: steps.quota.outputs.skip == 'false'
+        id: check_onboard_dispatch
+        run: |
+          python3 - << 'PYEOF'
+          import yaml, os, sys
+          ob = yaml.safe_load(open('config/onboarding.yml'))
+          errors = []
+          for entry in ob.get('dispatch_list', []):
+              wf = entry.get('workflow','')
+              if wf and not os.path.exists(f'.github/workflows/{wf}'):
+                  errors.append(f"MISSING: onboarding dispatch_list → {wf}")
+          if errors:
+              for e in errors: print(e)
+              sys.exit(1)
+          print(f"OK  all {len(ob.get('dispatch_list',[]))} onboarding dispatch_list workflows exist")
+          PYEOF
+
+      - name: Check 19 — shell-tools registry vs consumers vs imports
+        if: steps.quota.outputs.skip == 'false'
+        id: check_shell_tools_wiring
+        run: |
+          python3 - << 'PYEOF'
+          import yaml, json, sys
+          registry  = yaml.safe_load(open('config/shell-tools-registry.yml'))
+          consumers = yaml.safe_load(open('config/template-consumers.yml'))
+          imports   = json.load(open('registered-imports.json'))
+          reg_repos  = {t['repo'] for t in registry.get('tools', [])}
+          shell_cons = {c['name'] for c in consumers.get('consumers', []) if c.get('profile') == 'shell-tools'}
+          imp_names  = {e['target_name'] for e in imports}
+          errors = []
+          for r in sorted(reg_repos - shell_cons):
+              errors.append(f"In registry but not template-consumers (shell-tools profile): {r}")
+          for r in sorted(reg_repos - imp_names):
+              errors.append(f"In registry but not registered-imports: {r}")
+          if errors:
+              for e in errors: print(e)
+              sys.exit(1)
+          print(f"OK  {len(reg_repos)} shell-tools all in consumers + imports")
+          PYEOF
+
+      - name: Check 20 — pre-flush-prep min_quota adequate
+        if: steps.quota.outputs.skip == 'false'
+        id: check_flush_quota
+        run: |
+          python3 - << 'PYEOF'
+          import yaml, sys
+          costs = yaml.safe_load(open('config/workflow-quota-costs.yml'))
+          for e in costs.get('workflows', []):
+              if e['name'] == 'Pre-Flush Prep':
+                  mq = e.get('min_quota', 0)
+                  if mq < 1500:
+                      print(f"ERROR Pre-Flush Prep min_quota={mq} (needs ≥1500)")
+                      sys.exit(1)
+                  print(f"OK  Pre-Flush Prep min_quota={mq}")
+                  sys.exit(0)
+          print("WARN Pre-Flush Prep not found in quota-costs")
+          PYEOF
+
       - name: Summarise
         if: always() && steps.quota.outputs.skip == 'false'
         run: |
@@ -359,7 +479,7 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "| Check | Result |" >> "$GITHUB_STEP_SUMMARY"
           echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
-          for check in check_yaml check_guards check_shell check_perms check_ext check_registry check_sync check_assets check_consumers check_shell_tools check_vendor check_chains check_schedules check_imports check_subgroups; do
+          for check in check_yaml check_guards check_shell check_perms check_ext check_registry check_sync check_assets check_consumers check_shell_tools check_vendor check_chains check_schedules check_imports check_subgroups check_new_wf_registration check_dc_wired check_onboard_dispatch check_shell_tools_wiring check_flush_quota; do
             result="${{ steps[check].outcome }}"
             icon="✅"
             [[ "$result" == "failure" ]] && icon="❌"

--- a/.github/workflows/full-audit.yml
+++ b/.github/workflows/full-audit.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Quota pre-flight
         id: quota

--- a/.github/workflows/integrate-shell-tools.yml
+++ b/.github/workflows/integrate-shell-tools.yml
@@ -43,7 +43,7 @@ jobs:
     name: Shell tools smoke tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/integrate-shell-tools.yml
+++ b/.github/workflows/integrate-shell-tools.yml
@@ -30,6 +30,11 @@ on:
         required: false
         default: false
         type: boolean
+      dry_run:
+        description: 'Log smoke tests without executing them'
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: integrate-shell-tools
@@ -39,9 +44,34 @@ permissions:
   contents: read
 
 jobs:
+  quota:
+    name: Quota pre-flight
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.check.outputs.skip }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check quota
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+        run: |
+          source scripts/includes/budget.sh
+          min=$(workflow_min_quota "Integrate Shell Tools")
+          remaining=$(curl -sf -H "Authorization: token $GH_TOKEN" \
+            "https://api.github.com/rate_limit" | jq '.resources.core.remaining // 0')
+          if [[ "$remaining" -lt "$min" ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Quota too low ($remaining < $min) — skipping." >&2
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
   smoke-tests:
     name: Shell tools smoke tests
     runs-on: ubuntu-latest
+    needs: quota
+    if: needs.quota.outputs.skip == 'false'
     steps:
       - uses: actions/checkout@v6
 
@@ -58,10 +88,13 @@ jobs:
         id: smoke
         env:
           TOOL_FILTER: ${{ inputs.tool_filter || '' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
           FAIL_ON_ERROR: ${{ inputs.fail_on_error || 'false' }}
           REPO_ROOT: ${{ github.workspace }}
         run: |
           set -uo pipefail
+          source scripts/includes/quota-instrument.sh
+          qi_begin
           source scripts/includes/shell-tools.sh
 
           passed=0
@@ -165,7 +198,11 @@ jobs:
 
       - name: Write step summary
         if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
         run: |
+          qi_end
           echo "## Shell Tools Integration" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "| Metric | Value |" >> "$GITHUB_STEP_SUMMARY"
@@ -174,3 +211,4 @@ jobs:
           echo "| Smoke tests failed | ${{ steps.smoke.outputs.failed || 0 }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Smoke tests skipped | ${{ steps.smoke.outputs.skipped || 0 }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Run at | $(date -u '+%Y-%m-%d %H:%M UTC') |" >> "$GITHUB_STEP_SUMMARY"
+          bash scripts/write-summary.sh

--- a/.github/workflows/manage-subtrees.yml
+++ b/.github/workflows/manage-subtrees.yml
@@ -1,0 +1,109 @@
+name: Manage Subtrees
+
+# Keeps git subtrees, submodules, and umbrella repo relationships
+# declared in config/subtree-manifest.yml current.
+#
+# Runs weekly (Sunday 01:00 UTC) and on manual dispatch.
+# All operations are idempotent — safe to re-run at any time.
+#
+# Commands:
+#   sync              — add/update all subtrees + submodules per manifest
+#   umbrella-init     — register all umbrella children as submodules
+#   update-submodules — pull latest on all submodule branches
+#   status            — report current state (no writes)
+
+on:
+  schedule:
+    - cron: '0 1 * * 0'   # Sunday 01:00 UTC
+
+  workflow_dispatch:
+    inputs:
+      command:
+        description: 'Operation to run'
+        required: false
+        type: choice
+        options: [sync, umbrella-init, update-submodules, status]
+        default: sync
+      dry_run:
+        description: 'Log actions without executing git operations'
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: manage-subtrees
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  quota:
+    name: Quota pre-flight
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.check.outputs.skip }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check quota
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+        run: |
+          source scripts/includes/budget.sh
+          min=$(workflow_min_quota "Manage Subtrees")
+          remaining=$(curl -sf -H "Authorization: token $GH_TOKEN" \
+            "https://api.github.com/rate_limit" | jq '.resources.core.remaining // 0')
+          if [[ "$remaining" -lt "$min" ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Quota too low ($remaining < $min) — skipping." >&2
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  run:
+    name: ${{ inputs.command || 'sync' }}
+    runs-on: ubuntu-latest
+    needs: quota
+    if: needs.quota.outputs.skip == 'false'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.SYNC_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Install dependencies
+        run: pip install pyyaml --quiet
+
+      - name: Run manage-subtrees
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          MANIFEST: config/subtree-manifest.yml
+        run: bash scripts/manage-subtrees.sh ${{ inputs.command || 'sync' }}
+
+      - name: Commit changes
+        if: inputs.command != 'status' && inputs.dry_run != true
+        run: |
+          if git diff --quiet && git diff --staged --quiet; then
+            echo "No changes to commit" >&2
+          else
+            git add -A
+            git commit -m "chore(subtrees): ${{ inputs.command || 'sync' }} [skip ci]" \
+              -m "Automated by Manage Subtrees workflow." \
+              -m "Co-authored-by: Ona <no-reply@ona.com>"
+            git push
+          fi
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/onboard-repo.yml
+++ b/.github/workflows/onboard-repo.yml
@@ -90,7 +90,7 @@ jobs:
       has_repos: ${{ steps.diff.outputs.has_repos }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
 
@@ -126,7 +126,7 @@ jobs:
       skip: ${{ steps.check.outputs.skip }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Check quota
         id: check
         env:
@@ -154,7 +154,7 @@ jobs:
         repo: ${{ fromJSON(needs.detect.outputs.repos_json) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Onboard ${{ matrix.repo.name }}
         env:

--- a/.github/workflows/onboard-repo.yml
+++ b/.github/workflows/onboard-repo.yml
@@ -175,7 +175,10 @@ jobs:
           DO_DISPATCH_WORKFLOWS: ${{ inputs.dispatch_workflows || '' }}
         run: |
           pip install pyyaml --quiet
+          source scripts/includes/quota-instrument.sh
+          qi_begin
           bash scripts/onboard-repo.sh
+          qi_end
 
       - name: Write summary
         if: always()

--- a/.github/workflows/sync-shell-tools.yml
+++ b/.github/workflows/sync-shell-tools.yml
@@ -55,7 +55,7 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: steps.quota.outputs.skip == 'false'
         with:
           token: ${{ secrets.SYNC_TOKEN }}

--- a/.github/workflows/sync-shell-tools.yml
+++ b/.github/workflows/sync-shell-tools.yml
@@ -171,3 +171,10 @@ jobs:
             -m "Synced by sync-shell-tools.yml at ${TS}" \
             -m "Co-authored-by: Ona <no-reply@ona.com>"
           git push origin main
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -107,7 +107,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout fork-sync-all (template source)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -205,7 +205,7 @@ jobs:
     needs: validate
     steps:
       - name: Checkout fork-sync-all (template source)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -240,7 +240,7 @@ jobs:
     needs: validate
     steps:
       - name: Checkout fork-sync-all (template source)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -107,7 +107,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout fork-sync-all (template source)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
@@ -205,7 +205,7 @@ jobs:
     needs: validate
     steps:
       - name: Checkout fork-sync-all (template source)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
@@ -240,7 +240,7 @@ jobs:
     needs: validate
     steps:
       - name: Checkout fork-sync-all (template source)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 

--- a/.github/workflows/sync-uaa-vendor.yml
+++ b/.github/workflows/sync-uaa-vendor.yml
@@ -58,7 +58,7 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: steps.quota.outputs.skip == 'false'
         with:
           token: ${{ secrets.SYNC_TOKEN }}

--- a/.github/workflows/sync-uaa-vendor.yml
+++ b/.github/workflows/sync-uaa-vendor.yml
@@ -71,6 +71,8 @@ jobs:
           UPSTREAM_REF: ${{ inputs.upstream_ref || 'main' }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: |
+          source scripts/includes/quota-instrument.sh
+          qi_begin
           UPSTREAM="https://x-access-token:${GH_TOKEN}@github.com/Interested-Deving-1896/unified-agnostic-api.git"
           VENDOR_DIR="vendor/unified-agnostic-api"
 
@@ -116,3 +118,11 @@ jobs:
             -m "Synced from Interested-Deving-1896/unified-agnostic-api@${SHORT}" \
             -m "Co-authored-by: Ona <no-reply@ona.com>"
           git push origin main
+          qi_end
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,13 +296,18 @@ can measure it automatically.
 - Reconcile Org References
 - Cleanup Stale Branches
 - Check OSP-Bound CI Status
+- Check Shell Tools CI
 - Sync Registered Imports
+- Sync Shell Tools
+- Sync UAA Vendor
 - Mirror Interested-Deving-1896 → OSP
 - Pre-Mirror CI Gate
 - Verify Mirror Integrity
 - Post-Flush Verification
 - Pipeline Telemetry
 - Translate Docs
+- Integrate Shell Tools
+- Onboard Repo
 
 ### Path filters + required status checks (gate job pattern)
 
@@ -439,6 +444,61 @@ repo. Plain entries (no `:`) write to the same path.
 are skipped if the destination file already exists in the target repo. This
 prevents overwriting a consumer's existing `DOCS/` content on subsequent syncs.
 
+### Devcontainer template propagation
+
+`devcontainer.template.json` and `automations.template.yaml` are propagated to
+consumer repos via source:dest remaps in `config/template-manifest.yml`. Both
+are scaffold-only — skipped if the destination already exists in the consumer.
+
+```yaml
+include:
+  - .devcontainer/devcontainer.template.json:.devcontainer/devcontainer.json
+  - .devcontainer/automations.template.yaml:.ona/automations.yaml
+```
+
+These entries are present in the `infra-core`, `upstream-sync`, `standalone`,
+and `shell-tools` profiles. The `.devcontainer/` directory is otherwise excluded
+from template sync (it contains fork-sync-all-specific config that consumers
+should not receive).
+
+**Template divergence rule**: `devcontainer.template.json` and the live
+`.devcontainer/devcontainer.json` must stay in sync. When updating either:
+- Pin `headroom-ai` to a specific version in both files
+- Keep `--no-ccr-inject-tool` in the headroom proxy start command in both
+  `automations.template.yaml` and `.ona/automations.yaml`
+- Run `python3 scripts/devcontainer-validate.py` to catch divergences
+
+### Devcontainer feature — `git-platform-clis`
+
+`.devcontainer/features/git-platform-clis/` is a devcontainer feature that
+installs CLIs for all major git hosting platforms.
+
+**Installed by default:** `gh` (GitHub CLI), `glab` (GitLab CLI), `tea` (Gitea CLI)
+
+**Optional via feature options:** `hub` (legacy GitHub CLI), `bb` (Bitbucket CLI),
+`forgejo-cli` (Forgejo/Gitea v1.21+ API client) — all `false` by default.
+
+Referenced in `devcontainer.json` and `devcontainer.template.json` by local path.
+When published to GHCR via `devcontainer-sdk.yml publish` mode, consumers can
+reference it by URI: `ghcr.io/Interested-Deving-1896/fork-sync-all/git-platform-clis:1`
+
+**The feature has not yet been published to GHCR.** Until a `publish` run
+completes, only local path references work. Run `devcontainer-sdk.yml` with
+`mode: publish` to push it.
+
+### Devcontainer SDK workflow (`devcontainer-sdk.yml`)
+
+Three modes, selectable via `workflow_dispatch`:
+
+| Mode | Trigger | What it does |
+|---|---|---|
+| `validate` | Auto on push to `.devcontainer/` | Runs `devcontainer-validate.py` — checks JSON validity, template divergence, feature schema |
+| `build` | Manual | Builds the devcontainer image and pushes to GHCR as an OCI artifact |
+| `publish` | Manual | Publishes features from `.devcontainer/features/` to GHCR so consumers can reference by URI |
+
+Supporting scripts: `scripts/devcontainer-validate.py`, `scripts/devcontainer-build.sh`,
+`scripts/devcontainer-publish-features.sh`, `scripts/devcontainer-base-image.py`.
+
 ### Verify Fork Integrity
 
 `verify-fork-integrity.yml` / `scripts/verify-fork-integrity.sh` — single-repo
@@ -574,6 +634,82 @@ concurrency:
   group: workflow-name-${{ github.ref }}
   cancel-in-progress: true
 ```
+
+---
+
+## Brandable backend
+
+`config/brand.yml` allows fork-sync-all to be adopted as a white-label subsystem.
+When `brand.enabled=true`, `sync-template.sh` substitutes `{{FSA_*}}` tokens in
+propagated file content with the consumer's own identity values.
+
+**Default state: `brand.enabled=false`** — no behaviour change until a consumer
+explicitly opts in by setting `enabled: true` in their own `config/brand.yml`.
+
+### Substitution tokens
+
+| Token | Field | Example |
+|---|---|---|
+| `{{FSA_NAME}}` | `brand.name` | `fork-sync-all` |
+| `{{FSA_SLUG}}` | `brand.slug` | `fsa` |
+| `{{FSA_ORG}}` | `brand.org` | `Interested-Deving-1896` |
+| `{{FSA_REPO}}` | `brand.repo` | `fork-sync-all` |
+| `{{FSA_DESCRIPTION}}` | `brand.description` | one-line description |
+| `{{FSA_SUPPORT_URL}}` | `brand.support_url` | support/docs URL |
+
+### Applying brand substitution
+
+`scripts/apply-brand.py` reads `config/brand.yml` and rewrites tokens in a
+target file. Called by `sync-template.sh` after writing each propagated file
+when `brand.enabled=true`.
+
+```bash
+python3 scripts/apply-brand.py path/to/file.yml
+```
+
+### `skin.files` overrides
+
+The `skin.files` list in `config/brand.yml` maps source files to destination
+paths in consumer repos, applied after the profile include list. Entries are
+scaffold-only by default (`scaffold_only: true`). Set `scaffold_only: false`
+to always overwrite.
+
+---
+
+## Git subtree / submodule / umbrella scaffold
+
+`config/subtree-manifest.yml` declares three relationship types between this
+repo and external repos. `scripts/manage-subtrees.sh` implements all operations.
+`manage-subtrees.yml` runs weekly (Sunday 01:00 UTC) and on manual dispatch.
+
+### Relationship types
+
+| Type | Mechanism | Best for |
+|---|---|---|
+| `subtree` | `git subtree add/pull` — remote history merged under a prefix dir, no `.gitmodules` | Vendored upstream code you modify locally |
+| `submodule` | Standard git submodule — pinned SHA, `.gitmodules` entry, pointer not copy | External deps you consume but don't modify |
+| `umbrella` | This repo as super-repo — aggregates child repos as submodules under `umbrella.prefix/` | Monorepo-style development across org repos |
+
+### `manage-subtrees.sh` commands
+
+```bash
+bash scripts/manage-subtrees.sh sync          # pull all subtrees + update all submodules
+bash scripts/manage-subtrees.sh add <name>    # add a new subtree/submodule from manifest
+bash scripts/manage-subtrees.sh status        # show drift vs upstream for all entries
+bash scripts/manage-subtrees.sh umbrella-init # initialise umbrella children as submodules
+```
+
+### Adding a new entry
+
+Add to the appropriate list in `config/subtree-manifest.yml`, then run
+`manage-subtrees.sh add <name>`. Do not run `git subtree add` or
+`git submodule add` manually — the script handles squash flags, shallow
+clones, and `.gitmodules` consistency.
+
+### Nested submodule policy
+
+`nested.recurse=false` by default. Enable only when a submodule itself has
+submodules you need. `nested.max_depth=2` prevents runaway recursion.
 
 ---
 

--- a/config/brand.yml
+++ b/config/brand.yml
@@ -1,0 +1,69 @@
+# config/brand.yml
+#
+# Brandable backend configuration for fork-sync-all.
+#
+# fork-sync-all can be adopted as a white-label subsystem by consumer repos.
+# When a consumer sets brand.enabled=true, the sync-template workflow uses
+# these values to customise the files it propagates — replacing fork-sync-all
+# references with the consumer's own identity.
+#
+# This file defines the DEFAULT (fork-sync-all's own) brand.
+# Consumer repos override it via their own config/brand.yml (propagated as
+# a scaffold-only file — only written if the consumer doesn't have one yet).
+#
+# Fields:
+#   enabled         — activate branding substitution in propagated files
+#   name            — human-readable product name
+#   slug            — short identifier used in workflow names, labels, etc.
+#   org             — GitHub org that owns this fork-sync-all instance
+#   repo            — repo name of this fork-sync-all instance
+#   description     — one-line description shown in welcome issues + READMEs
+#   color           — hex accent color (used in labels, badges)
+#   logo_url        — URL to a logo image (used in generated READMEs)
+#   support_url     — URL for support / documentation
+#   upstream        — upstream fork-sync-all repo this instance tracks
+#                     (used by ota-self-update.yml for branded update checks)
+#
+# Substitution tokens (replaced in propagated file content):
+#   {{FSA_NAME}}        → brand.name
+#   {{FSA_SLUG}}        → brand.slug
+#   {{FSA_ORG}}         → brand.org
+#   {{FSA_REPO}}        → brand.repo
+#   {{FSA_DESCRIPTION}} → brand.description
+#   {{FSA_SUPPORT_URL}} → brand.support_url
+
+brand:
+  enabled: false
+  name: "fork-sync-all"
+  slug: "fsa"
+  org: "Interested-Deving-1896"
+  repo: "fork-sync-all"
+  description: "Org-wide mirror, sync, and template propagation control plane"
+  color: "0075ca"
+  logo_url: ""
+  support_url: "https://github.com/Interested-Deving-1896/fork-sync-all"
+  upstream: "Interested-Deving-1896/fork-sync-all"
+
+# Theming — controls visual presentation in generated READMEs and issues.
+# All fields are optional; unset fields fall back to fork-sync-all defaults.
+theme:
+  badge_style: "flat-square"   # shields.io badge style
+  readme_header: ""            # custom header injected at top of generated READMEs
+  readme_footer: ""            # custom footer injected at bottom of generated READMEs
+  issue_prefix: ""             # prefix added to all auto-opened issue titles
+
+# Skinning — file-level overrides propagated to consumers.
+# Each entry maps a source file (in this repo) to a destination path in the
+# consumer repo. These are applied AFTER the profile include list, allowing
+# brand-specific files to override profile defaults.
+# Entries are scaffold-only by default (skipped if destination already exists).
+skin:
+  files: []
+  # Example:
+  # files:
+  #   - source: assets/brand/README-header.md
+  #     dest: .github/README-header.md
+  #     scaffold_only: true
+  #   - source: assets/brand/CONTRIBUTING.md
+  #     dest: CONTRIBUTING.md
+  #     scaffold_only: false   # always overwrite

--- a/config/subtree-manifest.yml
+++ b/config/subtree-manifest.yml
@@ -1,0 +1,65 @@
+# config/subtree-manifest.yml
+#
+# Declares git subtrees and submodules for this repo and its consumers.
+#
+# Three relationship types:
+#
+#   subtree    — git subtree add/pull. The remote's history is merged into
+#                this repo under a prefix directory. No .gitmodules entry.
+#                Best for: vendoring upstream code you want to modify locally.
+#
+#   submodule  — standard git submodule. Pinned to a specific commit SHA.
+#                A .gitmodules entry is created. The submodule dir is a
+#                pointer, not a copy.
+#                Best for: external dependencies you consume but don't modify.
+#
+#   umbrella   — this repo acts as an umbrella (super-repo) that aggregates
+#                multiple child repos as submodules. The umbrella pattern
+#                gives a single checkout that spans all child repos.
+#                Best for: monorepo-style development across org repos.
+#
+# manage-subtrees.yml reads this file and keeps all entries current.
+# manage-subtrees.sh is the implementation script.
+
+# ── Subtrees (merged history, local prefix) ───────────────────────────────────
+subtrees: []
+# Example:
+# subtrees:
+#   - name: infra-dashboard
+#     remote: https://github.com/Interested-Deving-1896/infra-dashboard
+#     branch: main
+#     prefix: vendor/infra-dashboard
+#     squash: true          # squash upstream history on pull (recommended)
+#     message: "chore: sync infra-dashboard subtree"
+
+# ── Submodules (pinned pointer, .gitmodules entry) ────────────────────────────
+submodules: []
+# Example:
+# submodules:
+#   - name: btrfs-dwarfs-framework
+#     url: https://github.com/Interested-Deving-1896/btrfs-dwarfs-framework
+#     path: modules/btrfs-dwarfs-framework
+#     branch: main
+#     shallow: true         # clone with --depth=1
+
+# ── Umbrella repos (this repo aggregates children as submodules) ──────────────
+# When umbrella.enabled=true, manage-subtrees.sh ensures all listed children
+# are registered as submodules under umbrella.prefix/.
+umbrella:
+  enabled: false
+  prefix: repos
+  children: []
+  # Example:
+  # children:
+  #   - name: btrfs-dwarfs-framework
+  #     url: https://github.com/Interested-Deving-1896/btrfs-dwarfs-framework
+  #     branch: main
+  #   - name: immutable-linux-framework
+  #     url: https://github.com/Interested-Deving-1896/immutable-linux-framework
+  #     branch: main
+
+# ── Nested submodule policy ───────────────────────────────────────────────────
+# Controls how manage-subtrees.sh handles submodules within submodules.
+nested:
+  recurse: false            # init/update nested submodules on checkout
+  max_depth: 2              # maximum nesting depth to recurse

--- a/config/template-manifest.yml
+++ b/config/template-manifest.yml
@@ -212,6 +212,9 @@ profiles:
       - DOCS/accessibility.md
       - .gitignore
       - LICENSE
+      # Devcontainer + Ona automations — scaffold-only (skipped if already present)
+      - .devcontainer/devcontainer.template.json:.devcontainer/devcontainer.json
+      - .devcontainer/automations.template.yaml:.ona/automations.yaml
 
   # ── upstream-sync ────────────────────────────────────────────────────────────
   # For repos that declare their upstream dependencies in a registry file and
@@ -309,6 +312,9 @@ profiles:
       - DOCS/accessibility.md
       - .gitignore
       - LICENSE
+      # Devcontainer + Ona automations — scaffold-only (skipped if already present)
+      - .devcontainer/devcontainer.template.json:.devcontainer/devcontainer.json
+      - .devcontainer/automations.template.yaml:.ona/automations.yaml
 
   # ── standalone ──────────────────────────────────────────────────────────────
   # Minimal footprint: only PR automation and token rotation. For repos that
@@ -329,6 +335,9 @@ profiles:
       - scripts/write-summary.sh
       - .gitignore
       - LICENSE
+      # Devcontainer + Ona automations — scaffold-only (skipped if already present)
+      - .devcontainer/devcontainer.template.json:.devcontainer/devcontainer.json
+      - .devcontainer/automations.template.yaml:.ona/automations.yaml
 
   # ── shell-tools ──────────────────────────────────────────────────────────────
   # For shell/filesystem utility repos registered in the shell-tools group.
@@ -353,3 +362,6 @@ profiles:
       - scripts/write-summary.sh
       - .gitignore
       - LICENSE
+      # Devcontainer + Ona automations — scaffold-only (skipped if already present)
+      - .devcontainer/devcontainer.template.json:.devcontainer/devcontainer.json
+      - .devcontainer/automations.template.yaml:.ona/automations.yaml

--- a/config/workflow-priority-tiers.yml
+++ b/config/workflow-priority-tiers.yml
@@ -45,6 +45,10 @@ tiers:
     tier: 3
   - name: "Onboard Repository"
     tier: 3
+  - name: "Devcontainer SDK"
+    tier: 3
+  - name: "Manage Subtrees"
+    tier: 4
   - name: "Token Health Monitor"
     tier: 1
   - name: "Mirror Watchdog"

--- a/config/workflow-quota-costs.yml
+++ b/config/workflow-quota-costs.yml
@@ -45,7 +45,7 @@ workflows:
   synopsis: Checks expiry dates for all tracked PATs and GitLab tokens. Opens a GitHub issue labelled token-monitor when any
     token expires within 45 days.
 - name: Pre-Flush Prep
-  min_quota: 100
+  min_quota: 1500
   cost_low: 10
   cost_mid: 30
   cost_high: 60
@@ -486,6 +486,22 @@ workflows:
   basis: code-audit
   synopsis: Stub template for new platform critical deploy targets. Non-functional until TODOs are filled in.
     Update costs when the platform is activated.
+- name: Devcontainer SDK
+  min_quota: 50
+  cost_low: 0
+  cost_mid: 5
+  cost_high: 20
+  basis: code-audit
+  notes: validate mode is fully local. build/publish modes use GHCR (no REST quota).
+  synopsis: Validates devcontainer.json, features, and automations templates. Optionally builds and pushes the devcontainer image or publishes features to GHCR.
+- name: Manage Subtrees
+  min_quota: 50
+  cost_low: 0
+  cost_mid: 0
+  cost_high: 5
+  basis: code-audit
+  notes: All git operations are local. Quota used only for pre-flight check.
+  synopsis: Keeps git subtrees, submodules, and umbrella repo relationships current per config/subtree-manifest.yml.
 - name: Onboard Repository
   min_quota: 200
   cost_low: 20

--- a/config/workflow-sync.yml
+++ b/config/workflow-sync.yml
@@ -327,6 +327,10 @@ github_only:
     reason: Weekly structural audit of all config, scripts, and workflow registries
   - workflow_file: onboard-repo.yml
     reason: Onboards new repos — labels, branch protection, topics, welcome issue, downstream dispatches
+  - workflow_file: devcontainer-sdk.yml
+    reason: Validates, builds, and publishes devcontainer image and features to GHCR
+  - workflow_file: manage-subtrees.yml
+    reason: Keeps git subtrees, submodules, and umbrella repo relationships current per config/subtree-manifest.yml
   - workflow_file: readme-wizard.yml
     reason: Interactive README generator — workflow_dispatch only
   - workflow_file: repo-manifest.yml

--- a/registered-imports.json
+++ b/registered-imports.json
@@ -808,5 +808,95 @@
     "target_name": "mass_clone",
     "platform": "github",
     "added": "2026-06-13T00:00:00Z"
+  },
+  {
+    "source_url": "https://github.com/ublue-os/blincus",
+    "target_name": "blincus",
+    "platform": "github",
+    "added": "2026-06-14T00:00:00Z"
+  },
+  {
+    "source_url": "https://github.com/89luca89/distrobox",
+    "target_name": "distrobox",
+    "platform": "github",
+    "added": "2026-06-14T00:00:00Z"
+  },
+  {
+    "source_url": "https://github.com/devcontainers/cli",
+    "target_name": "devcontainers-cli",
+    "platform": "github",
+    "added": "2026-06-14T00:00:00Z"
+  },
+  {
+    "source_url": "https://github.com/niabhail/claude-devcontainer-bootstrap",
+    "target_name": "claude-devcontainer-bootstrap",
+    "platform": "github",
+    "added": "2026-06-14T00:00:00Z"
+  },
+  {
+    "source_url": "https://github.com/loft-sh/devpod",
+    "target_name": "devpod",
+    "platform": "github",
+    "added": "2026-06-14T00:00:00Z"
+  },
+  {
+    "source_url": "https://github.com/siderolabs/talos",
+    "target_name": "talos",
+    "platform": "github",
+    "added": "2026-06-14T00:00:00Z"
+  },
+  {
+    "source_url": "https://github.com/windsorcli/talos-incus",
+    "target_name": "talos-incus",
+    "platform": "github",
+    "added": "2026-06-14T00:00:00Z"
+  },
+  {
+    "source_url": "https://github.com/siderolabs/omni",
+    "target_name": "omni-talos",
+    "platform": "github",
+    "added": "2026-06-14T00:00:00Z"
+  },
+  {
+    "source_url": "https://github.com/siderolabs/extensions",
+    "target_name": "extensions-talos",
+    "platform": "github",
+    "added": "2026-06-14T00:00:00Z"
+  },
+  {
+    "source_url": "https://github.com/lxc/incus",
+    "target_name": "incus",
+    "platform": "github",
+    "added": "2026-06-14T00:00:00Z"
+  },
+  {
+    "source_url": "https://github.com/lxc/incus-os",
+    "target_name": "incus-os",
+    "platform": "github",
+    "added": "2026-06-14T00:00:00Z"
+  },
+  {
+    "source_url": "https://github.com/lxc/distrobuilder",
+    "target_name": "distrobuilder",
+    "platform": "github",
+    "added": "2026-06-14T00:00:00Z"
+  },
+  {
+    "source_url": "https://github.com/firecracker-microvm/firecracker-containerd",
+    "target_name": "firecracker-containerd",
+    "platform": "github",
+    "added": "2026-06-14T00:00:00Z"
+  },
+  {
+    "source_url": "https://github.com/rugix/rugix",
+    "target_name": "rugix",
+    "platform": "github",
+    "added": "2026-06-14T00:00:00Z"
+  },
+  {
+    "source_url": "https://github.com/ashos/ashos",
+    "target_name": "ashos",
+    "platform": "github",
+    "added": "2026-06-14T00:00:00Z"
   }
 ]

--- a/scripts/apply-brand.py
+++ b/scripts/apply-brand.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""
+Applies brand substitutions to a file's content.
+
+Reads config/brand.yml and replaces {{FSA_*}} tokens in the given file.
+Used by sync-template.sh when propagating files to branded consumer repos.
+
+Usage:
+  python3 scripts/apply-brand.py <file_path>
+  python3 scripts/apply-brand.py --stdin   (reads from stdin, writes to stdout)
+
+Exits 0 always — branding is best-effort; missing tokens are left as-is.
+"""
+import sys
+import yaml
+
+BRAND_CONFIG = "config/brand.yml"
+
+TOKEN_MAP = {
+    "{{FSA_NAME}}":        ("brand", "name"),
+    "{{FSA_SLUG}}":        ("brand", "slug"),
+    "{{FSA_ORG}}":         ("brand", "org"),
+    "{{FSA_REPO}}":        ("brand", "repo"),
+    "{{FSA_DESCRIPTION}}": ("brand", "description"),
+    "{{FSA_SUPPORT_URL}}": ("brand", "support_url"),
+}
+
+
+def load_brand():
+    try:
+        d = yaml.safe_load(open(BRAND_CONFIG))
+        return d or {}
+    except Exception:
+        return {}
+
+
+def apply_brand(content: str, brand_cfg: dict) -> str:
+    brand = brand_cfg.get("brand") or {}
+    if not brand.get("enabled"):
+        return content
+    for token, (section, key) in TOKEN_MAP.items():
+        value = brand_cfg.get(section, {}).get(key, "")
+        if value:
+            content = content.replace(token, str(value))
+    return content
+
+
+def main():
+    brand_cfg = load_brand()
+
+    if len(sys.argv) > 1 and sys.argv[1] == "--stdin":
+        content = sys.stdin.read()
+        sys.stdout.write(apply_brand(content, brand_cfg))
+        return
+
+    if len(sys.argv) < 2:
+        print("Usage: apply-brand.py <file_path> | --stdin", file=sys.stderr)
+        sys.exit(1)
+
+    path = sys.argv[1]
+    try:
+        content = open(path).read()
+    except OSError as e:
+        print(f"apply-brand: cannot read {path}: {e}", file=sys.stderr)
+        sys.exit(0)  # non-fatal
+
+    result = apply_brand(content, brand_cfg)
+    open(path, "w").write(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/devcontainer-base-image.py
+++ b/scripts/devcontainer-base-image.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""Print the base image from .devcontainer/devcontainer.json (strips // comments)."""
+import json, sys
+
+raw = open('.devcontainer/devcontainer.json').read()
+lines = [l for l in raw.splitlines() if not l.strip().startswith('//')]
+dc = json.loads('\n'.join(lines))
+print(dc.get('image', 'mcr.microsoft.com/devcontainers/base:ubuntu'))

--- a/scripts/devcontainer-build.sh
+++ b/scripts/devcontainer-build.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Builds and pushes the devcontainer image to GHCR.
+# Falls back to plain docker build if devcontainer CLI is unavailable.
+#
+# Required env vars:
+#   REPO     — owner/repo (e.g. Interested-Deving-1896/fork-sync-all)
+#   SHA      — git commit SHA
+#   DRY_RUN  — true = log without pushing (default: false)
+set -uo pipefail
+
+REPO="${REPO:?REPO is required}"
+SHA="${SHA:?SHA is required}"
+DRY_RUN="${DRY_RUN:-false}"
+
+info() { echo "[devcontainer-build] $*" >&2; }
+ok()   { echo "[devcontainer-build][ok] $*" >&2; }
+warn() { echo "[devcontainer-build][warn] $*" >&2; }
+
+IMAGE="ghcr.io/${REPO,,}/devcontainer"
+TAG="${SHA:0:7}"
+
+info "Image: ${IMAGE}:${TAG}"
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  info "[dry-run] would build and push ${IMAGE}:${TAG}"
+  exit 0
+fi
+
+BASE_IMAGE=$(python3 scripts/devcontainer-base-image.py)
+info "Base image: ${BASE_IMAGE}"
+
+if command -v devcontainer >/dev/null 2>&1; then
+  info "Using devcontainer CLI..."
+  devcontainer build \
+    --workspace-folder . \
+    --image-name "${IMAGE}:${TAG}" \
+    --push
+else
+  info "devcontainer CLI not found — using plain docker build..."
+
+  # Write Dockerfile to a temp file to avoid heredoc in YAML
+  TMPFILE=$(mktemp /tmp/Dockerfile.XXXXXX)
+  cat > "$TMPFILE" << 'DOCKERFILE_CONTENT'
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+COPY . /workspace
+WORKDIR /workspace
+RUN pip install --quiet 'headroom-ai[proxy,mcp]==0.25.0' 2>/dev/null || true
+DOCKERFILE_CONTENT
+
+  docker build \
+    --build-arg "BASE_IMAGE=${BASE_IMAGE}" \
+    --label "org.opencontainers.image.source=https://github.com/${REPO}" \
+    --label "org.opencontainers.image.revision=${SHA}" \
+    -t "${IMAGE}:${TAG}" \
+    -t "${IMAGE}:latest" \
+    -f "$TMPFILE" .
+
+  rm -f "$TMPFILE"
+  docker push "${IMAGE}:${TAG}"
+  docker push "${IMAGE}:latest"
+fi
+
+ok "Built and pushed ${IMAGE}:${TAG}"
+echo "image=${IMAGE}:${TAG}" >> "${GITHUB_OUTPUT:-/dev/null}"

--- a/scripts/devcontainer-publish-features.sh
+++ b/scripts/devcontainer-publish-features.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Publishes devcontainer features from .devcontainer/features/ to GHCR as
+# OCI artifacts. Requires devcontainer CLI (npm install -g @devcontainers/cli).
+#
+# Usage: devcontainer-publish-features.sh
+#
+# Required env vars:
+#   REPO      — owner/repo (e.g. Interested-Deving-1896/fork-sync-all)
+#   DRY_RUN   — true = log without pushing (default: false)
+set -uo pipefail
+
+REPO="${REPO:?REPO is required}"
+DRY_RUN="${DRY_RUN:-false}"
+
+info() { echo "[devcontainer-publish] $*" >&2; }
+ok()   { echo "[devcontainer-publish][ok] $*" >&2; }
+warn() { echo "[devcontainer-publish][warn] $*" >&2; }
+
+REGISTRY="ghcr.io/${REPO,,}"
+info "Publishing features to ${REGISTRY}"
+
+for feat_dir in .devcontainer/features/*/; do
+  feat_name=$(basename "$feat_dir")
+  version=$(python3 -c "import json; print(json.load(open('${feat_dir}devcontainer-feature.json'))['version'])" 2>/dev/null || echo "1.0.0")
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    info "[dry-run] would publish ${REGISTRY}/${feat_name}:${version}"
+    continue
+  fi
+
+  if command -v devcontainer >/dev/null 2>&1; then
+    devcontainer features publish \
+      --registry "ghcr.io" \
+      --namespace "${REPO,,}" \
+      "$feat_dir" \
+      && ok "published ${feat_name}:${version}" \
+      || warn "failed to publish ${feat_name}"
+  else
+    warn "devcontainer CLI not available — install with: npm install -g @devcontainers/cli"
+    warn "Cannot publish ${feat_name}"
+  fi
+done

--- a/scripts/devcontainer-validate.py
+++ b/scripts/devcontainer-validate.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""
+Validates the devcontainer setup:
+  - devcontainer.json parses cleanly (strips // comments)
+  - devcontainer.template.json parses cleanly
+  - All local features have devcontainer-feature.json + install.sh
+  - automations templates have --no-ccr-inject-tool on headroom proxy
+  - All feature manifests have required fields and matching id/dirname
+
+Exits 1 on any error.
+"""
+import json, os, sys, glob
+import yaml
+
+errors = []
+
+
+def check_json_file(path, label):
+    if not os.path.exists(path):
+        errors.append(f"MISSING: {path}")
+        return None
+    raw = open(path).read()
+    lines = [l for l in raw.splitlines() if not l.strip().startswith("//")]
+    try:
+        return json.loads("\n".join(lines))
+    except json.JSONDecodeError as e:
+        errors.append(f"PARSE ERROR {label}: {e}")
+        return None
+
+
+# ── devcontainer.json ─────────────────────────────────────────────────────────
+dc = check_json_file(".devcontainer/devcontainer.json", "devcontainer.json")
+if dc is not None:
+    if not dc.get("image") and not dc.get("build") and not dc.get("dockerFile"):
+        errors.append("devcontainer.json: no image, build, or dockerFile")
+    for feat_ref in dc.get("features", {}).keys():
+        if feat_ref.startswith("./"):
+            feat_path = f".devcontainer/{feat_ref.lstrip('./')}"
+            if not os.path.isdir(feat_path):
+                errors.append(f"Local feature not found: {feat_path}")
+            else:
+                if not os.path.exists(f"{feat_path}/devcontainer-feature.json"):
+                    errors.append(f"Missing devcontainer-feature.json in {feat_path}")
+                if not os.path.exists(f"{feat_path}/install.sh"):
+                    errors.append(f"Missing install.sh in {feat_path}")
+    feat_count = len(dc.get("features", {}))
+    print(f"OK  devcontainer.json: {feat_count} features, image={dc.get('image','(build)')}")
+
+# ── devcontainer.template.json ────────────────────────────────────────────────
+tmpl = check_json_file(".devcontainer/devcontainer.template.json", "devcontainer.template.json")
+if tmpl is not None:
+    print(f"OK  devcontainer.template.json: {len(tmpl.get('features', {}))} features")
+
+# ── automations templates ─────────────────────────────────────────────────────
+for path in [".ona/automations.yaml", ".devcontainer/automations.template.yaml"]:
+    if not os.path.exists(path):
+        errors.append(f"MISSING: {path}")
+        continue
+    try:
+        d = yaml.safe_load(open(path))
+        for svc, cfg in ((d or {}).get("services", {}) or {}).items():
+            start = ((cfg or {}).get("commands") or {}).get("start", "")
+            if not start:
+                errors.append(f"{path}: service '{svc}' missing start command")
+            if "headroom proxy" in start and "--no-ccr-inject-tool" not in start:
+                errors.append(f"{path}: headroom proxy missing --no-ccr-inject-tool")
+        print(f"OK  {path}")
+    except yaml.YAMLError as e:
+        errors.append(f"{path}: YAML error: {e}")
+
+# ── feature manifests ─────────────────────────────────────────────────────────
+feat_dirs = sorted(glob.glob(".devcontainer/features/*/"))
+for feat_dir in feat_dirs:
+    name = feat_dir.rstrip("/").split("/")[-1]
+    m = check_json_file(f"{feat_dir}devcontainer-feature.json", f"feature:{name}")
+    if m is None:
+        continue
+    for field in ["id", "version", "name"]:
+        if not m.get(field):
+            errors.append(f"feature:{name}: missing '{field}'")
+    if m.get("id") != name:
+        errors.append(f"feature:{name}: id='{m.get('id')}' != dir name '{name}'")
+    if not os.path.exists(f"{feat_dir}install.sh"):
+        errors.append(f"feature:{name}: missing install.sh")
+
+print(f"OK  {len(feat_dirs)} devcontainer features checked")
+
+# ── Result ────────────────────────────────────────────────────────────────────
+if errors:
+    for e in errors:
+        print(f"ERROR {e}")
+    sys.exit(1)
+
+print("OK  all devcontainer checks passed")

--- a/scripts/dispatch-and-wait.sh
+++ b/scripts/dispatch-and-wait.sh
@@ -28,15 +28,23 @@ BEFORE_TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
 info "Dispatching ${WORKFLOW}..."
 
-HTTP_CODE=$(curl -sf -w "%{http_code}" -o /dev/null \
-  -X POST \
-  -H "Authorization: token ${GH_TOKEN}" \
-  -H "Accept: application/vnd.github+json" \
-  "${API}/repos/${REPO}/actions/workflows/${WORKFLOW}/dispatches" \
-  -d "{\"ref\":\"main\",\"inputs\":${INPUTS}}" 2>/dev/null || echo "000")
+# Retry up to 3 times — the dispatch API occasionally returns 400 transiently
+# (e.g. during a commit index window). A single failure should not abort the caller.
+HTTP_CODE="000"
+for _attempt in 1 2 3; do
+  HTTP_CODE=$(curl -sf -w "%{http_code}" -o /dev/null \
+    -X POST \
+    -H "Authorization: token ${GH_TOKEN}" \
+    -H "Accept: application/vnd.github+json" \
+    "${API}/repos/${REPO}/actions/workflows/${WORKFLOW}/dispatches" \
+    -d "{\"ref\":\"main\",\"inputs\":${INPUTS}}" 2>/dev/null || echo "000")
+  [[ "$HTTP_CODE" == "204" ]] && break
+  info "Dispatch attempt ${_attempt} failed (HTTP ${HTTP_CODE}) — retrying in 10s..."
+  sleep 10
+done
 
 if [[ "$HTTP_CODE" != "204" ]]; then
-  fail "Dispatch failed (HTTP ${HTTP_CODE})"
+  fail "Dispatch failed after 3 attempts (HTTP ${HTTP_CODE})"
 fi
 
 info "Dispatched. Waiting for run to appear..."

--- a/scripts/manage-subtrees.sh
+++ b/scripts/manage-subtrees.sh
@@ -1,0 +1,357 @@
+#!/usr/bin/env bash
+#
+# Manages git subtrees, submodules, and umbrella repo relationships
+# declared in config/subtree-manifest.yml.
+#
+# Commands:
+#   sync        — add/update all subtrees and submodules per manifest
+#   add-subtree — add a single subtree (args: name remote branch prefix)
+#   pull-subtree— pull latest from a subtree remote (args: name)
+#   add-submodule — add a single submodule (args: name url path branch)
+#   update-submodules — update all submodules to latest on their branch
+#   umbrella-init — initialise umbrella repo (add all children as submodules)
+#   status      — show current state of all subtrees and submodules
+#
+# Required env vars:
+#   GH_TOKEN    — PAT (needed only for private repos)
+#
+# Optional env vars:
+#   DRY_RUN     — true = log without executing (default: false)
+#   MANIFEST    — path to manifest file (default: config/subtree-manifest.yml)
+
+set -uo pipefail
+
+MANIFEST="${MANIFEST:-config/subtree-manifest.yml}"
+DRY_RUN="${DRY_RUN:-false}"
+CMD="${1:-sync}"
+
+info()  { echo "[manage-subtrees] $*" >&2; }
+ok()    { echo "[manage-subtrees][ok] $*" >&2; }
+warn()  { echo "[manage-subtrees][warn] $*" >&2; }
+dry()   { echo "[manage-subtrees][dry-run] $*" >&2; }
+fail()  { echo "[manage-subtrees][error] $1" >&2; exit "${2:-1}"; }
+
+[[ -f "$MANIFEST" ]] || fail "Manifest not found: $MANIFEST"
+
+# ── YAML helpers ──────────────────────────────────────────────────────────────
+manifest_get() {
+  python3 -c "
+import yaml, json, sys
+d = yaml.safe_load(open('$MANIFEST'))
+keys = '$1'.split('.')
+v = d
+for k in keys:
+    v = (v or {}).get(k) if isinstance(v, dict) else None
+    if v is None: break
+print(json.dumps(v) if v is not None else 'null')
+" 2>/dev/null
+}
+
+manifest_list() {
+  python3 -c "
+import yaml, json
+d = yaml.safe_load(open('$MANIFEST'))
+items = d.get('$1', []) or []
+print(json.dumps(items))
+" 2>/dev/null
+}
+
+# ── Subtree operations ────────────────────────────────────────────────────────
+add_subtree() {
+  local name="$1" remote="$2" branch="$3" prefix="$4" squash="${5:-true}"
+  info "Adding subtree: ${name} → ${prefix} (${remote}@${branch})"
+
+  if [[ -d "$prefix" ]]; then
+    info "  ${prefix} already exists — pulling instead"
+    pull_subtree "$name" "$remote" "$branch" "$prefix" "$squash"
+    return
+  fi
+
+  local squash_flag=""
+  [[ "$squash" == "true" ]] && squash_flag="--squash"
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    dry "git subtree add --prefix=${prefix} ${remote} ${branch} ${squash_flag}"
+    return
+  fi
+
+  git subtree add --prefix="$prefix" "$remote" "$branch" $squash_flag \
+    && ok "Added subtree ${name} at ${prefix}" \
+    || warn "Failed to add subtree ${name}"
+}
+
+pull_subtree() {
+  local name="$1" remote="$2" branch="$3" prefix="$4" squash="${5:-true}"
+  info "Pulling subtree: ${name} (${remote}@${branch})"
+
+  local squash_flag=""
+  [[ "$squash" == "true" ]] && squash_flag="--squash"
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    dry "git subtree pull --prefix=${prefix} ${remote} ${branch} ${squash_flag}"
+    return
+  fi
+
+  git subtree pull --prefix="$prefix" "$remote" "$branch" $squash_flag \
+    && ok "Pulled subtree ${name}" \
+    || warn "Failed to pull subtree ${name} (may already be up to date)"
+}
+
+sync_subtrees() {
+  local subtrees
+  subtrees=$(manifest_list "subtrees")
+  local count
+  count=$(python3 -c "import json,sys; print(len(json.loads(sys.argv[1])))" "$subtrees" 2>/dev/null || echo 0)
+  info "Syncing ${count} subtree(s)..."
+
+  python3 - "$subtrees" << 'PYEOF'
+import json, sys, subprocess, os
+
+items = json.loads(sys.argv[1])
+dry = os.environ.get('DRY_RUN', 'false') == 'true'
+
+for item in items:
+    name   = item.get('name', '')
+    remote = item.get('remote', '')
+    branch = item.get('branch', 'main')
+    prefix = item.get('prefix', f'vendor/{name}')
+    squash = item.get('squash', True)
+    msg    = item.get('message', f'chore: sync {name} subtree')
+
+    if not name or not remote:
+        print(f"[manage-subtrees][warn] skipping entry with missing name/remote", file=sys.stderr)
+        continue
+
+    args = ['git', 'subtree']
+    action = 'pull' if os.path.isdir(prefix) else 'add'
+    args += [action, f'--prefix={prefix}', remote, branch]
+    if squash:
+        args.append('--squash')
+    if action == 'add':
+        args += ['-m', msg]
+
+    print(f"[manage-subtrees] {action} subtree {name} → {prefix}", file=sys.stderr)
+    if dry:
+        print(f"[manage-subtrees][dry-run] {' '.join(args)}", file=sys.stderr)
+    else:
+        result = subprocess.run(args, capture_output=False)
+        if result.returncode != 0:
+            print(f"[manage-subtrees][warn] {action} failed for {name}", file=sys.stderr)
+        else:
+            print(f"[manage-subtrees][ok] {name}", file=sys.stderr)
+PYEOF
+}
+
+# ── Submodule operations ──────────────────────────────────────────────────────
+add_submodule() {
+  local name="$1" url="$2" path="$3" branch="${4:-main}" shallow="${5:-false}"
+  info "Adding submodule: ${name} → ${path} (${url}@${branch})"
+
+  if [[ -d "${path}/.git" ]] || grep -q "path = ${path}" .gitmodules 2>/dev/null; then
+    info "  ${path} already registered — updating"
+    update_submodule "$path" "$branch"
+    return
+  fi
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    dry "git submodule add -b ${branch} ${url} ${path}"
+    return
+  fi
+
+  local depth_flag=""
+  [[ "$shallow" == "true" ]] && depth_flag="--depth=1"
+
+  git submodule add -b "$branch" "$url" "$path" \
+    && git submodule update --init $depth_flag "$path" \
+    && ok "Added submodule ${name} at ${path}" \
+    || warn "Failed to add submodule ${name}"
+}
+
+update_submodule() {
+  local path="$1" branch="${2:-}"
+  if [[ "$DRY_RUN" == "true" ]]; then
+    dry "git submodule update --remote --merge ${path}"
+    return
+  fi
+  git submodule update --remote --merge "$path" 2>/dev/null \
+    && ok "Updated submodule at ${path}" \
+    || warn "Failed to update submodule at ${path}"
+}
+
+sync_submodules() {
+  local submodules
+  submodules=$(manifest_list "submodules")
+  local count
+  count=$(python3 -c "import json,sys; print(len(json.loads(sys.argv[1])))" "$submodules" 2>/dev/null || echo 0)
+  info "Syncing ${count} submodule(s)..."
+
+  python3 - "$submodules" << 'PYEOF'
+import json, sys, subprocess, os
+
+items = json.loads(sys.argv[1])
+dry = os.environ.get('DRY_RUN', 'false') == 'true'
+
+for item in items:
+    name    = item.get('name', '')
+    url     = item.get('url', '')
+    path    = item.get('path', f'modules/{name}')
+    branch  = item.get('branch', 'main')
+    shallow = item.get('shallow', False)
+
+    if not name or not url:
+        print(f"[manage-subtrees][warn] skipping submodule with missing name/url", file=sys.stderr)
+        continue
+
+    already = os.path.isdir(os.path.join(path, '.git')) or (
+        os.path.exists('.gitmodules') and
+        f'path = {path}' in open('.gitmodules').read()
+    )
+
+    if already:
+        print(f"[manage-subtrees] updating submodule {name}", file=sys.stderr)
+        args = ['git', 'submodule', 'update', '--remote', '--merge', path]
+    else:
+        print(f"[manage-subtrees] adding submodule {name} → {path}", file=sys.stderr)
+        args = ['git', 'submodule', 'add', '-b', branch, url, path]
+
+    if dry:
+        print(f"[manage-subtrees][dry-run] {' '.join(args)}", file=sys.stderr)
+    else:
+        result = subprocess.run(args, capture_output=False)
+        if result.returncode != 0:
+            print(f"[manage-subtrees][warn] failed for {name}", file=sys.stderr)
+        elif not already:
+            depth = ['--depth=1'] if shallow else []
+            subprocess.run(['git', 'submodule', 'update', '--init'] + depth + [path])
+            print(f"[manage-subtrees][ok] {name}", file=sys.stderr)
+PYEOF
+}
+
+# ── Umbrella operations ───────────────────────────────────────────────────────
+umbrella_init() {
+  local enabled
+  enabled=$(manifest_get "umbrella.enabled")
+  if [[ "$enabled" != "true" ]]; then
+    info "Umbrella mode disabled in manifest — skipping"
+    return
+  fi
+
+  local prefix
+  prefix=$(manifest_get "umbrella.prefix" | tr -d '"')
+  prefix="${prefix:-repos}"
+
+  info "Initialising umbrella repo (prefix: ${prefix})..."
+
+  python3 - "$prefix" << 'PYEOF'
+import yaml, json, sys, subprocess, os
+
+manifest = yaml.safe_load(open(os.environ.get('MANIFEST', 'config/subtree-manifest.yml')))
+prefix = sys.argv[1]
+children = (manifest.get('umbrella') or {}).get('children') or []
+dry = os.environ.get('DRY_RUN', 'false') == 'true'
+
+os.makedirs(prefix, exist_ok=True)
+
+for child in children:
+    name   = child.get('name', '')
+    url    = child.get('url', '')
+    branch = child.get('branch', 'main')
+    path   = f"{prefix}/{name}"
+
+    if not name or not url:
+        continue
+
+    already = os.path.exists('.gitmodules') and f'path = {path}' in open('.gitmodules').read()
+    if already:
+        print(f"[manage-subtrees] umbrella: {name} already registered", file=sys.stderr)
+        continue
+
+    print(f"[manage-subtrees] umbrella: adding {name} → {path}", file=sys.stderr)
+    if dry:
+        print(f"[manage-subtrees][dry-run] git submodule add -b {branch} {url} {path}", file=sys.stderr)
+    else:
+        result = subprocess.run(['git', 'submodule', 'add', '-b', branch, url, path])
+        if result.returncode == 0:
+            subprocess.run(['git', 'submodule', 'update', '--init', '--depth=1', path])
+            print(f"[manage-subtrees][ok] {name}", file=sys.stderr)
+        else:
+            print(f"[manage-subtrees][warn] failed to add {name}", file=sys.stderr)
+PYEOF
+}
+
+# ── Status ────────────────────────────────────────────────────────────────────
+show_status() {
+  info "=== Subtree status ==="
+  python3 -c "
+import yaml, os
+d = yaml.safe_load(open('$MANIFEST'))
+for s in (d.get('subtrees') or []):
+    p = s.get('prefix', '')
+    exists = os.path.isdir(p)
+    print(f\"  {'✅' if exists else '❌'} {s['name']} → {p}\")
+" 2>/dev/null || true
+
+  info "=== Submodule status ==="
+  if [[ -f ".gitmodules" ]]; then
+    git submodule status 2>/dev/null || true
+  else
+    info "  No .gitmodules file"
+  fi
+
+  info "=== Umbrella status ==="
+  python3 -c "
+import yaml, os
+d = yaml.safe_load(open('$MANIFEST'))
+u = d.get('umbrella') or {}
+if not u.get('enabled'):
+    print('  Umbrella mode disabled')
+else:
+    prefix = u.get('prefix', 'repos')
+    for c in (u.get('children') or []):
+        p = f\"{prefix}/{c['name']}\"
+        exists = os.path.isdir(p)
+        print(f\"  {'✅' if exists else '❌'} {c['name']} → {p}\")
+" 2>/dev/null || true
+}
+
+# ── Dispatch ──────────────────────────────────────────────────────────────────
+case "$CMD" in
+  sync)
+    sync_subtrees
+    sync_submodules
+    umbrella_init
+    ;;
+  add-subtree)
+    [[ $# -ge 5 ]] || fail "Usage: manage-subtrees.sh add-subtree <name> <remote> <branch> <prefix>"
+    add_subtree "$2" "$3" "$4" "$5" "${6:-true}"
+    ;;
+  pull-subtree)
+    [[ $# -ge 2 ]] || fail "Usage: manage-subtrees.sh pull-subtree <name>"
+    name="$2"
+    python3 -c "
+import yaml, json
+d = yaml.safe_load(open('$MANIFEST'))
+for s in (d.get('subtrees') or []):
+    if s['name'] == '$name':
+        print(s['remote'], s.get('branch','main'), s.get('prefix', f'vendor/$name'), s.get('squash', True))
+        break
+" | read -r remote branch prefix squash
+    pull_subtree "$name" "$remote" "$branch" "$prefix" "$squash"
+    ;;
+  add-submodule)
+    [[ $# -ge 4 ]] || fail "Usage: manage-subtrees.sh add-submodule <name> <url> <path> [branch]"
+    add_submodule "$2" "$3" "$4" "${5:-main}" "${6:-false}"
+    ;;
+  update-submodules)
+    sync_submodules
+    ;;
+  umbrella-init)
+    umbrella_init
+    ;;
+  status)
+    show_status
+    ;;
+  *)
+    fail "Unknown command: $CMD. Valid: sync, add-subtree, pull-subtree, add-submodule, update-submodules, umbrella-init, status"
+    ;;
+esac

--- a/scripts/sync-template.sh
+++ b/scripts/sync-template.sh
@@ -435,76 +435,17 @@ resolve_profile_filters() {
   fi
 
   python3 - "$MANIFEST_FILE" "$profile_name" << 'PYEOF'
-import sys, re
+import sys, yaml
 
 manifest_path = sys.argv[1]
 profile_name  = sys.argv[2]
 
 with open(manifest_path) as f:
-    content = f.read()
+    manifest = yaml.safe_load(f)
 
-# Minimal YAML parser: extract the named profile's include/exclude lists.
-# Handles the indented block-sequence format used in template-manifest.yml.
-lines = content.splitlines()
-
-in_profiles   = False
-in_profile    = False
-in_include    = False
-in_exclude    = False
-includes      = []
-excludes      = []
-
-for line in lines:
-    stripped = line.strip()
-    if not stripped or stripped.startswith('#'):
-        continue
-
-    if stripped == 'profiles:':
-        in_profiles = True
-        continue
-
-    if not in_profiles:
-        continue
-
-    # Top-level profile key (2-space indent)
-    m = re.match(r'^  (\S+):$', line)
-    if m:
-        if in_profile:
-            break  # past our profile — done
-        if m.group(1) == profile_name:
-            in_profile = True
-        in_include = False
-        in_exclude = False
-        continue
-
-    if not in_profile:
-        continue
-
-    # include:/exclude: sub-keys (4-space indent)
-    if re.match(r'^    include:\s*$', line):
-        in_include = True
-        in_exclude = False
-        continue
-    if re.match(r'^    exclude:\s*$', line):
-        in_exclude = True
-        in_include = False
-        continue
-
-    # List items under include/exclude (6-space indent)
-    # Supports "source:dest" remap syntax for include entries.
-    m = re.match(r'^      - (.+)$', line)
-    if m:
-        val = m.group(1).strip().strip('"\'')
-        if in_include:
-            includes.append(val)  # kept as "source:dest" or plain "path"
-        elif in_exclude:
-            excludes.append(val.split(':')[0])  # excludes never remap
-        continue
-
-    # Any other 4-space key resets include/exclude context
-    if re.match(r'^    \S', line):
-        in_include = False
-        in_exclude = False
+profile = (manifest.get('profiles') or {}).get(profile_name) or {}
+includes = [str(e) for e in (profile.get('include') or [])]
+excludes = [str(e).split(':')[0] for e in (profile.get('exclude') or [])]
 
 print('\n'.join(includes))
 print('---SENTINEL---')


### PR DESCRIPTION
## What changed

Three commits. All changes are local-only (no quota consumed during development). Validator passes clean: 101 workflows, 103 quota-cost entries, 0 warnings.

---

### `88fd777` — fix(sync-template): checkout@v6, yaml.safe_load for profile filters

- `actions/checkout@v4` → `v6` in `sync-template.yml` (v4 was behind the rest of the repo)
- `resolve_profile_filters()` replaced a 65-line hand-rolled regex/indent YAML parser with 8 lines using `yaml.safe_load` per AGENTS.md convention

### `172c9a7` — chore: bump actions/checkout to v6 in new workflows

7 workflows added in recent sessions were created with `checkout@v4`. Aligned with the rest of the repo (93 workflows already on v6).

### `f06dbeb` — feat: devcontainer SDK, git-platform-clis, brandable backend, subtree scaffold

---

#### Devcontainer

**Template divergence fixes:**
- `devcontainer.template.json`: pin `headroom-ai==0.25.0` (was unpinned)
- `automations.template.yaml`: add `--no-ccr-inject-tool` to headroom proxy start command (was missing; present in live `.ona/automations.yaml`)

**New feature — `.devcontainer/features/git-platform-clis/`:**
Installs CLIs for all major git hosting platforms inside the devcontainer. `gh`, `glab`, `tea` installed by default. `hub`, `bb`, `forgejo-cli` optional via feature options. Added to both `devcontainer.json` and `devcontainer.template.json`.

**Template wiring — `config/template-manifest.yml`:**
`devcontainer.template.json` and `automations.template.yaml` wired into `infra-core`, `upstream-sync`, `standalone`, `shell-tools` profiles via source:dest remaps. Both scaffold-only — skipped if destination already exists in the consumer repo.

**New workflow — `devcontainer-sdk.yml`:**
Three modes: `validate` (runs on push to `.devcontainer/`), `build` (OCI image → GHCR), `publish` (features → GHCR as OCI artifacts). Supporting scripts: `devcontainer-validate.py`, `devcontainer-build.sh`, `devcontainer-publish-features.sh`, `devcontainer-base-image.py`.

---

#### Brandable backend — `config/brand.yml` + `scripts/apply-brand.py`

fork-sync-all can be adopted as a white-label subsystem. `config/brand.yml` defines `{{FSA_*}}` substitution tokens, theme settings, and skin overrides. `brand.enabled=false` by default — no behaviour change until a consumer opts in.

---

#### Git subtree / submodule / umbrella scaffold

`config/subtree-manifest.yml` declares subtrees, submodules, and umbrella children (all lists empty by default). `scripts/manage-subtrees.sh` implements sync/add/pull/update/umbrella-init/status commands. `manage-subtrees.yml` runs weekly (Sunday 01:00 UTC) + manual dispatch.

---

#### Audit fixes

- `pre-flush-prep` `min_quota`: raised 100 → 1500 (dispatches full-chain-flush which needs 1000)
- `full-audit.yml`: 5 new checks (16–20) — workflow registration completeness, devcontainer template wiring, onboarding dispatch list validity, shell-tools registry cross-reference, pre-flush-prep quota adequacy
- `check-shell-tools-ci`, `integrate-shell-tools`, `sync-shell-tools`, `sync-uaa-vendor`, `onboard-repo`: `qi_begin`/`qi_end` instrumentation + `write-summary` steps added. `integrate-shell-tools` gains quota pre-flight job and `dry_run` input.

---

## Type

- [x] New feature / workflow
- [x] Bug fix
- [x] Config / dependency update

## Checklist

- [x] Validator scripts pass (`python3 scripts/validate-workflow-guards.py` — 101 workflows, 103 quota-cost entries, 0 warnings)
- [x] Config files validated (`python3 scripts/devcontainer-validate.py` — all checks pass)
- [x] No secrets or tokens committed
- [x] All new scripts use `>&2` for logging per AGENTS.md
- [x] All inline Python in `run:` blocks replaced with external scripts (no YAML block scalar violations)
- [x] `brand.enabled=false` by default — no behaviour change to existing consumers