### PR TITLE
fix(quota): GitLab path, pre-flush threshold, Translate READMEs triggers, cost estimates

### DIFF
--- a/.github/workflows/pre-flush-prep.yml
+++ b/.github/workflows/pre-flush-prep.yml
@@ -120,10 +120,13 @@ jobs:
             | python3 -c "import sys,json; print(json.load(sys.stdin)['resources']['core']['remaining'])" \
             || echo 0)
           echo "remaining=${remaining}" >> "$GITHUB_OUTPUT"
-          echo "Quota: ${remaining} remaining"
-          if [[ "${remaining}" -lt 500 ]]; then
+          echo "Quota: ${remaining} remaining (floor: ${QUOTA_FLOOR})"
+          # Skip if quota is below QUOTA_FLOOR — the flush itself needs that headroom.
+          # A threshold of 500 was too low: steps 1-6 would consume quota and then
+          # step 8 would skip anyway because remaining < QUOTA_FLOOR.
+          if [[ "${remaining}" -lt "${QUOTA_FLOOR}" ]]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "::warning::Quota critically low (${remaining}) — skipping prep entirely"
+            echo "::warning::Quota too low for flush (${remaining} < ${QUOTA_FLOOR}) — skipping prep entirely"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/sync-to-gitlab-variant.yml
+++ b/.github/workflows/sync-to-gitlab-variant.yml
@@ -76,7 +76,7 @@ jobs:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
           GITLAB_TOKEN: ${{ secrets.GITLAB_SYNC_TOKEN }}
           GITHUB_REPO: Interested-Deving-1896/fork-sync-all
-          GITLAB_PROJECT: openos-project/fork-sync-all-gitlab
+          GITLAB_PROJECT: openos-project/ops/fork-sync-all
           GITLAB_URL: https://gitlab.com
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: |


### PR DESCRIPTION
## What changed

Four related fixes targeting the quota exhaustion pattern (quota hitting 0 repeatedly within minutes of each reset).

---

### `sync-to-gitlab-variant.yml` — GitLab project 404

`GITLAB_PROJECT` pointed to `openos-project/fork-sync-all-gitlab` which does not exist. Every run produced 6× HTTP 404 errors and exited 1. Corrected to `openos-project/ops/fork-sync-all` (confirmed public, id=81413316).

### `pre-flush-prep.yml` — quota pre-flight skip threshold

Skip threshold was 500. At that level the job would start, run steps 1–6 consuming quota, then skip step 8 anyway because `remaining < QUOTA_FLOOR` (3000). Job exited success but did nothing — misleading and wasteful. Now skips immediately when `remaining < QUOTA_FLOOR`.

### `translate-readmes.yml` — over-triggering via workflow_run

Translate READMEs had 11 `workflow_run` upstream triggers. 8 of them (`Sync All Forks`, `Sync Registered Imports`, `Sync from GitLab`, `Clone Org`, `Merge Repos into Monorepo`, `Sync pieroproietti Forks`, `Sync Upstream Sources`, `Sync penguins-eggs docs`) do not change README content — triggering translation after them burned quota with no benefit.

Observed impact: ~10 Translate READMEs runs/day instead of ~1-2. Each run costs ~300 REST calls = ~2400 wasted calls/day.

Kept triggers: `Update READMEs`, `Add Mirror Repo`, `Import Repository` — these actually create or modify README content.

### `config/workflow-quota-costs.yml` — revised cost estimates

Code-audit estimates for 9 workflows were significantly understated (e.g. Sync All Forks estimated at 200 calls, actual ~500 for 250 forks × 2 calls avg). Revised to `code-audit-revised` basis pending Phase 2 observed measurements.

| Workflow | Old mid | New mid |
|---|---|---|
| Sync All Forks | 200 | 500 |
| Update READMEs | 150 | 300 |
| Sync Registered Imports | 15 | 300 |
| Translate READMEs | 40 | 300 |
| Check OSP-Bound CI Status | 150 | 200 |
| Mirror I-D-1896 → OSP | 80 | 150 |
| Setup OSP Mirror Workflows | 80 | 180 |
| Upstream PRs from OSP + OOC | 80 | 150 |
| Upstream Direct Commits | 80 | 150 |