### PR TITLE
fix(full-audit): force GitHub workflow re-registration

### DIFF
--- a/.github/workflows/full-audit.yml
+++ b/.github/workflows/full-audit.yml
@@ -1,3 +1,4 @@
+# Full Audit workflow — checks config, scripts, and workflow health
 name: Full Audit
 
 on:


### PR DESCRIPTION
## What

Adds a header comment to `full-audit.yml` to force GitHub to re-parse and re-register the workflow.

## Why

GitHub cached a broken workflow name (`.github/workflows/full-audit.yml` instead of `Full Audit`) from a previous parse failure. Every subsequent run was failing with 0 jobs — the workflow appeared to run but immediately exited failure before any job started.

The file is valid YAML (confirmed locally with PyYAML and the validator). GitHub's workflow registry had a stale/corrupted entry. A content change to the file forces GitHub to re-parse it and update the registry with the correct `name: Full Audit`.

No functional changes.