### PR TITLE
feat(ci): expand CI/CD failure coverage — GitLab pipelines, broad GraphQL scan, PR CI surfacing

### DIFF
--- a/.github/workflows/check-all-repos-ci.yml
+++ b/.github/workflows/check-all-repos-ci.yml
@@ -1,21 +1,19 @@
-name: Check OSP-Bound CI Status
+name: Check All Repos CI Status
 
-# Verifies that the default-branch HEAD of every OSP-bound repo
-# (registered via add-mirror-repo.yml, listed in config/gitlab-subgroups.yml)
-# has a green CI status. When failures are found, writes a summary and
+# Scans the default-branch CI state of every repo in Interested-Deving-1896
+# using GraphQL statusCheckRollup — one API call per 100 repos (~40-50 calls
+# total for 4000+ repos vs thousands of per-repo REST calls).
+#
+# Failing repos are written to the job summary. When failures are found,
 # dispatches resolve-failures.yml scoped to the failing repos.
 #
-# Also checks CI status on open PRs across all OSP-bound repos via GraphQL
-# (one call per 10-repo batch) and surfaces failing PRs in the summary.
+# Runs weekly (Sunday 06:00 UTC) and on demand. Not triggered after every
+# push — the OSP-bound daily check (check-osp-ci.yml) covers the critical
+# path; this is a broader weekly sweep.
 
 on:
-  workflow_run:
-    workflows:
-      - "Mirror Interested-Deving-1896 → OSP"
-      - "Add Mirror Repo"
-    types: [completed]
   schedule:
-    - cron: '5 9 * * *'
+    - cron: '0 6 * * 0'   # Sunday 06:00 UTC
   workflow_dispatch:
     inputs:
       repo_filter:
@@ -23,10 +21,15 @@ on:
         required: false
         default: ""
         type: string
+      skip_forks:
+        description: "Skip forked repos"
+        required: false
+        default: "false"
+        type: string
       dry_run:
         description: "Report failures without triggering resolver"
         required: false
-        default: false
+        default: "false"
         type: boolean
 
 permissions:
@@ -34,11 +37,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: check-osp-ci
+  group: check-all-repos-ci
   cancel-in-progress: true
 
 jobs:
   check:
+    name: Scan all repos via GraphQL
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -56,7 +60,7 @@ jobs:
           echo "remaining=${remaining}" >> "$GITHUB_OUTPUT"
           if [[ "${remaining}" -lt "${MIN_QUOTA}" ]]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "Quota too low (${remaining} < ${MIN_QUOTA}) -- skipping."
+            echo "Quota too low (${remaining} < ${MIN_QUOTA}) — skipping."
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
@@ -64,59 +68,48 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Check CI status across OSP-bound repos
+      - name: Scan CI status via GraphQL
         if: steps.quota.outputs.skip == 'false'
         id: check
         env:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
           GITHUB_OWNER: Interested-Deving-1896
           REPO_FILTER: ${{ inputs.repo_filter || '' }}
+          SKIP_FORKS: ${{ inputs.skip_forks || 'false' }}
+          SKIP_ARCHIVED: "true"
           BUDGET_MINUTES: "25"
           MIN_QUOTA: "500"
         run: |
           source scripts/includes/quota-instrument.sh
           qi_begin
-          bash scripts/check-osp-ci.sh > /tmp/osp-ci-results.json
-          bash scripts/check-osp-ci-summary.sh /tmp/osp-ci-results.json
-          echo "failing_count=$(bash scripts/check-osp-ci-summary.sh /tmp/osp-ci-results.json --count)" >> "$GITHUB_OUTPUT"
+          bash scripts/check-all-repos-ci.sh > /tmp/all-repos-ci-results.json
+          bash scripts/check-all-repos-ci-summary.sh /tmp/all-repos-ci-results.json >> "$GITHUB_STEP_SUMMARY"
+          failing=$(bash scripts/check-all-repos-ci-summary.sh /tmp/all-repos-ci-results.json --count)
+          echo "failing_count=${failing}" >> "$GITHUB_OUTPUT"
           qi_end
 
       - name: Trigger resolver for failing repos
-        if: steps.quota.outputs.skip == 'false' && steps.check.outputs.failing_count != '0' && inputs.dry_run != 'true'
+        if: >
+          steps.quota.outputs.skip == 'false' &&
+          steps.check.outputs.failing_count != '0' &&
+          inputs.dry_run != 'true'
         env:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
         run: |
-          failing_repos=$(bash scripts/check-osp-ci-summary.sh /tmp/osp-ci-results.json --repos)
+          failing_repos=$(bash scripts/check-all-repos-ci-summary.sh /tmp/all-repos-ci-results.json --repos)
           echo "Dispatching resolve-failures.yml for: ${failing_repos}"
           curl -sf \
             -X POST \
             -H "Authorization: token ${GH_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/${{ github.repository }}/actions/workflows/resolve-failures.yml/dispatches" \
-            -d "{\"ref\":\"main\",\"inputs\":{\"repo_filter\":\"${failing_repos// /|}\",\"dry_run\":\"false\"}}" \
+            -d "{\"ref\":\"main\",\"inputs\":{\"repo_filter\":\"${failing_repos// /|}\",\"dry_run\":\"false\",\"scan_owners\":\"Interested-Deving-1896\"}}" \
             && echo "Resolver dispatched." \
-            || echo "Failed to dispatch resolver -- check quota and token."
-
-      - name: Check PR CI status across OSP-bound repos
-        if: steps.quota.outputs.skip == 'false'
-        id: pr_check
-        env:
-          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
-          GITHUB_OWNER: Interested-Deving-1896
-          REPO_FILTER: ${{ inputs.repo_filter || '' }}
-          BUDGET_MINUTES: "10"
-          MIN_QUOTA: "300"
-        run: |
-          bash scripts/check-osp-pr-ci.sh > /tmp/osp-pr-ci-results.json
-          bash scripts/check-osp-pr-ci-summary.sh /tmp/osp-pr-ci-results.json >> "$GITHUB_STEP_SUMMARY"
-          echo "failing_pr_count=$(bash scripts/check-osp-pr-ci-summary.sh /tmp/osp-pr-ci-results.json --count)" >> "$GITHUB_OUTPUT"
+            || echo "Failed to dispatch resolver — check quota and token."
 
       - name: All green
-        if: >
-          steps.quota.outputs.skip == 'false' &&
-          steps.check.outputs.failing_count == '0' &&
-          steps.pr_check.outputs.failing_pr_count == '0'
-        run: echo "All OSP-bound repos and open PRs are green."
+        if: steps.quota.outputs.skip == 'false' && steps.check.outputs.failing_count == '0'
+        run: echo "All scanned repos are green on their default branch."
 
       - name: Write summary
         if: always()

--- a/.github/workflows/check-gitlab-ci.yml
+++ b/.github/workflows/check-gitlab-ci.yml
@@ -1,0 +1,66 @@
+name: Check GitLab CI Status
+
+# Checks the latest pipeline status on the default branch of every
+# OSP-bound repo mirrored to gitlab.com/openos-project.
+#
+# Runs after each OSP→GitLab mirror push and daily as a backstop.
+# Failing pipelines are written to the job summary; no auto-fix is
+# applied (GitLab pipelines run in the mirror's CI context and fixes
+# must go through the GitHub→OSP→GitLab mirror chain).
+
+on:
+  workflow_run:
+    workflows:
+      - "Mirror OSP → GitLab"
+    types: [completed]
+  schedule:
+    - cron: '15 10 * * *'   # 10:15 UTC daily — after mirror-osp-to-gitlab (10:00)
+  workflow_dispatch:
+    inputs:
+      repo_filter:
+        description: "Check only repos matching this substring (blank = all)"
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-gitlab-ci
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Check GitLab pipelines
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Check GitLab CI pipeline status
+        id: check
+        env:
+          GITLAB_TOKEN: ${{ secrets.GITLAB_SYNC_TOKEN }}
+          REPO_FILTER: ${{ inputs.repo_filter || '' }}
+          BUDGET_MINUTES: "25"
+        run: |
+          source scripts/includes/quota-instrument.sh
+          qi_begin
+          bash scripts/check-gitlab-ci.sh > /tmp/gitlab-ci-results.json
+          bash scripts/check-gitlab-ci-summary.sh /tmp/gitlab-ci-results.json >> "$GITHUB_STEP_SUMMARY"
+          failing=$(bash scripts/check-gitlab-ci-summary.sh /tmp/gitlab-ci-results.json --count)
+          echo "failing_count=${failing}" >> "$GITHUB_OUTPUT"
+          qi_end
+
+      - name: All green
+        if: steps.check.outputs.failing_count == '0'
+        run: echo "All OSP-bound GitLab mirrors have passing pipelines."
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/config/workflow-priority-tiers.yml
+++ b/config/workflow-priority-tiers.yml
@@ -109,6 +109,10 @@ tiers:
     tier: 3
   - name: "Check OSP-Bound CI Status"
     tier: 3
+  - name: "Check GitLab CI Status"
+    tier: 3
+  - name: "Check All Repos CI Status"
+    tier: 3
   - name: "Reconcile Org References"
     tier: 3
   - name: "Sync btrfs-devel Branches"

--- a/config/workflow-quota-costs.yml
+++ b/config/workflow-quota-costs.yml
@@ -182,15 +182,35 @@ workflows:
 - name: Check OSP-Bound CI Status
   min_quota: 300
   cost_low: 50
-  cost_mid: 150
-  cost_high: 300
+  cost_mid: 200
+  cost_high: 400
   basis: code-audit
-  notes: 'Per-repo: repo info + branch + check-runs + statuses (4 REST calls). check-runs/statuses not convertible to GraphQL.
-    ~49 repos × 4 = ~196 calls at high end.
+  notes: 'Default-branch pass: ~49 repos × 4 REST calls (repo info + branch + check-runs + statuses) = ~196 calls.
+    PR CI pass: GraphQL batches (1 call per 10 repos) = ~5 calls. Total mid estimate includes both passes.
 
     '
-  synopsis: Checks CI status across all OSP-bound repos and reports failing workflows. Triggers resolve-failures when failures
-    are detected.
+  synopsis: Checks CI status across all OSP-bound repos (default branch + open PRs) and reports failures. Triggers
+    resolve-failures when default-branch failures are detected.
+- name: Check GitLab CI Status
+  min_quota: 50
+  cost_low: 5
+  cost_mid: 60
+  cost_high: 120
+  basis: code-audit
+  notes: GitLab Pipelines API — 1 call per repo (latest pipeline). ~49 repos = ~49 GitLab API calls (not GitHub quota).
+    GitHub quota cost is near zero (only checkout). Listed for completeness.
+  synopsis: Checks the latest GitLab pipeline status for every OSP-bound repo mirrored to gitlab.com/openos-project.
+    Surfaces failing/canceled/blocked pipelines in the job summary.
+- name: Check All Repos CI Status
+  min_quota: 1000
+  cost_low: 20
+  cost_mid: 50
+  cost_high: 100
+  basis: code-audit
+  notes: GraphQL statusCheckRollup — 1 call per 100 repos. ~4000 repos = ~40 GraphQL calls (each counts as 1 REST unit).
+    Vastly cheaper than per-repo REST approach (~12000 calls).
+  synopsis: Weekly broad scan of all Interested-Deving-1896 repos using GraphQL statusCheckRollup. Surfaces default-branch
+    CI failures across the full org in ~40 API calls. Triggers resolve-failures for failing repos.
 - name: Rebase PRs
   min_quota: 100
   cost_low: 5

--- a/config/workflow-sync.yml
+++ b/config/workflow-sync.yml
@@ -429,7 +429,11 @@ github_only:
   - workflow_file: cancel-post-rotation.yml
     reason: Cancels in-flight runs after token rotation — GitHub Actions API only
   - workflow_file: check-osp-ci.yml
-    reason: Checks CI status of OSP-bound repos — GitHub API only
+    reason: Checks CI status of OSP-bound repos (default branch + open PRs) — GitHub API only
+  - workflow_file: check-gitlab-ci.yml
+    reason: Checks GitLab pipeline status for OSP mirrors — GitLab API only, no GitHub CI equivalent
+  - workflow_file: check-all-repos-ci.yml
+    reason: Broad GraphQL CI scan of all I-D-1896 repos — GitHub API only
   - workflow_file: rebase-prs.yml
     reason: Rebases open PRs onto main — GitHub API only
   - workflow_file: update-workflow-triggers-doc.yml

--- a/scripts/check-all-repos-ci-summary.sh
+++ b/scripts/check-all-repos-ci-summary.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Renders output from check-all-repos-ci.sh JSON results.
+#
+# Usage:
+#   check-all-repos-ci-summary.sh <results.json>          # Markdown summary to stdout
+#   check-all-repos-ci-summary.sh <results.json> --count  # failing repo count
+#   check-all-repos-ci-summary.sh <results.json> --repos  # space-separated failing repo names
+
+set -uo pipefail
+
+results="${1:?results JSON file required}"
+mode="${2:-summary}"
+
+case "$mode" in
+  --count)
+    python3 -c "import json; print(len(json.load(open('${results}'))))"
+    ;;
+  --repos)
+    python3 -c "
+import json
+data = json.load(open('${results}'))
+print(' '.join(r['repo'] for r in data))
+"
+    ;;
+  *)
+    RESULTS_FILE="$results" python3 - << 'PYEOF'
+import json, os
+
+results = os.environ["RESULTS_FILE"]
+data = json.load(open(results))
+count = len(data)
+
+print("## Broad CI Status — Interested-Deving-1896")
+print("")
+
+if count == 0:
+    print("All repos with CI configured are passing.")
+else:
+    print(f"**{count} repo(s) have CI failures on their default branch.**")
+    print("")
+    print("| Repo | Branch | Commit | State | Failing checks |")
+    print("|---|---|---|---|---|")
+    for r in data:
+        owner    = r.get("owner", "Interested-Deving-1896")
+        repo     = r["repo"]
+        branch   = r.get("branch", "")
+        sha      = r.get("sha", "")
+        state    = r.get("state", "")
+        url      = r.get("url", "")
+        contexts = r.get("contexts", [])
+        state_icon = "❌" if state == "FAILURE" else "⚠️"
+        ctx_str  = ", ".join(contexts[:5]) if contexts else "(rollup only)"
+        if len(contexts) > 5:
+            ctx_str += f" +{len(contexts)-5} more"
+        print(f"| [{owner}/{repo}](https://github.com/{owner}/{repo}) | `{branch}` | [`{sha}`]({url}) | {state_icon} {state} | {ctx_str} |")
+PYEOF
+    ;;
+esac

--- a/scripts/check-all-repos-ci.sh
+++ b/scripts/check-all-repos-ci.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+#
+# Checks the CI status of the default branch HEAD for ALL repos in
+# Interested-Deving-1896 using a single GraphQL query per page.
+#
+# Uses the statusCheckRollup field on defaultBranchRef.target to fetch
+# the combined CI state for every repo in one GraphQL call per 100 repos
+# (~40-50 calls total for 4000+ repos vs ~12000 REST calls the naive way).
+#
+# Outputs a JSON array of failing repos to stdout:
+#   [{"repo":"name","owner":"org","branch":"main","sha":"abc1234",
+#     "state":"FAILURE","url":"https://...","contexts":["job1","job2"]}, ...]
+#
+# Required env vars:
+#   GH_TOKEN       — PAT with repo scope (SYNC_TOKEN)
+#
+# Optional env vars:
+#   GITHUB_OWNER   — org to scan (default: Interested-Deving-1896)
+#   REPO_FILTER    — substring filter on repo name (blank = all)
+#   BUDGET_MINUTES — time budget in minutes (default: 55)
+#   SKIP_ARCHIVED  — skip archived repos (default: true)
+#   SKIP_FORKS     — skip forked repos (default: false — forks are the point)
+#   MIN_QUOTA      — skip if quota below this (default: 1000)
+
+set -uo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+
+OWNER="${GITHUB_OWNER:-Interested-Deving-1896}"
+REPO_FILTER="${REPO_FILTER:-}"
+SKIP_ARCHIVED="${SKIP_ARCHIVED:-true}"
+SKIP_FORKS="${SKIP_FORKS:-false}"
+MIN_QUOTA="${MIN_QUOTA:-1000}"
+GH_API="https://api.github.com"
+
+# ── Logging ───────────────────────────────────────────────────────────────────
+info() { echo "[check-all-repos-ci] $*" >&2; }
+warn() { echo "[check-all-repos-ci] ⚠️  $*" >&2; }
+ok()   { echo "[check-all-repos-ci] ✓ $*" >&2; }
+
+# ── Budget guard ──────────────────────────────────────────────────────────────
+source "$(dirname "${BASH_SOURCE[0]}")/includes/budget.sh"
+budget_init
+
+# ── Quota pre-flight ──────────────────────────────────────────────────────────
+_quota_json=$(curl -sf \
+  -H "Authorization: token ${GH_TOKEN}" \
+  "${GH_API}/rate_limit" 2>/dev/null || echo '{}')
+_quota_remaining=$(echo "$_quota_json" | python3 -c \
+  "import sys,json; d=json.load(sys.stdin); print(d.get('resources',{}).get('core',{}).get('remaining',0))" \
+  2>/dev/null || echo 0)
+_quota_reset=$(echo "$_quota_json" | python3 -c \
+  "import sys,json,datetime; d=json.load(sys.stdin); \
+   ts=d.get('resources',{}).get('core',{}).get('reset',0); \
+   print(datetime.datetime.utcfromtimestamp(ts).strftime('%H:%M UTC') if ts else 'unknown')" \
+  2>/dev/null || echo 'unknown')
+
+if (( _quota_remaining < MIN_QUOTA )); then
+  warn "Quota too low (${_quota_remaining} < ${MIN_QUOTA}) — resets at ${_quota_reset}. Skipping."
+  echo "[]"
+  exit 0
+fi
+info "Quota: ${_quota_remaining} remaining (resets ${_quota_reset})"
+
+# ── GraphQL query ─────────────────────────────────────────────────────────────
+# Fetches per page: name, isArchived, isFork, defaultBranchRef with
+# statusCheckRollup (combined CI state + individual context names).
+# One GraphQL call = 1 REST quota unit regardless of repos per page.
+
+graphql_page() {
+  local after_clause="$1"   # empty string or ', after: "CURSOR"'
+  local skip_archived_clause=""
+  [[ "$SKIP_ARCHIVED" == "true" ]] && skip_archived_clause=", isArchived: false"
+
+  local query
+  query=$(python3 -c "
+import sys
+after = sys.argv[1]
+skip_archived = sys.argv[2]
+q = '''{ organization(login: \"OWNER\") {
+  repositories(first: 100AFTER SKIP_ARCHIVED, orderBy: {field: PUSHED_AT, direction: DESC}) {
+    nodes {
+      name
+      isArchived
+      isFork
+      defaultBranchRef {
+        name
+        target {
+          ... on Commit {
+            oid
+            statusCheckRollup {
+              state
+              contexts(last: 20) {
+                nodes {
+                  ... on CheckRun {
+                    name
+                    conclusion
+                    status
+                  }
+                  ... on StatusContext {
+                    context
+                    state
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    pageInfo { hasNextPage endCursor }
+  }
+} }'''
+q = q.replace('OWNER', 'PLACEHOLDER_OWNER')
+q = q.replace('AFTER', after)
+q = q.replace('SKIP_ARCHIVED', skip_archived)
+# Collapse to single line for JSON embedding
+q = ' '.join(q.split())
+print(q)
+" "$after_clause" "$skip_archived_clause" | sed "s/PLACEHOLDER_OWNER/${OWNER}/g")
+
+  curl -sf \
+    -H "Authorization: bearer ${GH_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -X POST "${GH_API}/graphql" \
+    -d "{\"query\":\"${query}\"}" \
+    2>/dev/null || echo "{}"
+}
+
+# ── Paginate and collect failures ─────────────────────────────────────────────
+failing_repos="[]"
+cursor=""
+page=0
+total_repos=0
+total_checked=0
+total_no_ci=0
+
+info "Scanning ${OWNER} repos via GraphQL statusCheckRollup..."
+
+while true; do
+  budget_check "page-${page}" || { warn "Budget exhausted after ${page} pages"; break; }
+
+  after_clause=""
+  [[ -n "$cursor" ]] && after_clause=", after: \\\"${cursor}\\\""
+
+  result=$(graphql_page "$after_clause")
+
+  # Extract nodes
+  nodes_json=$(echo "$result" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+nodes=d.get('data',{}).get('organization',{}).get('repositories',{}).get('nodes',[])
+print(json.dumps(nodes))
+" 2>/dev/null || echo "[]")
+
+  node_count=$(echo "$nodes_json" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))" 2>/dev/null || echo 0)
+
+  if (( node_count == 0 )); then
+    [[ $page -eq 0 ]] && warn "GraphQL returned no repos — check token and org name"
+    break
+  fi
+
+  (( page++ ))
+  (( total_repos += node_count ))
+
+  # Process each repo node
+  while IFS=$'\t' read -r name is_archived is_fork branch sha rollup_state contexts_json; do
+    [[ -z "$name" ]] && continue
+
+    # Apply filters
+    [[ "$SKIP_ARCHIVED" == "true" && "$is_archived" == "True" ]] && continue
+    [[ "$SKIP_FORKS" == "true" && "$is_fork" == "True" ]] && continue
+    [[ -n "$REPO_FILTER" && "$name" != *"$REPO_FILTER"* ]] && continue
+
+    (( total_checked++ ))
+
+    # No default branch or no CI data
+    if [[ -z "$branch" || -z "$rollup_state" || "$rollup_state" == "None" ]]; then
+      (( total_no_ci++ ))
+      continue
+    fi
+
+    # FAILURE / ERROR are actionable; SUCCESS / PENDING / EXPECTED are not
+    case "$rollup_state" in
+      FAILURE|ERROR)
+        repo_url="https://github.com/${OWNER}/${name}/commit/${sha}"
+        warn "${OWNER}/${name}: CI ${rollup_state} on ${branch}@${sha:0:7}"
+
+        # Extract failing context names
+        failing_contexts=$(echo "$contexts_json" | python3 -c "
+import json,sys
+nodes=json.loads(sys.argv[1])
+bad=[]
+for n in nodes:
+    # CheckRun
+    if 'conclusion' in n:
+        if n.get('conclusion') in ('FAILURE','ACTION_REQUIRED','TIMED_OUT','CANCELLED') \
+           and n.get('status') == 'COMPLETED':
+            bad.append(n.get('name','?'))
+    # StatusContext
+    elif 'context' in n:
+        if n.get('state') in ('FAILURE','ERROR'):
+            bad.append(n.get('context','?'))
+print(json.dumps(bad))
+" "$contexts_json" 2>/dev/null || echo "[]")
+
+        failing_repos=$(echo "$failing_repos" | python3 -c "
+import json,sys
+lst=json.load(sys.stdin)
+lst.append({
+  'repo':     '${name}',
+  'owner':    '${OWNER}',
+  'branch':   '${branch}',
+  'sha':      '${sha:0:7}',
+  'state':    '${rollup_state}',
+  'url':      '${repo_url}',
+  'contexts': json.loads('''${failing_contexts}''')
+})
+print(json.dumps(lst))
+" 2>/dev/null || echo "$failing_repos")
+        ;;
+      SUCCESS|PENDING|EXPECTED)
+        : # healthy or in-progress — skip
+        ;;
+    esac
+  done < <(echo "$nodes_json" | python3 -c "
+import json,sys
+nodes=json.load(sys.stdin)
+for n in nodes:
+    name        = n.get('name','')
+    is_archived = str(n.get('isArchived', False))
+    is_fork     = str(n.get('isFork', False))
+    dbr         = n.get('defaultBranchRef') or {}
+    branch      = dbr.get('name','')
+    target      = dbr.get('target') or {}
+    sha         = target.get('oid','')
+    rollup      = target.get('statusCheckRollup') or {}
+    state       = rollup.get('state','')
+    ctx_nodes   = (rollup.get('contexts') or {}).get('nodes',[])
+    print(f'{name}\t{is_archived}\t{is_fork}\t{branch}\t{sha}\t{state}\t{json.dumps(ctx_nodes)}')
+" 2>/dev/null)
+
+  # Pagination
+  has_next=$(echo "$result" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+print(d.get('data',{}).get('organization',{}).get('repositories',{}).get('pageInfo',{}).get('hasNextPage',False))
+" 2>/dev/null || echo "False")
+
+  [[ "$has_next" != "True" ]] && break
+
+  cursor=$(echo "$result" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+print(d.get('data',{}).get('organization',{}).get('repositories',{}).get('pageInfo',{}).get('endCursor',''))
+" 2>/dev/null || echo "")
+
+  [[ -z "$cursor" ]] && break
+done
+
+failing_count=$(echo "$failing_repos" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))" 2>/dev/null || echo "?")
+info "Pages: ${page} | Repos scanned: ${total_repos} | Checked: ${total_checked} | No CI: ${total_no_ci} | Failing: ${failing_count}"
+info "GraphQL calls used: ${page} (vs ~$((total_repos * 3)) REST calls the naive way)"
+
+echo "$failing_repos"

--- a/scripts/check-gitlab-ci-summary.sh
+++ b/scripts/check-gitlab-ci-summary.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Renders output from check-gitlab-ci.sh JSON results.
+#
+# Usage:
+#   check-gitlab-ci-summary.sh <results.json>          # Markdown summary to stdout
+#   check-gitlab-ci-summary.sh <results.json> --count  # failing repo count
+#   check-gitlab-ci-summary.sh <results.json> --repos  # space-separated failing repo names
+
+set -uo pipefail
+
+results="${1:?results JSON file required}"
+mode="${2:-summary}"
+
+case "$mode" in
+  --count)
+    python3 -c "import json; print(len(json.load(open('${results}'))))"
+    ;;
+  --repos)
+    python3 -c "
+import json
+data = json.load(open('${results}'))
+print(' '.join(r['repo'] for r in data))
+"
+    ;;
+  *)
+    RESULTS_FILE="$results" python3 - << 'PYEOF'
+import json, os
+
+results = os.environ["RESULTS_FILE"]
+data = json.load(open(results))
+count = len(data)
+
+print("## GitLab CI Pipeline Status")
+print("")
+
+if count == 0:
+    print("All OSP-bound GitLab mirrors have passing pipelines.")
+else:
+    print(f"**{count} repo(s) have failing pipelines on GitLab.**")
+    print("")
+    print("| Repo | Branch | Commit | Status | Pipeline |")
+    print("|---|---|---|---|---|")
+    for r in data:
+        gl_path  = r["gl_path"]
+        ref      = r.get("ref", "")
+        sha      = r.get("sha", "")
+        status   = r["status"]
+        web_url  = r.get("web_url", "")
+        pid      = r.get("pipeline_id", "")
+        gl_url   = f"https://gitlab.com/{gl_path}"
+        status_icon = {"failed": "❌", "canceled": "⚠️", "blocked": "🔒"}.get(status, "❓")
+        pipeline_link = f"[#{pid}]({web_url})" if web_url else str(pid)
+        print(f"| [{gl_path}]({gl_url}) | `{ref}` | `{sha}` | {status_icon} {status} | {pipeline_link} |")
+PYEOF
+    ;;
+esac

--- a/scripts/check-gitlab-ci.sh
+++ b/scripts/check-gitlab-ci.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+#
+# Checks the CI pipeline status of the default branch HEAD for every
+# OSP-bound repo mirrored to gitlab.com/openos-project.
+#
+# For each repo, queries the GitLab Pipelines API for the latest pipeline
+# on the default branch. A repo is considered failing if the latest pipeline
+# status is failed, canceled, or blocked.
+#
+# Outputs a JSON array of failing repos to stdout:
+#   [{"repo":"name","gl_path":"openos-project/sg/name","pipeline_id":123,
+#     "status":"failed","url":"https://gitlab.com/...","web_url":"..."}, ...]
+#
+# Required env vars:
+#   GITLAB_TOKEN   — GitLab PAT with read_api scope on openos-project
+#
+# Optional env vars:
+#   REPO_FILTER    — substring filter on repo name (blank = all)
+#   BUDGET_MINUTES — time budget in minutes (default: 55)
+#   MIN_QUOTA      — skip if GitLab API calls remaining below this (default: 0,
+#                    GitLab rate limit is 2000 req/min — not a concern here)
+#   DRY_RUN        — if "true", report only without side effects
+
+set -uo pipefail
+
+: "${GITLAB_TOKEN:?GITLAB_TOKEN is required}"
+
+REPO_FILTER="${REPO_FILTER:-}"
+GL_API="https://gitlab.com/api/v4"
+GL_AUTH="PRIVATE-TOKEN: ${GITLAB_TOKEN}"
+
+# ── Logging ───────────────────────────────────────────────────────────────────
+info() { echo "[check-gitlab-ci] $*" >&2; }
+warn() { echo "[check-gitlab-ci] ⚠️  $*" >&2; }
+ok()   { echo "[check-gitlab-ci] ✓ $*" >&2; }
+
+# ── Budget guard ──────────────────────────────────────────────────────────────
+source "$(dirname "${BASH_SOURCE[0]}")/includes/budget.sh"
+budget_init
+
+# ── Config ────────────────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+CONFIG="${REPO_ROOT}/config/gitlab-subgroups.yml"
+
+if [[ ! -f "$CONFIG" ]]; then
+  warn "config/gitlab-subgroups.yml not found"
+  echo "[]"
+  exit 1
+fi
+
+# ── GitLab API helper ─────────────────────────────────────────────────────────
+gl_get() {
+  curl -sf -H "$GL_AUTH" "$@" 2>/dev/null
+}
+
+# ── Build repo→gl_path map from config ───────────────────────────────────────
+# Returns lines of: repo_name<TAB>gl_path<TAB>default_branch
+mapfile -t REPO_ENTRIES < <(python3 - "$CONFIG" <<'PYEOF'
+import yaml, sys
+
+config_path = sys.argv[1]
+data = yaml.safe_load(open(config_path))
+subgroups = data.get("subgroups", {}) or {}
+default_sg = data.get("default_subgroup", "ops")
+
+for sg_name, sg in subgroups.items():
+    sg_path = sg.get("path") or f"openos-project/{sg_name}"
+    for repo in (sg.get("repos") or []):
+        gl_path = f"{sg_path}/{repo}"
+        print(f"{repo}\t{gl_path}")
+PYEOF
+)
+
+info "OSP-bound repos to check: ${#REPO_ENTRIES[@]}"
+
+# ── Check pipeline status for each repo ──────────────────────────────────────
+failing_repos="[]"
+checked=0
+skipped=0
+no_pipeline=0
+
+for entry in "${REPO_ENTRIES[@]}"; do
+  repo=$(echo "$entry" | cut -f1)
+  gl_path=$(echo "$entry" | cut -f2)
+
+  budget_check "$repo" || break
+
+  if [[ -n "$REPO_FILTER" && "$repo" != *"$REPO_FILTER"* ]]; then
+    continue
+  fi
+
+  # URL-encode the full path (/ → %2F)
+  encoded_path=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1],''))" "$gl_path")
+
+  # Get latest pipeline on default branch
+  # GitLab returns pipelines sorted by id desc — first result is the latest
+  pipeline_json=$(gl_get "${GL_API}/projects/${encoded_path}/pipelines?per_page=1&order_by=id&sort=desc" || echo "[]")
+
+  if [[ "$pipeline_json" == "[]" || "$pipeline_json" == "" ]]; then
+    info "${gl_path}: no pipelines found — skipping"
+    (( no_pipeline++ ))
+    continue
+  fi
+
+  (( checked++ ))
+
+  status=$(echo "$pipeline_json" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+if not d: print('none'); sys.exit(0)
+print(d[0].get('status','unknown'))
+" 2>/dev/null || echo "unknown")
+
+  pipeline_id=$(echo "$pipeline_json" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+if not d: print(0); sys.exit(0)
+print(d[0].get('id',0))
+" 2>/dev/null || echo "0")
+
+  web_url=$(echo "$pipeline_json" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+if not d: print(''); sys.exit(0)
+print(d[0].get('web_url',''))
+" 2>/dev/null || echo "")
+
+  ref=$(echo "$pipeline_json" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+if not d: print(''); sys.exit(0)
+print(d[0].get('ref',''))
+" 2>/dev/null || echo "")
+
+  sha=$(echo "$pipeline_json" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+if not d: print(''); sys.exit(0)
+print(d[0].get('sha','')[:7])
+" 2>/dev/null || echo "")
+
+  # failed / canceled / blocked are actionable failures
+  # running / pending / created / waiting_for_resource / preparing / scheduled are in-progress
+  # success / skipped / manual are healthy
+  case "$status" in
+    failed|canceled|blocked)
+      warn "${gl_path}: pipeline #${pipeline_id} ${status} on ${ref}@${sha} — ${web_url}"
+      failing_repos=$(echo "$failing_repos" | python3 -c "
+import json,sys
+lst = json.load(sys.stdin)
+lst.append({
+  'repo':        '${repo}',
+  'gl_path':     '${gl_path}',
+  'pipeline_id': ${pipeline_id},
+  'status':      '${status}',
+  'ref':         '${ref}',
+  'sha':         '${sha}',
+  'web_url':     '${web_url}'
+})
+print(json.dumps(lst))
+" 2>/dev/null || echo "$failing_repos")
+      ;;
+    success|skipped|manual)
+      ok "${gl_path}: pipeline #${pipeline_id} ${status} on ${ref}@${sha}"
+      ;;
+    running|pending|created|waiting_for_resource|preparing|scheduled)
+      info "${gl_path}: pipeline #${pipeline_id} ${status} (in progress) — not counted as failure"
+      ;;
+    *)
+      warn "${gl_path}: pipeline #${pipeline_id} unknown status '${status}'"
+      ;;
+  esac
+done
+
+failing_count=$(echo "$failing_repos" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))" 2>/dev/null || echo "?")
+info "Checked: ${checked} | Failing: ${failing_count} | No pipeline: ${no_pipeline} | Skipped: ${skipped}"
+
+echo "$failing_repos"

--- a/scripts/check-osp-pr-ci-summary.sh
+++ b/scripts/check-osp-pr-ci-summary.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Renders output from check-osp-pr-ci.sh JSON results.
+#
+# Usage:
+#   check-osp-pr-ci-summary.sh <results.json>          # Markdown summary to stdout
+#   check-osp-pr-ci-summary.sh <results.json> --count  # failing PR count
+#   check-osp-pr-ci-summary.sh <results.json> --repos  # space-separated repo names with failing PRs
+
+set -uo pipefail
+
+results="${1:?results JSON file required}"
+mode="${2:-summary}"
+
+case "$mode" in
+  --count)
+    python3 -c "import json; print(len(json.load(open('${results}'))))"
+    ;;
+  --repos)
+    python3 -c "
+import json
+data = json.load(open('${results}'))
+repos = sorted(set(r['repo'] for r in data))
+print(' '.join(repos))
+"
+    ;;
+  *)
+    RESULTS_FILE="$results" python3 - << 'PYEOF'
+import json, os
+
+results = os.environ["RESULTS_FILE"]
+data = json.load(open(results))
+count = len(data)
+
+print("## OSP-Bound PR CI Status")
+print("")
+
+if count == 0:
+    print("All open PRs on OSP-bound repos have passing CI (or no CI configured).")
+else:
+    print(f"**{count} open PR(s) have failing CI.**")
+    print("")
+    print("| Repo | PR | Author | Branch | Commit | State | Failing checks |")
+    print("|---|---|---|---|---|---|---|")
+    for r in data:
+        owner    = r.get("owner", "Interested-Deving-1896")
+        repo     = r["repo"]
+        pr_num   = r["pr"]
+        title    = r.get("title", "")[:60]
+        author   = r.get("author", "")
+        branch   = r.get("branch", "")
+        sha      = r.get("sha", "")
+        state    = r.get("state", "")
+        url      = r.get("url", "")
+        contexts = r.get("contexts", [])
+        state_icon = "❌" if state == "FAILURE" else "⚠️"
+        ctx_str  = ", ".join(contexts[:4]) if contexts else "(rollup only)"
+        if len(contexts) > 4:
+            ctx_str += f" +{len(contexts)-4} more"
+        print(f"| [{owner}/{repo}](https://github.com/{owner}/{repo}) | [#{pr_num}]({url}) \"{title}\" | @{author} | `{branch}` | `{sha}` | {state_icon} {state} | {ctx_str} |")
+PYEOF
+    ;;
+esac

--- a/scripts/check-osp-pr-ci.sh
+++ b/scripts/check-osp-pr-ci.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+#
+# Checks CI status on open PRs across all OSP-bound repos in
+# Interested-Deving-1896 using GraphQL — one call per repo page.
+#
+# For each open PR, fetches the statusCheckRollup on the PR head commit.
+# PRs with failing CI are surfaced so authors can be notified or the
+# resolver can attempt a fix.
+#
+# Outputs a JSON array of failing PRs to stdout:
+#   [{"repo":"name","pr":42,"title":"...","author":"...","branch":"feat/x",
+#     "sha":"abc1234","state":"FAILURE","url":"https://...","contexts":["job"]}, ...]
+#
+# Required env vars:
+#   GH_TOKEN       — PAT with repo scope (SYNC_TOKEN)
+#   GITHUB_OWNER   — default: Interested-Deving-1896
+#
+# Optional env vars:
+#   REPO_FILTER    — substring filter on repo name (blank = all)
+#   BUDGET_MINUTES — time budget in minutes (default: 55)
+#   MIN_QUOTA      — skip if quota below this (default: 500)
+
+set -uo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+
+OWNER="${GITHUB_OWNER:-Interested-Deving-1896}"
+REPO_FILTER="${REPO_FILTER:-}"
+MIN_QUOTA="${MIN_QUOTA:-500}"
+GH_API="https://api.github.com"
+
+# ── Logging ───────────────────────────────────────────────────────────────────
+info() { echo "[check-osp-pr-ci] $*" >&2; }
+warn() { echo "[check-osp-pr-ci] ⚠️  $*" >&2; }
+ok()   { echo "[check-osp-pr-ci] ✓ $*" >&2; }
+
+# ── Budget guard ──────────────────────────────────────────────────────────────
+source "$(dirname "${BASH_SOURCE[0]}")/includes/budget.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/includes/gh-api.sh"
+budget_init
+
+# ── Quota pre-flight ──────────────────────────────────────────────────────────
+_quota_remaining=$(curl -sf \
+  -H "Authorization: token ${GH_TOKEN}" \
+  "${GH_API}/rate_limit" 2>/dev/null \
+  | python3 -c "import sys,json; print(json.load(sys.stdin).get('resources',{}).get('core',{}).get('remaining',0))" \
+  2>/dev/null || echo 0)
+
+if (( _quota_remaining < MIN_QUOTA )); then
+  warn "Quota too low (${_quota_remaining} < ${MIN_QUOTA}) — skipping PR CI check."
+  echo "[]"
+  exit 0
+fi
+info "Quota: ${_quota_remaining} remaining"
+
+# ── Load OSP-bound repo list ──────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+CONFIG="${REPO_ROOT}/config/gitlab-subgroups.yml"
+
+if [[ ! -f "$CONFIG" ]]; then
+  warn "config/gitlab-subgroups.yml not found"
+  echo "[]"
+  exit 1
+fi
+
+mapfile -t OSP_REPOS < <(python3 - "$CONFIG" <<'PYEOF'
+import yaml, sys
+data = yaml.safe_load(open(sys.argv[1]))
+repos = []
+for sg in (data.get("subgroups") or {}).values():
+    repos.extend(sg.get("repos") or [])
+for r in sorted(set(repos)):
+    print(r)
+PYEOF
+)
+
+info "OSP-bound repos: ${#OSP_REPOS[@]}"
+
+# ── GraphQL: fetch open PRs + head CI status per repo ────────────────────────
+# Batches up to 10 repos per GraphQL call using aliases.
+# Each alias fetches: open PRs (first 20) with head commit statusCheckRollup.
+# 1 GraphQL call = 1 REST quota unit.
+
+BATCH_SIZE=10
+failing_prs="[]"
+total_prs=0
+total_failing=0
+batch_num=0
+
+for (( i=0; i<${#OSP_REPOS[@]}; i+=BATCH_SIZE )); do
+  budget_check "batch-${batch_num}" || { warn "Budget exhausted"; break; }
+  (( batch_num++ ))
+
+  # Build alias slice
+  batch=("${OSP_REPOS[@]:$i:$BATCH_SIZE}")
+
+  # Apply repo filter — skip entire batch if no repos match
+  filtered_batch=()
+  for repo in "${batch[@]}"; do
+    [[ -n "$REPO_FILTER" && "$repo" != *"$REPO_FILTER"* ]] && continue
+    filtered_batch+=("$repo")
+  done
+  [[ ${#filtered_batch[@]} -eq 0 ]] && continue
+
+  # Build GraphQL aliases
+  aliases=$(python3 -c "
+import sys, json
+repos = json.loads(sys.argv[1])
+owner = sys.argv[2]
+parts = []
+for i, repo in enumerate(repos):
+    safe = repo.replace('-','_').replace('.','_')
+    parts.append(
+        f'r{i}: repository(owner: \"{owner}\", name: \"{repo}\") {{ '
+        f'name '
+        f'pullRequests(states: OPEN, first: 20, orderBy: {{field: UPDATED_AT, direction: DESC}}) {{ '
+        f'nodes {{ '
+        f'number title url author {{ login }} '
+        f'headRefName '
+        f'headCommit: commits(last: 1) {{ nodes {{ commit {{ oid statusCheckRollup {{ '
+        f'state contexts(last: 20) {{ nodes {{ '
+        f'... on CheckRun {{ name conclusion status }} '
+        f'... on StatusContext {{ context state }} '
+        f'}} }} }} }} }} }} '
+        f'}} }} }}'
+    )
+print(' '.join(parts))
+" "$(python3 -c "import json,sys; print(json.dumps(sys.argv[1:]))" "${filtered_batch[@]}")" "$OWNER")
+
+  result=$(curl -sf \
+    -H "Authorization: bearer ${GH_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -X POST "${GH_API}/graphql" \
+    -d "{\"query\":\"{ ${aliases} }\"}" \
+    2>/dev/null || echo "{}")
+
+  # Parse results
+  while IFS=$'\t' read -r repo pr_num title author branch sha rollup_state contexts_json pr_url; do
+    [[ -z "$repo" || -z "$pr_num" ]] && continue
+    (( total_prs++ ))
+
+    case "$rollup_state" in
+      FAILURE|ERROR)
+        warn "${OWNER}/${repo}#${pr_num}: CI ${rollup_state} on ${branch}@${sha:0:7} — ${pr_url}"
+        (( total_failing++ ))
+
+        failing_contexts=$(echo "$contexts_json" | python3 -c "
+import json,sys
+nodes=json.loads(sys.argv[1])
+bad=[]
+for n in nodes:
+    if 'conclusion' in n:
+        if n.get('conclusion') in ('FAILURE','ACTION_REQUIRED','TIMED_OUT','CANCELLED') \
+           and n.get('status') == 'COMPLETED':
+            bad.append(n.get('name','?'))
+    elif 'context' in n:
+        if n.get('state') in ('FAILURE','ERROR'):
+            bad.append(n.get('context','?'))
+print(json.dumps(bad))
+" "$contexts_json" 2>/dev/null || echo "[]")
+
+        failing_prs=$(echo "$failing_prs" | python3 -c "
+import json,sys
+lst=json.load(sys.stdin)
+lst.append({
+  'repo':     '${repo}',
+  'owner':    '${OWNER}',
+  'pr':       ${pr_num},
+  'title':    '${title}',
+  'author':   '${author}',
+  'branch':   '${branch}',
+  'sha':      '${sha:0:7}',
+  'state':    '${rollup_state}',
+  'url':      '${pr_url}',
+  'contexts': json.loads('''${failing_contexts}''')
+})
+print(json.dumps(lst))
+" 2>/dev/null || echo "$failing_prs")
+        ;;
+      SUCCESS|PENDING|EXPECTED|"")
+        : # healthy or no CI
+        ;;
+    esac
+  done < <(echo "$result" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+data=d.get('data',{})
+for key,repo_data in data.items():
+    if not repo_data: continue
+    repo_name=repo_data.get('name','')
+    prs=repo_data.get('pullRequests',{}).get('nodes',[])
+    for pr in prs:
+        pr_num=pr.get('number',0)
+        title=pr.get('title','').replace(chr(9),' ').replace(chr(10),' ')
+        pr_url=pr.get('url','')
+        author=(pr.get('author') or {}).get('login','')
+        branch=pr.get('headRefName','')
+        commits=(pr.get('headCommit') or {}).get('nodes',[])
+        if not commits: continue
+        commit=commits[-1].get('commit',{})
+        sha=commit.get('oid','')
+        rollup=commit.get('statusCheckRollup') or {}
+        state=rollup.get('state','')
+        ctx_nodes=(rollup.get('contexts') or {}).get('nodes',[])
+        print(f'{repo_name}\t{pr_num}\t{title}\t{author}\t{branch}\t{sha}\t{state}\t{json.dumps(ctx_nodes)}\t{pr_url}')
+" 2>/dev/null)
+done
+
+info "Open PRs checked: ${total_prs} | Failing CI: ${total_failing} | GraphQL batches: ${batch_num}"
+
+echo "$failing_prs"


### PR DESCRIPTION
## What

Closes three gaps in CI/CD failure visibility:

### 1. GitLab pipeline checker
`check-gitlab-ci.yml` + `check-gitlab-ci.sh`

The existing `check-osp-ci` only covers GitHub CI. OSP repos mirrored to GitLab had no pipeline failure visibility.

- Queries `GET /projects/:id/pipelines?per_page=1` for every OSP-bound repo in `config/gitlab-subgroups.yml`
- Classifies `failed`, `canceled`, `blocked` as actionable; `running`/`pending` as in-progress
- Runs after each `Mirror OSP → GitLab` completion and daily at 10:15 UTC
- Summary script (`check-gitlab-ci-summary.sh`) supports `--count` and `--repos` modes matching the existing `check-osp-ci-summary.sh` pattern

### 2. Broad I-D-1896 CI scanner
`check-all-repos-ci.yml` + `check-all-repos-ci.sh`

The existing `check-osp-ci` only covers ~49 OSP-bound repos. The other ~4000 I-D-1896 repos had no CI failure visibility.

- Uses GraphQL `statusCheckRollup` on `defaultBranchRef.target` — 1 API call per 100 repos
- ~40 GraphQL calls for 4000 repos vs ~12,000 REST calls the naive way
- Skips archived repos by default; `SKIP_FORKS=true` available for narrower scans
- Runs weekly Sunday 06:00 UTC; dispatches `resolve-failures.yml` for failing repos
- `check-all-repos-ci-summary.sh` follows the same `--count`/`--repos` interface

### 3. PR CI surfacing in Check OSP-Bound CI Status
`check-osp-pr-ci.sh` + `check-osp-pr-ci-summary.sh`

Open PRs with failing CI were invisible — only default-branch HEAD was checked.

- New step added to `check-osp-ci.yml` after the default-branch pass
- Batches open PRs across all OSP-bound repos via GraphQL (1 call per 10 repos, ~5 calls total)
- Surfaces failing PRs in the job summary with PR number, author, branch, and failing check names
- Does not dispatch the resolver (PR fixes require human review)

## Config registrations

All three new workflows registered in:
- `config/workflow-quota-costs.yml` — cost estimates with GraphQL call counts noted
- `config/workflow-priority-tiers.yml` — tier 3 (MEDIUM)
- `config/workflow-sync.yml` — `github_only` with reasons

`onboard-repo.sh` executable bit fixed in git index (was missing `100755`).

## Validation

```
validate-workflow-guards.py: all checks passed (103 workflows, 105 quota-cost entries, 20 workflow_run triggers)
YAML parse: 103 files clean
Shell syntax: all scripts pass bash -n
Config completeness: all 103 workflows in quota-costs, priority-tiers, workflow-sync
```