### PR TITLE
feat: agnostic mirror-chain backend + node identity layer

### DIFF
--- a/.github/workflows/mirror-chain-dispatch.yml
+++ b/.github/workflows/mirror-chain-dispatch.yml
@@ -1,0 +1,416 @@
+name: Mirror Chain Dispatch
+
+# Agnostic mirror-chain backend. Abstracts the I-D-1896 → OSP → GitLab → OOC
+# topology into configurable dispatch fields. Drop this into any fork of
+# fork-sync-all and it will auto-detect its position in the chain, then run
+# only the operations appropriate for that position.
+#
+# ── Chain positions ───────────────────────────────────────────────────────────
+#   source          — canonical upstream (Interested-Deving-1896). Runs all
+#                     write operations: readme, badges, fork-sync, templates.
+#   mirror          — downstream GitHub mirror (e.g. OSP). Receives pushes;
+#                     skips source-only operations to avoid duplicate work.
+#   downstream-fork — independent fork managing its own org. Runs all
+#                     operations scoped to its own org.
+#
+# ── Auto-detection ────────────────────────────────────────────────────────────
+#   Position is detected by fsa-node-identity.sh (see that file for logic).
+#   Override with the chain_position dispatch input or FSA_CHAIN_POSITION env.
+#
+# ── Adding a new chain leg ────────────────────────────────────────────────────
+#   1. Add a dest_backends entry (e.g. "github:MyOrg,gitlab:my-group/subgroup")
+#   2. Set the corresponding token secret (DEST_GITHUB_TOKEN / DEST_GITLAB_TOKEN)
+#   3. No workflow edits needed — the dispatch script reads dest_backends at runtime.
+
+on:
+  workflow_dispatch:
+    inputs:
+      chain_position:
+        description: "Override chain position (auto-detected if blank)"
+        required: false
+        default: ""
+        type: choice
+        options:
+          - ""
+          - source
+          - mirror
+          - downstream-fork
+      source_owner:
+        description: "GitHub org/user to mirror FROM (blank = this repo's owner)"
+        required: false
+        default: ""
+        type: string
+      dest_backends:
+        description: "Comma-separated push targets: github:ORG, gitlab:GROUP/SUBGROUP"
+        required: false
+        default: ""
+        type: string
+      operations:
+        description: "Comma-separated ops to run (blank = position-appropriate defaults)"
+        required: false
+        default: ""
+        type: string
+        # Valid values: mirror-github, mirror-gitlab, readmes, badges, sync-forks,
+        #               translate, templates
+        # Example: "mirror-github,mirror-gitlab"
+      repo_filter:
+        description: "Limit to this repo name (blank = all)"
+        required: false
+        default: ""
+        type: string
+      dry_run:
+        description: "Report without pushing"
+        required: false
+        default: false
+        type: boolean
+      force:
+        description: "Force-push even if destination has diverged"
+        required: false
+        default: false
+        type: boolean
+
+  # Scheduled leg — runs as source on the canonical instance, as a no-op
+  # (position=mirror, no write ops) on downstream mirrors.
+  schedule:
+    - cron: '47 */6 * * *'   # Every 6h at :47 — staggered from mirror-to-osp (:13)
+
+concurrency:
+  group: mirror-chain-dispatch-${{ github.ref }}
+  cancel-in-progress: false   # Never cancel mid-mirror
+
+permissions:
+  contents: read
+
+jobs:
+  # ── Step 1: detect node identity ─────────────────────────────────────────
+  detect:
+    name: Detect chain position
+    runs-on: ubuntu-latest
+    outputs:
+      position:        ${{ steps.node.outputs.fsa_node_position }}
+      node_owner:      ${{ steps.node.outputs.fsa_node_owner }}
+      upstream_owner:  ${{ steps.node.outputs.fsa_upstream_owner }}
+      chain_depth:     ${{ steps.node.outputs.fsa_chain_depth }}
+      skip:            ${{ steps.quota.outputs.skip }}
+      remaining:       ${{ steps.quota.outputs.remaining }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Quota pre-flight
+        id: quota
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+          MIN_QUOTA: "1200"
+        run: |
+          remaining=$(curl -sf \
+            -H "Authorization: token ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/rate_limit \
+            | python3 -c "import sys,json; print(json.load(sys.stdin)['resources']['core']['remaining'])")
+          echo "remaining=${remaining}" >> "$GITHUB_OUTPUT"
+          if [[ "${remaining}" -lt "${MIN_QUOTA}" ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Quota too low (${remaining} < ${MIN_QUOTA}) — skipping."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Detect node identity
+        id: node
+        if: steps.quota.outputs.skip == 'false'
+        env:
+          GH_TOKEN:            ${{ secrets.SYNC_TOKEN }}
+          FSA_MANAGED:         ${{ vars.FSA_MANAGED }}
+          REPO_OWNER:          ${{ github.repository_owner }}
+          FSA_CHAIN_POSITION:  ${{ inputs.chain_position }}
+          FSA_UPSTREAM_OWNER:  ${{ inputs.source_owner }}
+          FSA_CHAIN_DEPTH:     ""
+        run: |
+          source scripts/includes/fsa-node-identity.sh
+          fsa_node_detect
+          fsa_node_summary
+
+  # ── Step 2: GitHub mirror leg ─────────────────────────────────────────────
+  # Pushes repos from source_owner → dest GitHub org.
+  # Runs for: source (→ OSP), mirror (→ OOC), downstream-fork (→ own mirror).
+  mirror-github:
+    name: Mirror → GitHub
+    needs: detect
+    if: |
+      needs.detect.outputs.skip == 'false' &&
+      (
+        contains(inputs.operations, 'mirror-github') ||
+        inputs.operations == '' ||
+        inputs.operations == null
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Resolve GitHub destinations
+        id: dest
+        env:
+          DEST_BACKENDS:   ${{ inputs.dest_backends }}
+          NODE_POSITION:   ${{ needs.detect.outputs.position }}
+          NODE_OWNER:      ${{ needs.detect.outputs.node_owner }}
+          UPSTREAM_OWNER:  ${{ needs.detect.outputs.upstream_owner }}
+        run: |
+          # Parse dest_backends for github: entries.
+          # Fall back to position-appropriate defaults when not specified.
+          python3 - <<'PYEOF'
+          import os, sys
+
+          dest_backends = os.environ.get("DEST_BACKENDS", "").strip()
+          position      = os.environ.get("NODE_POSITION", "downstream-fork")
+          node_owner    = os.environ.get("NODE_OWNER", "")
+          upstream      = os.environ.get("UPSTREAM_OWNER", "")
+
+          github_dests = []
+          if dest_backends:
+              for entry in dest_backends.split(","):
+                  entry = entry.strip()
+                  if entry.startswith("github:"):
+                      github_dests.append(entry[len("github:"):].strip())
+          else:
+              # Position-appropriate defaults
+              if position == "source":
+                  github_dests = ["OpenOS-Project-OSP"]
+              elif position == "mirror":
+                  github_dests = ["OpenOS-Project-Ecosystem-OOC"]
+              # downstream-fork: no default GitHub dest (manages its own org)
+
+          output_file = os.environ.get("GITHUB_OUTPUT", "")
+          dest_str = ",".join(github_dests)
+          print(f"github_dests={dest_str}", file=open(output_file, "a") if output_file else sys.stdout)
+          print(f"has_github_dests={'true' if github_dests else 'false'}", file=open(output_file, "a") if output_file else sys.stdout)
+          print(f"[mirror-chain] GitHub destinations: {dest_str or '(none)'}", file=sys.stderr)
+          PYEOF
+
+      - name: Mirror repos to GitHub destinations
+        if: steps.dest.outputs.has_github_dests == 'true'
+        env:
+          GH_TOKEN:        ${{ secrets.SYNC_TOKEN }}
+          UPSTREAM_OWNER:  ${{ needs.detect.outputs.upstream_owner || needs.detect.outputs.node_owner }}
+          GITHUB_DESTS:    ${{ steps.dest.outputs.github_dests }}
+          REPO_FILTER:     ${{ inputs.repo_filter }}
+          DRY_RUN:         ${{ inputs.dry_run || 'false' }}
+          FORCE:           ${{ inputs.force || 'false' }}
+          BUDGET_MINUTES:  "30"
+        run: |
+          source scripts/includes/quota-instrument.sh
+          qi_begin
+          # Mirror to each GitHub destination in sequence.
+          IFS=',' read -ra dests <<< "${GITHUB_DESTS}"
+          for dest_org in "${dests[@]}"; do
+            dest_org="${dest_org// /}"
+            [[ -z "$dest_org" ]] && continue
+            echo "[mirror-chain] Mirroring ${UPSTREAM_OWNER} → ${dest_org}" >&2
+            OSP_ORG="${dest_org}" bash scripts/mirror-to-osp.sh
+          done
+          qi_end
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS:   ${{ job.status }}
+          INPUTS_JSON:  ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh
+
+  # ── Step 3: GitLab mirror leg ─────────────────────────────────────────────
+  # Pushes repos from source GitHub org → GitLab group.
+  # Runs for: source and mirror positions (downstream-fork opt-in via dest_backends).
+  mirror-gitlab:
+    name: Mirror → GitLab
+    needs: detect
+    if: |
+      needs.detect.outputs.skip == 'false' &&
+      (
+        contains(inputs.operations, 'mirror-gitlab') ||
+        inputs.operations == '' ||
+        inputs.operations == null
+      ) &&
+      needs.detect.outputs.position != 'downstream-fork'
+    runs-on: ubuntu-latest
+    timeout-minutes: 65
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Resolve GitLab destinations
+        id: dest
+        env:
+          DEST_BACKENDS:  ${{ inputs.dest_backends }}
+          NODE_POSITION:  ${{ needs.detect.outputs.position }}
+        run: |
+          python3 - <<'PYEOF'
+          import os, sys
+
+          dest_backends = os.environ.get("DEST_BACKENDS", "").strip()
+          position      = os.environ.get("NODE_POSITION", "source")
+
+          gitlab_dests = []
+          if dest_backends:
+              for entry in dest_backends.split(","):
+                  entry = entry.strip()
+                  if entry.startswith("gitlab:"):
+                      gitlab_dests.append(entry[len("gitlab:"):].strip())
+          else:
+              # Default: push to openos-project (canonical GitLab group)
+              gitlab_dests = ["openos-project"]
+
+          output_file = os.environ.get("GITHUB_OUTPUT", "")
+          dest_str = ",".join(gitlab_dests)
+          print(f"gitlab_dests={dest_str}", file=open(output_file, "a") if output_file else sys.stdout)
+          print(f"has_gitlab_dests={'true' if gitlab_dests else 'false'}", file=open(output_file, "a") if output_file else sys.stdout)
+          print(f"[mirror-chain] GitLab destinations: {dest_str or '(none)'}", file=sys.stderr)
+          PYEOF
+
+      - name: Mirror OSP repos to GitLab
+        if: steps.dest.outputs.has_gitlab_dests == 'true'
+        env:
+          GH_TOKEN:        ${{ secrets.SYNC_TOKEN }}
+          GITLAB_TOKEN:    ${{ secrets.GITLAB_SYNC_TOKEN }}
+          OSP_ORG:         OpenOS-Project-OSP
+          GITLAB_DESTS:    ${{ steps.dest.outputs.gitlab_dests }}
+          REPO_FILTER:     ${{ inputs.repo_filter }}
+          DRY_RUN:         ${{ inputs.dry_run || 'false' }}
+          BUDGET_MINUTES:  "60"
+        run: |
+          # Mirror to each GitLab destination in sequence.
+          IFS=',' read -ra dests <<< "${GITLAB_DESTS}"
+          for dest_group in "${dests[@]}"; do
+            dest_group="${dest_group// /}"
+            [[ -z "$dest_group" ]] && continue
+            echo "[mirror-chain] Mirroring OSP → GitLab ${dest_group}" >&2
+            GITLAB_GROUP="${dest_group}" bash scripts/mirror-osp-to-gitlab.sh
+          done
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS:   ${{ job.status }}
+          INPUTS_JSON:  ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh
+
+  # ── Step 4: source-only operations ───────────────────────────────────────
+  # README updates, badge injection, fork sync, template management.
+  # Only runs for source and downstream-fork positions.
+  source-ops:
+    name: Source operations
+    needs: detect
+    if: |
+      needs.detect.outputs.skip == 'false' &&
+      needs.detect.outputs.position != 'mirror' &&
+      (
+        contains(inputs.operations, 'readmes') ||
+        contains(inputs.operations, 'badges') ||
+        contains(inputs.operations, 'sync-forks') ||
+        contains(inputs.operations, 'templates') ||
+        inputs.operations == '' ||
+        inputs.operations == null
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Resolve enabled operations
+        id: ops
+        env:
+          OPERATIONS:     ${{ inputs.operations }}
+          NODE_POSITION:  ${{ needs.detect.outputs.position }}
+        run: |
+          ops="${OPERATIONS:-}"
+          # Blank = all position-appropriate ops
+          if [[ -z "$ops" ]]; then
+            ops="readmes,badges,sync-forks,templates"
+          fi
+          echo "ops=${ops}" >> "$GITHUB_OUTPUT"
+          echo "[mirror-chain] source-ops enabled: ${ops}" >&2
+
+      - name: Update READMEs
+        if: contains(steps.ops.outputs.ops, 'readmes')
+        env:
+          GH_TOKEN:        ${{ secrets.SYNC_TOKEN }}
+          TARGET_ORG:      ${{ needs.detect.outputs.node_owner }}
+          REPO_FILTER:     ${{ inputs.repo_filter }}
+          DRY_RUN:         ${{ inputs.dry_run || 'false' }}
+          BUDGET_MINUTES:  "20"
+        run: bash scripts/update-readmes.sh
+
+      - name: Inject badges
+        if: contains(steps.ops.outputs.ops, 'badges')
+        env:
+          GH_TOKEN:        ${{ secrets.SYNC_TOKEN }}
+          TARGET_ORG:      ${{ needs.detect.outputs.node_owner }}
+          REPO_FILTER:     ${{ inputs.repo_filter }}
+          DRY_RUN:         ${{ inputs.dry_run || 'false' }}
+          BUDGET_MINUTES:  "15"
+        run: bash scripts/inject-badges.sh
+
+      - name: Sync upstream forks
+        if: contains(steps.ops.outputs.ops, 'sync-forks')
+        env:
+          GH_TOKEN:        ${{ secrets.SYNC_TOKEN }}
+          TARGET_ORG:      ${{ needs.detect.outputs.node_owner }}
+          REPO_FILTER:     ${{ inputs.repo_filter }}
+          DRY_RUN:         ${{ inputs.dry_run || 'false' }}
+          BUDGET_MINUTES:  "20"
+        run: bash scripts/sync-forks.sh
+
+      - name: Sync templates to consumers
+        if: contains(steps.ops.outputs.ops, 'templates')
+        env:
+          GH_TOKEN:        ${{ secrets.SYNC_TOKEN }}
+          TARGET_ORG:      ${{ needs.detect.outputs.node_owner }}
+          REPO_FILTER:     ${{ inputs.repo_filter }}
+          DRY_RUN:         ${{ inputs.dry_run || 'false' }}
+          BUDGET_MINUTES:  "15"
+        run: bash scripts/sync-template.sh
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS:   ${{ job.status }}
+          INPUTS_JSON:  ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh
+
+  # ── Step 5: translation leg ───────────────────────────────────────────────
+  # Runs only for source and downstream-fork; mirrors skip to avoid duplicate
+  # translation jobs across the chain.
+  translate:
+    name: Translate docs
+    needs: detect
+    if: |
+      needs.detect.outputs.skip == 'false' &&
+      needs.detect.outputs.position != 'mirror' &&
+      (
+        contains(inputs.operations, 'translate') ||
+        inputs.operations == '' ||
+        inputs.operations == null
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Translate READMEs
+        env:
+          GH_TOKEN:        ${{ secrets.SYNC_TOKEN }}
+          TARGET_ORG:      ${{ needs.detect.outputs.node_owner }}
+          REPO_FILTER:     ${{ inputs.repo_filter }}
+          DRY_RUN:         ${{ inputs.dry_run || 'false' }}
+          BUDGET_MINUTES:  "25"
+        run: bash scripts/translate-readmes.sh
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS:   ${{ job.status }}
+          INPUTS_JSON:  ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/config/workflow-priority-tiers.yml
+++ b/config/workflow-priority-tiers.yml
@@ -69,6 +69,8 @@ tiers:
     tier: 2
   - name: "Mirror to OpenOS-Project-Ecosystem-OOC"
     tier: 2
+  - name: "Mirror Chain Dispatch"
+    tier: 2
   - name: "Sync Registered Imports"
     tier: 2
   - name: "Sync All Forks"

--- a/config/workflow-quota-costs.yml
+++ b/config/workflow-quota-costs.yml
@@ -891,3 +891,11 @@ workflows:
   basis: code-audit
   notes: 1 quota pre-flight + 1 FSA mode check + 2 content fetches (accessibility-report.json, README.audio.mp3 existence) + 1 commit push (if artifacts changed). High end assumes managed mode scanning multiple repos.
   synopsis: Multi-layer accessibility audit — CODEOWNERS coverage, README screen-reader scan, WCAG 2.1 AA HTML check, audio overview (espeak-ng), and Braille output (liblouis). Commits README.audio.mp3 and README.brl artifacts.
+- name: Mirror Chain Dispatch
+  min_quota: 1200
+  cost_low: 50
+  cost_mid: 300
+  cost_high: 800
+  basis: code-audit
+  notes: 1 quota pre-flight + 1 node-identity detect (1–3 API calls). Mirror legs delegate to mirror-to-osp.sh and mirror-osp-to-gitlab.sh — costs scale with number of repos and enabled operations. Low = single-repo filter, dry-run. Mid = full GitHub mirror leg only. High = all legs (GitHub + GitLab + source-ops + translate) across all repos.
+  synopsis: "Agnostic mirror-chain backend. Auto-detects chain position (source/mirror/downstream-fork) and runs only the operations appropriate for that position. Configurable via dispatch inputs: source_owner, dest_backends, operations, repo_filter."

--- a/config/workflow-sync.yml
+++ b/config/workflow-sync.yml
@@ -278,6 +278,8 @@ paired:
 # are interactive tools not suited to scheduled CI.
 
 github_only:
+  - workflow_file: mirror-chain-dispatch.yml
+    reason: Agnostic mirror-chain backend — dispatches to GitHub and GitLab legs from GitHub Actions
   - workflow_file: mirror-releases.yml
     reason: Mirrors GitHub Releases — no GitLab equivalent concept
   - workflow_file: mirror-osp-to-gitlab.yml

--- a/scripts/includes/fsa-node-identity.sh
+++ b/scripts/includes/fsa-node-identity.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+#
+# scripts/includes/fsa-node-identity.sh — mirror-chain node identity detection
+#
+# Determines where this fork-sync-all instance sits in the mirror chain and
+# what operations it should perform. Extends fsa-mode.sh (managed/autonomous)
+# with a position layer: source / mirror / downstream-fork.
+#
+# ── Chain topology ────────────────────────────────────────────────────────────
+#
+#   source          — the canonical upstream instance (Interested-Deving-1896).
+#                     Runs all operations: mirror-to-osp, mirror-osp-to-gitlab,
+#                     readme updates, badge injection, fork sync, etc.
+#
+#   mirror          — a downstream GitHub mirror (e.g. OpenOS-Project-OSP).
+#                     Receives pushes from source; should NOT re-run source
+#                     operations. May run GitLab-push and OOC-push legs.
+#
+#   downstream-fork — an independent fork of fork-sync-all that manages its
+#                     own org. Runs all operations scoped to its own org,
+#                     not to I-D-1896 or OSP.
+#
+# ── Detection logic ──────────────────────────────────────────────────────────
+#
+#   1. FSA_CHAIN_POSITION env var — explicit override (highest priority).
+#      Values: source | mirror | downstream-fork
+#
+#   2. GITHUB_REPOSITORY — if it matches the canonical source slug
+#      (Interested-Deving-1896/fork-sync-all), position = source.
+#
+#   3. FSA_UPSTREAM_OWNER env var — if set, this instance is a mirror of
+#      that owner. Position = mirror.
+#
+#   4. fsa_is_managed() from fsa-mode.sh — if managed by an upstream FSA
+#      instance (FSA_MANAGED=true or upstream fork-sync-all exists), and
+#      GITHUB_REPOSITORY_OWNER != canonical source owner, position = mirror.
+#
+#   5. Default — position = downstream-fork (independent instance).
+#
+# ── Exported variables ────────────────────────────────────────────────────────
+#
+#   FSA_NODE_POSITION   — source | mirror | downstream-fork
+#   FSA_NODE_OWNER      — the org/user this instance manages (its own org)
+#   FSA_UPSTREAM_OWNER  — the org being mirrored from (empty for source/fork)
+#   FSA_CHAIN_DEPTH     — 0=source, 1=first mirror, 2=second mirror, etc.
+#                         (set via FSA_CHAIN_DEPTH env var; defaults to 0 for
+#                          source, 1 for mirror, 2 for downstream-fork)
+#
+# ── Operation capability flags ────────────────────────────────────────────────
+#
+#   fsa_can_mirror_to_github   — push repos to a downstream GitHub org
+#   fsa_can_mirror_to_gitlab   — push repos to a GitLab group
+#   fsa_can_update_readmes     — write README files to managed repos
+#   fsa_can_inject_badges      — inject built-with-ona badges
+#   fsa_can_sync_forks         — sync upstream forks
+#   fsa_can_translate          — run translation workflows
+#   fsa_can_manage_templates   — push template files to consumer repos
+#
+#   All return 0 (true) or 1 (false). Callers use:
+#     fsa_can_mirror_to_github && bash scripts/mirror-to-osp.sh
+#
+# ── Usage ─────────────────────────────────────────────────────────────────────
+#
+#   source scripts/includes/fsa-node-identity.sh
+#   fsa_node_detect          # populate FSA_NODE_* vars
+#   echo "Position: $FSA_NODE_POSITION"
+#   fsa_can_mirror_to_github && echo "will mirror to GitHub"
+#
+# Guard against double-sourcing
+[[ -n "${_FSA_NODE_IDENTITY_LOADED:-}" ]] && return 0
+_FSA_NODE_IDENTITY_LOADED=1
+
+# Source fsa-mode.sh for fsa_is_managed()
+_FSA_NODE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/includes/fsa-mode.sh
+source "${_FSA_NODE_DIR}/fsa-mode.sh"
+
+# Canonical source identity — the one true upstream instance.
+_FSA_CANONICAL_OWNER="${FSA_CANONICAL_OWNER:-Interested-Deving-1896}"
+_FSA_CANONICAL_REPO="${FSA_CANONICAL_REPO:-fork-sync-all}"
+_FSA_CANONICAL_SLUG="${_FSA_CANONICAL_OWNER}/${_FSA_CANONICAL_REPO}"
+
+# ── fsa_node_detect ───────────────────────────────────────────────────────────
+# Populates FSA_NODE_POSITION, FSA_NODE_OWNER, FSA_UPSTREAM_OWNER,
+# FSA_CHAIN_DEPTH. Safe to call multiple times (idempotent after first call).
+fsa_node_detect() {
+  # Already detected — skip.
+  [[ -n "${FSA_NODE_POSITION:-}" ]] && return 0
+
+  local repo="${GITHUB_REPOSITORY:-}"
+  local owner="${GITHUB_REPOSITORY_OWNER:-}"
+
+  # ── 1. Explicit override ──────────────────────────────────────────────────
+  if [[ -n "${FSA_CHAIN_POSITION:-}" ]]; then
+    FSA_NODE_POSITION="${FSA_CHAIN_POSITION}"
+    FSA_NODE_OWNER="${owner}"
+    FSA_CHAIN_DEPTH="${FSA_CHAIN_DEPTH:-1}"
+    echo "[fsa-node] explicit FSA_CHAIN_POSITION=${FSA_NODE_POSITION}" >&2
+    _fsa_node_export
+    return 0
+  fi
+
+  # ── 2. Canonical source slug match ───────────────────────────────────────
+  if [[ "$repo" == "${_FSA_CANONICAL_SLUG}" ]]; then
+    FSA_NODE_POSITION="source"
+    FSA_NODE_OWNER="${_FSA_CANONICAL_OWNER}"
+    FSA_UPSTREAM_OWNER=""
+    FSA_CHAIN_DEPTH=0
+    echo "[fsa-node] canonical source detected (${_FSA_CANONICAL_SLUG})" >&2
+    _fsa_node_export
+    return 0
+  fi
+
+  # ── 3. Explicit upstream owner set — this is a mirror ────────────────────
+  if [[ -n "${FSA_UPSTREAM_OWNER:-}" ]]; then
+    FSA_NODE_POSITION="mirror"
+    FSA_NODE_OWNER="${owner}"
+    FSA_CHAIN_DEPTH="${FSA_CHAIN_DEPTH:-1}"
+    echo "[fsa-node] FSA_UPSTREAM_OWNER=${FSA_UPSTREAM_OWNER} — mirror mode" >&2
+    _fsa_node_export
+    return 0
+  fi
+
+  # ── 4. Managed by upstream FSA + not canonical owner → mirror ────────────
+  if fsa_is_managed 2>/dev/null; then
+    if [[ "$owner" != "${_FSA_CANONICAL_OWNER}" ]]; then
+      FSA_NODE_POSITION="mirror"
+      FSA_NODE_OWNER="${owner}"
+      FSA_UPSTREAM_OWNER="${FSA_UPSTREAM_OWNER:-${_FSA_CANONICAL_OWNER}}"
+      FSA_CHAIN_DEPTH="${FSA_CHAIN_DEPTH:-1}"
+      echo "[fsa-node] managed mode + non-canonical owner → mirror" >&2
+      _fsa_node_export
+      return 0
+    fi
+  fi
+
+  # ── 5. Default: independent downstream fork ───────────────────────────────
+  FSA_NODE_POSITION="downstream-fork"
+  FSA_NODE_OWNER="${owner}"
+  FSA_UPSTREAM_OWNER=""
+  FSA_CHAIN_DEPTH="${FSA_CHAIN_DEPTH:-2}"
+  echo "[fsa-node] no upstream detected — downstream-fork (${owner})" >&2
+  _fsa_node_export
+}
+
+# _fsa_node_export: write detected values to GITHUB_OUTPUT if available.
+_fsa_node_export() {
+  export FSA_NODE_POSITION FSA_NODE_OWNER FSA_UPSTREAM_OWNER FSA_CHAIN_DEPTH
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    {
+      echo "fsa_node_position=${FSA_NODE_POSITION}"
+      echo "fsa_node_owner=${FSA_NODE_OWNER}"
+      echo "fsa_upstream_owner=${FSA_UPSTREAM_OWNER:-}"
+      echo "fsa_chain_depth=${FSA_CHAIN_DEPTH}"
+    } >> "$GITHUB_OUTPUT"
+  fi
+}
+
+# ── Capability predicates ─────────────────────────────────────────────────────
+# Each returns 0 (true) if the current node should perform that operation.
+# Call fsa_node_detect first.
+
+# Mirror repos to a downstream GitHub org (e.g. I-D-1896 → OSP).
+fsa_can_mirror_to_github() {
+  fsa_node_detect
+  case "${FSA_NODE_POSITION}" in
+    source)          return 0 ;;  # source always mirrors downstream
+    mirror)          return 0 ;;  # mirrors can re-mirror further (OSP → OOC)
+    downstream-fork) return 0 ;;  # forks manage their own chain
+  esac
+  return 1
+}
+
+# Push repos to GitLab.
+fsa_can_mirror_to_gitlab() {
+  fsa_node_detect
+  case "${FSA_NODE_POSITION}" in
+    source)          return 0 ;;
+    mirror)          return 0 ;;
+    downstream-fork) return 0 ;;
+  esac
+  return 1
+}
+
+# Write README files to managed repos.
+fsa_can_update_readmes() {
+  fsa_node_detect
+  # Only the source (or an independent fork) should write READMEs.
+  # A mirror that is managed by source should not duplicate this work.
+  case "${FSA_NODE_POSITION}" in
+    source)          return 0 ;;
+    downstream-fork) return 0 ;;
+    mirror)          return 1 ;;  # source handles this
+  esac
+  return 1
+}
+
+# Inject built-with-ona badges.
+fsa_can_inject_badges() {
+  fsa_node_detect
+  case "${FSA_NODE_POSITION}" in
+    source)          return 0 ;;
+    downstream-fork) return 0 ;;
+    mirror)          return 1 ;;
+  esac
+  return 1
+}
+
+# Sync upstream forks (pull from upstream into managed repos).
+fsa_can_sync_forks() {
+  fsa_node_detect
+  case "${FSA_NODE_POSITION}" in
+    source)          return 0 ;;
+    downstream-fork) return 0 ;;
+    mirror)          return 1 ;;
+  esac
+  return 1
+}
+
+# Run translation workflows.
+fsa_can_translate() {
+  fsa_node_detect
+  case "${FSA_NODE_POSITION}" in
+    source)          return 0 ;;
+    downstream-fork) return 0 ;;
+    mirror)          return 1 ;;
+  esac
+  return 1
+}
+
+# Push template files to consumer repos.
+fsa_can_manage_templates() {
+  fsa_node_detect
+  case "${FSA_NODE_POSITION}" in
+    source)          return 0 ;;
+    downstream-fork) return 0 ;;
+    mirror)          return 1 ;;
+  esac
+  return 1
+}
+
+# fsa_node_summary: print a human-readable summary of the detected identity.
+fsa_node_summary() {
+  fsa_node_detect
+  echo "[fsa-node] position=${FSA_NODE_POSITION} owner=${FSA_NODE_OWNER} upstream=${FSA_UPSTREAM_OWNER:-none} depth=${FSA_CHAIN_DEPTH}" >&2
+  echo "[fsa-node] capabilities:" >&2
+  local caps=()
+  fsa_can_mirror_to_github  && caps+=("mirror-to-github")
+  fsa_can_mirror_to_gitlab  && caps+=("mirror-to-gitlab")
+  fsa_can_update_readmes    && caps+=("update-readmes")
+  fsa_can_inject_badges     && caps+=("inject-badges")
+  fsa_can_sync_forks        && caps+=("sync-forks")
+  fsa_can_translate         && caps+=("translate")
+  fsa_can_manage_templates  && caps+=("manage-templates")
+  echo "[fsa-node]   ${caps[*]:-none}" >&2
+}


### PR DESCRIPTION
## What changed

Adds a position-aware node identity layer and a plug-and-play mirror-chain dispatch workflow. Any fork of fork-sync-all can drop these in and the workflow will auto-detect its position in the chain (`source` / `mirror` / `downstream-fork`), then run only the operations appropriate for that position — no hardcoded org names, no duplicate work across chain nodes.

### `scripts/includes/fsa-node-identity.sh`

Extends `fsa-mode.sh` (managed/autonomous binary) with a three-position layer:

| Position | Detected when | Write ops |
|---|---|---|
| `source` | `GITHUB_REPOSITORY == Interested-Deving-1896/fork-sync-all` | All |
| `mirror` | `FSA_MANAGED=true` + non-canonical owner, or `FSA_UPSTREAM_OWNER` set | Mirror-to-github, mirror-to-gitlab only |
| `downstream-fork` | No upstream FSA detected | All (scoped to own org) |

Detection order: explicit `FSA_CHAIN_POSITION` env → canonical slug match → `FSA_UPSTREAM_OWNER` set → `fsa_is_managed()` → default downstream-fork.

Exports `FSA_NODE_POSITION`, `FSA_NODE_OWNER`, `FSA_UPSTREAM_OWNER`, `FSA_CHAIN_DEPTH` to `GITHUB_OUTPUT`. Capability predicates (`fsa_can_mirror_to_github`, `fsa_can_update_readmes`, etc.) let callers guard operations without knowing the position.

Mirror nodes skip source-only ops (readmes, badges, fork-sync, templates, translate) to prevent duplicate work across the chain.

### `.github/workflows/mirror-chain-dispatch.yml`

Five-job workflow:

```
detect → mirror-github → mirror-gitlab → source-ops → translate
```

- `mirror-github` / `mirror-gitlab` run for all positions
- `source-ops` / `translate` skip mirror nodes
- `dest_backends` input accepts `github:ORG,gitlab:GROUP` — falls back to position-appropriate defaults when blank
- `operations` input selects a subset; blank runs all position-defaults
- Scheduled every 6h at :47, staggered from `mirror-to-osp` (:13)

## Type

- [x] New feature / workflow

## Checklist

- [x] Validator scripts pass (`python3 scripts/validate-workflow-guards.py` — 102 workflows, all checks passed)
- [x] Config files validated
- [x] No secrets or tokens committed