### PR TITLE
feat: agnostic git platform sync backend + platform adapter

### DIFF
--- a/.github/workflows/git-platform-sync.yml
+++ b/.github/workflows/git-platform-sync.yml
@@ -1,0 +1,192 @@
+name: Git Platform Sync
+
+# Agnostic git platform sync. Replaces sync-to-gitlab.yml and
+# sync-from-gitlab.yml with a single configurable workflow that works
+# against any combination of GitHub, GitLab, Gitea, Forgejo, or Codeberg.
+#
+# ── Default behaviour (no dispatch inputs) ───────────────────────────────────
+#   push: Interested-Deving-1896 (GitHub) → openos-project (GitLab)
+#   This matches the behaviour of the deprecated sync-to-gitlab.yml.
+#
+# ── To replace sync-from-gitlab.yml ──────────────────────────────────────────
+#   Dispatch with direction=pull (or direction=both for bidirectional).
+#
+# ── To sync to a different platform ──────────────────────────────────────────
+#   Set dest_platform=gitea, dest_org=myorg, dest_host=https://gitea.myco.com
+#   and add DEST_TOKEN to repo secrets.
+#
+# ── Deprecation notice ───────────────────────────────────────────────────────
+#   sync-to-gitlab.yml   — superseded by this workflow (direction=push)
+#   sync-from-gitlab.yml — superseded by this workflow (direction=pull)
+#   Both are kept as no-op stubs for backwards compatibility with any
+#   workflow_run triggers that reference them by name.
+
+on:
+  schedule:
+    # Push leg: daily at 09:23 UTC (replaces sync-to-gitlab.yml at 09:17)
+    - cron: '23 9 * * *'
+  workflow_run:
+    workflows:
+      - "Add Mirror Repo"
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      direction:
+        description: "Sync direction"
+        required: false
+        default: "push"
+        type: choice
+        options:
+          - push
+          - pull
+          - both
+      source_platform:
+        description: "Source platform (blank = github)"
+        required: false
+        default: ""
+        type: choice
+        options:
+          - ""
+          - github
+          - gitlab
+          - gitea
+          - forgejo
+          - codeberg
+      source_org:
+        description: "Source org/group (blank = Interested-Deving-1896)"
+        required: false
+        default: ""
+        type: string
+      source_host:
+        description: "Source base URL override (blank = platform default)"
+        required: false
+        default: ""
+        type: string
+      dest_platform:
+        description: "Destination platform (blank = gitlab)"
+        required: false
+        default: ""
+        type: choice
+        options:
+          - ""
+          - github
+          - gitlab
+          - gitea
+          - forgejo
+          - codeberg
+      dest_org:
+        description: "Destination org/group (blank = openos-project)"
+        required: false
+        default: ""
+        type: string
+      dest_host:
+        description: "Destination base URL override (blank = platform default)"
+        required: false
+        default: ""
+        type: string
+      repo_filter:
+        description: "Sync only repos whose name contains this substring"
+        required: false
+        default: ""
+        type: string
+      subgroup_filter:
+        description: "GitLab only: limit to this subgroup under the org"
+        required: false
+        default: ""
+        type: choice
+        options:
+          - ""
+          - neon-deving
+          - core
+          - desktop
+          - tools
+          - infra
+          - mirrors
+          - ops
+      dry_run:
+        description: "Report without pushing"
+        required: false
+        default: false
+        type: boolean
+      force:
+        description: "Force-push even if destination has diverged"
+        required: false
+        default: false
+        type: boolean
+      rate_limit_rerun:
+        description: "Set by rate-limit-rerun workflow — prevents re-trigger loops"
+        required: false
+        default: "false"
+        type: string
+
+concurrency:
+  group: git-platform-sync-${{ inputs.direction || 'push' }}
+  cancel-in-progress: false   # Never cancel mid-sync
+
+permissions:
+  contents: read
+
+# ── Rate limits ───────────────────────────────────────────────────────────────
+# GitHub REST API (SOURCE_TOKEN/DEST_TOKEN): 5 000 req/hr.
+# GitLab REST API: 2 000 req/min per token.
+# Gitea/Forgejo: varies by instance (typically 5 000 req/hr).
+# git push: retried up to 3× with linear backoff (15s, 30s, 45s).
+# No REST calls are made per-repo during the sync itself — only git operations.
+
+jobs:
+  sync:
+    name: Sync ${{ inputs.source_platform || 'github' }} → ${{ inputs.dest_platform || 'gitlab' }}
+    if: inputs.rate_limit_rerun != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 65
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Quota pre-flight (GitHub source/dest only)
+        id: quota
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+          MIN_QUOTA: "500"
+        run: |
+          remaining=$(curl -sf \
+            -H "Authorization: token ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/rate_limit \
+            | python3 -c "import sys,json; print(json.load(sys.stdin)['resources']['core']['remaining'])")
+          echo "remaining=${remaining}" >> "$GITHUB_OUTPUT"
+          if [[ "${remaining}" -lt "${MIN_QUOTA}" ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Quota too low (${remaining} < ${MIN_QUOTA}) — skipping."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Sync repos between platforms
+        if: steps.quota.outputs.skip == 'false'
+        env:
+          # Source
+          SOURCE_PLATFORM: ${{ inputs.source_platform || 'github' }}
+          SOURCE_ORG:      ${{ inputs.source_org || 'Interested-Deving-1896' }}
+          SOURCE_HOST:     ${{ inputs.source_host || '' }}
+          SOURCE_TOKEN:    ${{ secrets.SYNC_TOKEN }}
+          # Destination
+          DEST_PLATFORM:   ${{ inputs.dest_platform || 'gitlab' }}
+          DEST_ORG:        ${{ inputs.dest_org || 'openos-project' }}
+          DEST_HOST:       ${{ inputs.dest_host || '' }}
+          DEST_TOKEN:      ${{ secrets.GITLAB_SYNC_TOKEN }}
+          # Operation
+          DIRECTION:       ${{ inputs.direction || 'push' }}
+          REPO_FILTER:     ${{ inputs.repo_filter || '' }}
+          SUBGROUP_FILTER: ${{ inputs.subgroup_filter || '' }}
+          DRY_RUN:         ${{ inputs.dry_run || 'false' }}
+          FORCE:           ${{ inputs.force || 'false' }}
+          BUDGET_MINUTES:  "60"
+        run: bash scripts/git-platform-sync.sh
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS:  ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/sync-from-gitlab.yml
+++ b/.github/workflows/sync-from-gitlab.yml
@@ -1,5 +1,10 @@
 name: Sync from GitLab
 
+# DEPRECATED — superseded by git-platform-sync.yml (direction=pull).
+# Kept as a no-op stub so that any workflow_run triggers referencing
+# "Sync from GitLab" by name continue to resolve without error.
+# Remove this file once all downstream references have been updated.
+
 on:
   schedule:
     # Daily at 04:22 UTC — scheduled fallback; the primary trigger is
@@ -46,23 +51,12 @@ concurrency:
 #   gh_api_check() retries HTTP 403/429 with X-RateLimit-Reset sleep.
 
 jobs:
-  sync:
+  deprecated-stub:
+    name: "Deprecated — use git-platform-sync.yml"
     if: inputs.rate_limit_rerun != 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
-
-      - name: Sync repos from GitLab openos-project
-        env:
-          GITLAB_TOKEN: ${{ secrets.GITLAB_SYNC_TOKEN }}
-          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
-          GITHUB_OWNER: Interested-Deving-1896
-          BUDGET_MINUTES: "55"
-        run: bash scripts/sync-from-gitlab.sh
-      - name: Write summary
-        if: always()
-        env:
-          JOB_STATUS: ${{ job.status }}
-          INPUTS_JSON: ${{ toJSON(inputs) }}
-        run: bash scripts/write-summary.sh
+      - name: Redirect notice
+        run: |
+          echo "This workflow is deprecated. Use 'Git Platform Sync' (git-platform-sync.yml) with direction=pull instead." >&2
+          echo "Dispatching git-platform-sync.yml is equivalent to running this workflow." >&2

--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -1,9 +1,13 @@
 name: Sync to GitLab
 
+# DEPRECATED — superseded by git-platform-sync.yml (direction=push).
+# Kept as a no-op stub so that any workflow_run triggers referencing
+# "Sync to GitLab" by name continue to resolve without error.
+# Remove this file once all downstream references have been updated.
+
 on:
   schedule:
-    # Runs daily at 09:17 UTC — moved out of 03:xx cluster.
-    # Still after sync-forks (06:00) and sync-upstream-sources (01:30).
+    # Kept to avoid phantom trigger errors; git-platform-sync.yml runs at 09:23.
     - cron: '17 9 * * *'
   workflow_dispatch:
     inputs:
@@ -40,23 +44,12 @@ concurrency:
 #   transient rejections without failing the workflow.
 
 jobs:
-  sync:
+  deprecated-stub:
+    name: "Deprecated — use git-platform-sync.yml"
     if: inputs.rate_limit_rerun != 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
-
-      - name: Sync repos to GitLab
-        env:
-          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
-          GITLAB_TOKEN: ${{ secrets.GITLAB_SYNC_TOKEN }}
-          GITHUB_OWNER: Interested-Deving-1896
-          BUDGET_MINUTES: "55"
-        run: bash scripts/sync-to-gitlab.sh
-      - name: Write summary
-        if: always()
-        env:
-          JOB_STATUS: ${{ job.status }}
-          INPUTS_JSON: ${{ toJSON(inputs) }}
-        run: bash scripts/write-summary.sh
+      - name: Redirect notice
+        run: |
+          echo "This workflow is deprecated. Use 'Git Platform Sync' (git-platform-sync.yml) with direction=push instead." >&2
+          echo "Dispatching git-platform-sync.yml is equivalent to running this workflow." >&2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,12 @@ Changes there have broad impact.
   is in place (`_GH_API_LOADED`). `gh_get URL` is a convenience GET wrapper around
   `gh_api` with full retry and reset-aware backoff — the canonical implementation
   that individual scripts should migrate to (see consolidation note below).
+- `platform-adapter.sh` — uniform interface for GitHub, GitLab, Gitea, Forgejo,
+  and Codeberg. See [Platform adapter](#platform-adapter-platform-adaptersh) below.
+- `fsa-node-identity.sh` — extends `fsa-mode.sh` with a chain position layer.
+  See [Node identity](#node-identity-fsa-node-identitysh) below.
+- `auto-merge-prs.sh` — standalone script (not an include); see
+  [Auto-merge PRs](#auto-merge-prs) below.
 
 ### `gh_get` / `gh_api` consolidation (complete)
 
@@ -413,6 +419,61 @@ For workflows **without a checkout** (e.g. `notify-poller.yml`), inline the
 three-tier check directly in the step's `run:` block rather than sourcing
 `fsa-mode.sh`. See `notify-poller.yml` for the canonical inline implementation.
 The inline version replicates checks B → A → C using `curl` and `python3`.
+
+### Node identity (`fsa-node-identity.sh`)
+
+`scripts/includes/fsa-node-identity.sh` extends `fsa-mode.sh` (managed/autonomous
+binary) with a **position layer** — each instance knows *where* it sits in the
+mirror chain and adjusts which operations it runs accordingly.
+
+**Three positions:**
+
+| Position | Detected when | Write operations |
+|---|---|---|
+| `source` | `GITHUB_REPOSITORY == Interested-Deving-1896/fork-sync-all` | All |
+| `mirror` | `FSA_MANAGED=true` + non-canonical owner, or `FSA_UPSTREAM_OWNER` set | Mirror-to-github, mirror-to-gitlab only |
+| `downstream-fork` | No upstream FSA detected | All (scoped to own org) |
+
+Mirror nodes skip source-only operations (readmes, badges, fork-sync, templates,
+translate) to prevent duplicate work across the chain.
+
+**Detection order** (first match wins):
+1. Explicit `FSA_CHAIN_POSITION` env var override
+2. `GITHUB_REPOSITORY` matches canonical slug (`Interested-Deving-1896/fork-sync-all`)
+3. `FSA_UPSTREAM_OWNER` env var set → mirror
+4. `fsa_is_managed()` returns true + non-canonical owner → mirror
+5. Default → `downstream-fork`
+
+**Exported variables** (also written to `GITHUB_OUTPUT`):
+- `FSA_NODE_POSITION` — `source` | `mirror` | `downstream-fork`
+- `FSA_NODE_OWNER` — the org this instance manages
+- `FSA_UPSTREAM_OWNER` — the org being mirrored from (empty for source/fork)
+- `FSA_CHAIN_DEPTH` — 0=source, 1=first mirror, 2=downstream-fork
+
+**Capability predicates** — return 0 (true) or 1 (false):
+```bash
+fsa_can_mirror_to_github   # push repos to a downstream GitHub org
+fsa_can_mirror_to_gitlab   # push repos to a GitLab group
+fsa_can_update_readmes     # write README files (source + fork only)
+fsa_can_inject_badges      # inject badges (source + fork only)
+fsa_can_sync_forks         # sync upstream forks (source + fork only)
+fsa_can_translate          # run translation (source + fork only)
+fsa_can_manage_templates   # push templates to consumers (source + fork only)
+```
+
+**Usage:**
+```bash
+source scripts/includes/fsa-node-identity.sh
+fsa_node_detect
+fsa_node_summary   # prints position + active capabilities to stderr
+
+fsa_can_update_readmes && bash scripts/update-readmes.sh
+```
+
+**Override env vars** (set in workflow `env:` block):
+- `FSA_CHAIN_POSITION` — force a specific position (skips all detection)
+- `FSA_UPSTREAM_OWNER` — declare the upstream org (triggers mirror detection)
+- `FSA_CANONICAL_OWNER` — override the canonical source org (default: `Interested-Deving-1896`)
 
 ### Scope narrowing in autonomous mode
 
@@ -1042,3 +1103,107 @@ a successful merge, entering it into the standard OSP mirror chain automatically
   No delay when quota > 2000; scales to 30s when < 500. The cached
   `_quota_remaining` variable is decremented by 10 per repo to trigger
   re-checks before actually hitting the threshold.
+
+---
+
+## Platform adapter (`platform-adapter.sh`)
+
+`scripts/includes/platform-adapter.sh` provides a uniform interface for
+interacting with any supported git hosting platform so that sync scripts can
+be written once and work against any backend.
+
+**Supported platforms:** `github` | `gitlab` | `gitea` | `forgejo` | `codeberg`
+
+**Initialisation** — must be called before any other `pa_*` function:
+```bash
+PLATFORM=gitlab PLATFORM_TOKEN="$GITLAB_TOKEN" pa_init gitlab
+# With self-hosted host override:
+PLATFORM=gitea PLATFORM_TOKEN="$TEA_TOKEN" pa_init gitea https://gitea.myco.com
+```
+
+Sets `PA_HOST`, `PA_API`, `PA_AUTH_HEADER`, `PA_CLONE_PREFIX` as internal state.
+Guard against double-sourcing is in place (`_PLATFORM_ADAPTER_LOADED`).
+
+**Public functions:**
+
+| Function | Purpose |
+|---|---|
+| `pa_init PLATFORM [HOST]` | Initialise adapter for the given platform |
+| `pa_list_repos ORG` | Print one repo name per line; handles pagination |
+| `pa_repo_exists ORG REPO` | Returns 0 if repo exists, 1 otherwise |
+| `pa_clone_url ORG REPO` | Authenticated HTTPS clone URL |
+| `pa_push_url ORG REPO` | Authenticated HTTPS push URL (same as clone for most platforms) |
+| `pa_create_repo ORG REPO [DESC]` | Create repo if absent; no-op if already exists |
+| `pa_api_get URL` | Authenticated GET with rate-limit retry |
+| `pa_rate_limit_remaining` | Remaining API quota (best-effort) |
+
+**Rate-limit retry** — `pa_api_get` retries HTTP 429/403 up to 3 times with
+reset-aware backoff. Reads `X-RateLimit-Reset` (GitHub/Gitea/Forgejo) or
+`RateLimit-Reset` (GitLab) from response headers; falls back to 60s if absent.
+
+**Auth header format per platform:**
+- GitHub: `Authorization: token TOKEN`
+- GitLab: `PRIVATE-TOKEN: TOKEN`
+- Gitea/Forgejo/Codeberg: `Authorization: token TOKEN`
+
+**Clone URL prefix per platform:**
+- GitHub: `https://x-access-token:TOKEN@github.com`
+- GitLab: `https://oauth2:TOKEN@gitlab.com`
+- Gitea/Forgejo/Codeberg: `https://x-access-token:TOKEN@HOST`
+
+**`git-platform-sync.sh`** is the primary consumer. It uses `pa_init` twice per
+sync leg (once for source, once for dest) and calls `pa_list_repos`, `pa_repo_exists`,
+`pa_clone_url`, `pa_push_url`, and `pa_create_repo`. The `git-platform-sync.yml`
+workflow replaces the deprecated `sync-to-gitlab.yml` (direction=push) and
+`sync-from-gitlab.yml` (direction=pull) — both are now no-op stubs kept only for
+`workflow_run` name resolution.
+
+---
+
+## Auto-merge PRs
+
+`scripts/auto-merge-prs.sh` merges open PRs once their required checks pass.
+Three hybrid detections run per PR at runtime — no static configuration needed.
+
+### Scope detection (which PRs to merge)
+
+Priority order — first match wins:
+1. Label `auto-merge` present → merge (explicit opt-in)
+2. PR author login ends in `[bot]`, or matches the SYNC_TOKEN owner → merge (automation output)
+3. `AUTO_MERGE_ALL=true` env var → merge all open PRs
+4. Default → skip (human PRs require explicit opt-in)
+
+Bot detection uses the token owner resolved via `GET /user` at startup (1 API call,
+cached for the run). Any login matching `*[bot]` is also treated as a bot regardless
+of token ownership.
+
+### Strategy detection (how to merge)
+
+Per-PR, based on commit history (`GET /repos/{repo}/pulls/{n}/commits`):
+- Single commit → `rebase` (linear history, no merge commit)
+- Multiple commits, single author → `squash` (clean history)
+- Multiple commits, multiple authors → `merge` (preserves attribution)
+
+Override with `MERGE_STRATEGY=squash|rebase|merge`.
+
+### Mechanism detection (when to fire)
+
+Detected once per run via `GET /repos/{repo}/branches/{base}/protection`:
+- Required status checks configured → **native auto-merge** (`gh pr merge --auto`).
+  GitHub queues the merge and fires it exactly when checks pass. Zero polling,
+  no runner time consumed waiting.
+- No branch protection / no required checks → **poll** `mergeable_state` until
+  `clean`, then merge directly. Polls every `POLL_INTERVAL_SEC` (default 30s)
+  up to `POLL_TIMEOUT_MIN` (default 30min).
+
+Override with `MERGE_MECHANISM=native|poll`.
+
+### Workflow trigger
+
+`auto-merge-prs.yml` fires on:
+- `workflow_run` completion of `Validate Config` with `conclusion == success`
+  (primary — fires immediately after CI passes on any PR)
+- Schedule every 2h at :55 (fallback for PRs already green before the workflow existed)
+- `workflow_dispatch` with optional `pr_filter` (comma-separated PR numbers)
+
+Registered: tier 3 MEDIUM, `min_quota: 300`.

--- a/config/workflow-quota-costs.yml
+++ b/config/workflow-quota-costs.yml
@@ -263,9 +263,9 @@ workflows:
   synopsis: "Merges open PRs once required checks pass. Hybrid auto-detection per PR: scope (label/bot/all), strategy (rebase/squash/merge), mechanism (native auto-merge vs poll)."
 - name: Sync to GitLab
   min_quota: 100
-  cost_low: 5
-  cost_mid: 20
-  cost_high: 50
+  cost_low: 0
+  cost_mid: 0
+  cost_high: 0
   basis: code-audit
   notes: Deprecated stub — no-op. Kept for workflow_run name resolution.
   synopsis: "DEPRECATED. Superseded by Git Platform Sync (direction=push). Stub kept for backwards compatibility."
@@ -280,9 +280,9 @@ workflows:
     or for testing.
 - name: Sync from GitLab
   min_quota: 100
-  cost_low: 5
-  cost_mid: 20
-  cost_high: 50
+  cost_low: 0
+  cost_mid: 0
+  cost_high: 0
   basis: code-audit
   notes: Deprecated stub — no-op. Kept for workflow_run name resolution.
   synopsis: "DEPRECATED. Superseded by Git Platform Sync (direction=pull). Stub kept for backwards compatibility."

--- a/scripts/git-platform-sync.sh
+++ b/scripts/git-platform-sync.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+#
+# scripts/git-platform-sync.sh — agnostic git platform sync
+#
+# Syncs repos between any two git hosting platforms (GitHub, GitLab, Gitea,
+# Forgejo, Codeberg). Replaces the platform-specific sync-to-gitlab.sh and
+# sync-from-gitlab.sh with a single configurable backend.
+#
+# ── How it works ──────────────────────────────────────────────────────────────
+#
+#   push  — bare-clone each repo from SOURCE_PLATFORM/SOURCE_ORG, push all
+#           branches and tags to DEST_PLATFORM/DEST_ORG. Creates the dest
+#           repo if it doesn't exist. Preserves dest-only branches (no prune).
+#
+#   pull  — bare-clone each repo from DEST_PLATFORM/DEST_ORG, push all
+#           branches and tags back to SOURCE_PLATFORM/SOURCE_ORG. Only syncs
+#           repos that already exist on the source (no new repos created).
+#
+#   both  — push leg first, then pull leg.
+#
+# ── Required env vars ─────────────────────────────────────────────────────────
+#
+#   SOURCE_PLATFORM   — github | gitlab | gitea | forgejo | codeberg
+#   SOURCE_ORG        — org/group/namespace on the source platform
+#   SOURCE_TOKEN      — auth token for the source platform
+#   DEST_PLATFORM     — github | gitlab | gitea | forgejo | codeberg
+#   DEST_ORG          — org/group/namespace on the destination platform
+#   DEST_TOKEN        — auth token for the destination platform
+#
+# ── Optional env vars ─────────────────────────────────────────────────────────
+#
+#   DIRECTION         — push | pull | both (default: push)
+#   REPO_FILTER       — only sync repos whose name contains this substring
+#   DRY_RUN           — "true" = report without pushing (default: false)
+#   FORCE             — "true" = force-push even if dest has diverged (default: false)
+#   CREATE_MISSING    — "true" = create dest repo if absent (default: true for push,
+#                       false for pull — pull never creates source repos)
+#   SOURCE_HOST       — base URL override for source (e.g. https://gitlab.myco.com)
+#   DEST_HOST         — base URL override for dest
+#   BUDGET_MINUTES    — max runtime in minutes (default: 55)
+#   SUBGROUP_FILTER   — GitLab only: limit to this subgroup path under DEST_ORG/SOURCE_ORG
+#   EXCLUDED_REPOS    — space-separated repo names to never sync
+
+set -uo pipefail
+
+: "${SOURCE_PLATFORM:?SOURCE_PLATFORM is required}"
+: "${SOURCE_ORG:?SOURCE_ORG is required}"
+: "${SOURCE_TOKEN:?SOURCE_TOKEN is required}"
+: "${DEST_PLATFORM:?DEST_PLATFORM is required}"
+: "${DEST_ORG:?DEST_ORG is required}"
+: "${DEST_TOKEN:?DEST_TOKEN is required}"
+
+DIRECTION="${DIRECTION:-push}"
+REPO_FILTER="${REPO_FILTER:-}"
+DRY_RUN="${DRY_RUN:-false}"
+FORCE="${FORCE:-false}"
+BUDGET_MINUTES="${BUDGET_MINUTES:-55}"
+SUBGROUP_FILTER="${SUBGROUP_FILTER:-}"
+EXCLUDED_REPOS="${EXCLUDED_REPOS:-}"
+
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/includes/platform-adapter.sh
+source "${_SCRIPT_DIR}/includes/platform-adapter.sh"
+# shellcheck source=scripts/includes/budget.sh
+source "${_SCRIPT_DIR}/includes/budget.sh"
+budget_init
+
+info() { echo "[git-platform-sync] $*" >&2; }
+warn() { echo "[git-platform-sync][warn] $*" >&2; }
+dry()  { echo "[git-platform-sync][dry-run] $*" >&2; }
+
+[[ "$DRY_RUN" == "true" ]] && info "Dry run — no pushes will occur."
+[[ "$FORCE"   == "true" ]] && info "Force mode — all repos will be re-pushed."
+[[ -n "$REPO_FILTER"    ]] && info "Repo filter: '${REPO_FILTER}'"
+info "Direction: ${DIRECTION} | ${SOURCE_PLATFORM}/${SOURCE_ORG} ↔ ${DEST_PLATFORM}/${DEST_ORG}"
+
+# ── git push with retry ───────────────────────────────────────────────────────
+_git_push_retry() {
+  local remote="$1"; shift
+  local refspecs=("$@")
+  local max_retries=3 attempt=0
+  while true; do
+    if git push "$remote" "${refspecs[@]}" 2>&1 \
+        | sed "s/${SOURCE_TOKEN}/***TOKEN***/g" \
+        | sed "s/${DEST_TOKEN}/***TOKEN***/g"; then
+      return 0
+    fi
+    (( attempt++ )) || true
+    (( attempt > max_retries )) && { warn "Push failed after ${max_retries} attempts"; return 1; }
+    local wait=$(( attempt * 15 ))
+    warn "Push attempt ${attempt}/${max_retries} failed — retrying in ${wait}s"
+    sleep "$wait"
+  done
+}
+
+# ── _sync_repo FROM_PLATFORM FROM_ORG TO_PLATFORM TO_ORG REPO ────────────────
+# Bare-clones REPO from FROM and pushes all branches+tags to TO.
+# Creates the dest repo if CREATE_MISSING=true and it doesn't exist.
+_sync_repo() {
+  local from_platform="$1" from_org="$2" to_platform="$3" to_org="$4" repo="$5"
+  local create_missing="${6:-true}"
+
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  trap 'rm -rf "$tmpdir"' RETURN
+
+  # Initialise adapters for this direction
+  PLATFORM="$from_platform" PLATFORM_TOKEN="$SOURCE_TOKEN" \
+    PLATFORM_HOST="${SOURCE_HOST:-}" pa_init "$from_platform" "${SOURCE_HOST:-}" 2>/dev/null
+  local from_url
+  from_url=$(pa_clone_url "$from_org" "$repo")
+
+  PLATFORM="$to_platform" PLATFORM_TOKEN="$DEST_TOKEN" \
+    PLATFORM_HOST="${DEST_HOST:-}" pa_init "$to_platform" "${DEST_HOST:-}" 2>/dev/null
+  local to_url
+  to_url=$(pa_push_url "$to_org" "$repo")
+
+  # Create dest repo if needed
+  if [[ "$create_missing" == "true" ]]; then
+    pa_create_repo "$to_org" "$repo" "Mirror of ${from_platform}/${from_org}/${repo}" 2>/dev/null || true
+  fi
+
+  info "  Cloning ${from_platform}/${from_org}/${repo} ..."
+  if ! git clone --bare --quiet "$from_url" "$tmpdir/repo.git" 2>/dev/null; then
+    warn "  Clone failed for ${from_org}/${repo} — skipping"
+    return 1
+  fi
+
+  pushd "$tmpdir/repo.git" > /dev/null
+
+  # Collect all branches and tags
+  local branches tags
+  mapfile -t branches < <(git branch -r 2>/dev/null | sed 's|origin/||' | grep -v HEAD || true)
+  mapfile -t tags     < <(git tag 2>/dev/null || true)
+
+  if [[ ${#branches[@]} -eq 0 && ${#tags[@]} -eq 0 ]]; then
+    info "  No refs to push for ${repo} — skipping"
+    popd > /dev/null
+    return 0
+  fi
+
+  git remote add dest "$to_url" 2>/dev/null || git remote set-url dest "$to_url"
+
+  # Build refspecs — force-push branches, regular push tags
+  local refspecs=()
+  for branch in "${branches[@]}"; do
+    branch="${branch// /}"
+    [[ -z "$branch" ]] && continue
+    if [[ "$FORCE" == "true" ]]; then
+      refspecs+=("+refs/heads/${branch}:refs/heads/${branch}")
+    else
+      refspecs+=("refs/heads/${branch}:refs/heads/${branch}")
+    fi
+  done
+  for tag in "${tags[@]}"; do
+    tag="${tag// /}"
+    [[ -z "$tag" ]] && continue
+    refspecs+=("refs/tags/${tag}:refs/tags/${tag}")
+  done
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    dry "would push ${#branches[@]} branch(es) + ${#tags[@]} tag(s) to ${to_platform}/${to_org}/${repo}"
+    popd > /dev/null
+    return 0
+  fi
+
+  info "  Pushing ${#branches[@]} branch(es) + ${#tags[@]} tag(s) → ${to_platform}/${to_org}/${repo}"
+  _git_push_retry dest "${refspecs[@]}"
+  local rc=$?
+  popd > /dev/null
+  return $rc
+}
+
+# ── _is_excluded REPO ─────────────────────────────────────────────────────────
+_is_excluded() {
+  local repo="$1"
+  for ex in $EXCLUDED_REPOS; do
+    [[ "$repo" == "$ex" ]] && return 0
+  done
+  return 1
+}
+
+# ── _run_leg FROM_PLATFORM FROM_ORG TO_PLATFORM TO_ORG CREATE_MISSING ────────
+_run_leg() {
+  local from_platform="$1" from_org="$2" to_platform="$3" to_org="$4" create_missing="$5"
+  local synced=0 failed=0 skipped=0
+
+  info "Leg: ${from_platform}/${from_org} → ${to_platform}/${to_org}"
+
+  # Initialise source adapter to list repos
+  PLATFORM="$from_platform" PLATFORM_TOKEN="$SOURCE_TOKEN" \
+    PLATFORM_HOST="${SOURCE_HOST:-}" pa_init "$from_platform" "${SOURCE_HOST:-}"
+
+  # Apply subgroup filter for GitLab sources
+  local list_org="$from_org"
+  if [[ -n "$SUBGROUP_FILTER" && "$from_platform" == "gitlab" ]]; then
+    list_org="${from_org}/${SUBGROUP_FILTER}"
+    info "Subgroup filter: ${list_org}"
+  fi
+
+  local repos
+  mapfile -t repos < <(pa_list_repos "$list_org" 2>/dev/null)
+  info "Found ${#repos[@]} repos in ${from_platform}/${list_org}"
+
+  for repo in "${repos[@]}"; do
+    [[ -z "$repo" ]] && continue
+    budget_check 5 || { warn "Budget exhausted — stopping early"; break; }
+
+    # Apply name filter
+    if [[ -n "$REPO_FILTER" && "$repo" != *"$REPO_FILTER"* ]]; then
+      continue
+    fi
+
+    # Skip excluded repos
+    if _is_excluded "$repo"; then
+      info "  ${repo}: excluded — skipping"
+      (( skipped++ )) || true
+      continue
+    fi
+
+    # For pull leg: only sync repos that already exist on source (no new repos)
+    if [[ "$create_missing" == "false" ]]; then
+      PLATFORM="$to_platform" PLATFORM_TOKEN="$DEST_TOKEN" \
+        PLATFORM_HOST="${DEST_HOST:-}" pa_init "$to_platform" "${DEST_HOST:-}"
+      if ! pa_repo_exists "$to_org" "$repo" 2>/dev/null; then
+        info "  ${repo}: not on ${to_platform}/${to_org} — skipping (pull leg never creates)"
+        (( skipped++ )) || true
+        continue
+      fi
+    fi
+
+    info "${from_platform}/${from_org}/${repo}  →  ${to_platform}/${to_org}/${repo}"
+    if _sync_repo "$from_platform" "$from_org" "$to_platform" "$to_org" "$repo" "$create_missing"; then
+      (( synced++ )) || true
+    else
+      (( failed++ )) || true
+    fi
+  done
+
+  info "Leg done. synced=${synced} failed=${failed} skipped=${skipped}"
+  [[ "$failed" -gt 0 ]] && return 1
+  return 0
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+overall_rc=0
+
+case "$DIRECTION" in
+  push)
+    _run_leg "$SOURCE_PLATFORM" "$SOURCE_ORG" "$DEST_PLATFORM" "$DEST_ORG" "true" || overall_rc=1
+    ;;
+  pull)
+    _run_leg "$DEST_PLATFORM" "$DEST_ORG" "$SOURCE_PLATFORM" "$SOURCE_ORG" "false" || overall_rc=1
+    ;;
+  both)
+    _run_leg "$SOURCE_PLATFORM" "$SOURCE_ORG" "$DEST_PLATFORM" "$DEST_ORG" "true"  || overall_rc=1
+    _run_leg "$DEST_PLATFORM"   "$DEST_ORG"   "$SOURCE_PLATFORM" "$SOURCE_ORG" "false" || overall_rc=1
+    ;;
+  *)
+    warn "Unknown DIRECTION '${DIRECTION}'. Use: push | pull | both"
+    exit 1
+    ;;
+esac
+
+exit $overall_rc

--- a/scripts/includes/platform-adapter.sh
+++ b/scripts/includes/platform-adapter.sh
@@ -1,0 +1,333 @@
+#!/usr/bin/env bash
+#
+# scripts/includes/platform-adapter.sh — git hosting platform abstraction
+#
+# Provides a uniform interface for interacting with different git hosting
+# platforms (GitHub, GitLab, Gitea, Forgejo, Codeberg) so that sync scripts
+# can be written once and work against any backend.
+#
+# ── Supported platforms ───────────────────────────────────────────────────────
+#
+#   github    — github.com (or GitHub Enterprise via PLATFORM_HOST)
+#   gitlab    — gitlab.com (or self-hosted via PLATFORM_HOST)
+#   gitea     — any Gitea instance (PLATFORM_HOST required)
+#   forgejo   — any Forgejo instance (PLATFORM_HOST required)
+#   codeberg  — codeberg.org (Forgejo-based; PLATFORM_HOST defaults to codeberg.org)
+#
+# ── Configuration env vars ────────────────────────────────────────────────────
+#
+#   PLATFORM          — one of: github | gitlab | gitea | forgejo | codeberg
+#   PLATFORM_HOST     — base URL override (e.g. https://gitlab.mycompany.com)
+#                       Defaults to the platform's canonical public host.
+#   PLATFORM_TOKEN    — auth token for the platform
+#   PLATFORM_ORG      — org/group/namespace to operate on
+#
+# ── Functions ─────────────────────────────────────────────────────────────────
+#
+#   pa_init PLATFORM [HOST]
+#     Initialise the adapter. Must be called before any other pa_* function.
+#     Sets PA_HOST, PA_API, PA_AUTH_HEADER, PA_CLONE_PREFIX.
+#
+#   pa_list_repos ORG
+#     Print one repo name per line for the given org/group/namespace.
+#     Handles pagination automatically.
+#
+#   pa_repo_exists ORG REPO
+#     Returns 0 if the repo exists, 1 otherwise.
+#
+#   pa_clone_url ORG REPO
+#     Print the authenticated HTTPS clone URL for the repo.
+#
+#   pa_push_url ORG REPO
+#     Print the authenticated HTTPS push URL for the repo.
+#     Same as clone_url for most platforms; separated for clarity.
+#
+#   pa_create_repo ORG REPO [DESCRIPTION]
+#     Create the repo if it doesn't exist. No-op if it already exists.
+#     Returns 0 on success or if already exists.
+#
+#   pa_api_get URL
+#     Authenticated GET against the platform API. Handles rate-limit retry
+#     (HTTP 429/403) with reset-aware backoff up to 3 attempts.
+#     Prints response body on success; empty string on failure.
+#
+#   pa_rate_limit_remaining
+#     Print the number of remaining API calls for the current token.
+#     Returns 0 always (best-effort; not all platforms expose this).
+#
+# Guard against double-sourcing
+[[ -n "${_PLATFORM_ADAPTER_LOADED:-}" ]] && return 0
+_PLATFORM_ADAPTER_LOADED=1
+
+# ── Internal state ────────────────────────────────────────────────────────────
+PA_PLATFORM=""
+PA_HOST=""
+PA_API=""
+PA_AUTH_HEADER=""
+PA_CLONE_PREFIX=""   # https://TOKEN@host
+_PA_HEADER_TMP=""
+
+_pa_warn() { echo "[platform-adapter][warn] $*" >&2; }
+_pa_info() { echo "[platform-adapter] $*" >&2; }
+
+# ── pa_init ───────────────────────────────────────────────────────────────────
+pa_init() {
+  local platform="${1:-${PLATFORM:-}}"
+  local host_override="${2:-${PLATFORM_HOST:-}}"
+  local token="${PLATFORM_TOKEN:-${GH_TOKEN:-${GITLAB_TOKEN:-}}}"
+
+  [[ -z "$platform" ]] && { _pa_warn "PLATFORM is required"; return 1; }
+  [[ -z "$token"    ]] && { _pa_warn "PLATFORM_TOKEN (or GH_TOKEN/GITLAB_TOKEN) is required"; return 1; }
+
+  PA_PLATFORM="$platform"
+  _PA_HEADER_TMP=$(mktemp)
+  trap 'rm -f "$_PA_HEADER_TMP"' EXIT
+
+  case "$platform" in
+    github)
+      PA_HOST="${host_override:-https://github.com}"
+      PA_API="${host_override:+${host_override}/api/v3}"; PA_API="${PA_API:-https://api.github.com}"
+      PA_AUTH_HEADER="Authorization: token ${token}"
+      PA_CLONE_PREFIX="${PA_HOST/https:\/\//https://x-access-token:${token}@}"
+      ;;
+    gitlab)
+      PA_HOST="${host_override:-https://gitlab.com}"
+      PA_API="${PA_HOST}/api/v4"
+      PA_AUTH_HEADER="PRIVATE-TOKEN: ${token}"
+      PA_CLONE_PREFIX="${PA_HOST/https:\/\//https://oauth2:${token}@}"
+      ;;
+    gitea|forgejo)
+      [[ -z "$host_override" ]] && { _pa_warn "${platform}: PLATFORM_HOST is required (no canonical public host)"; return 1; }
+      PA_HOST="$host_override"
+      PA_API="${PA_HOST}/api/v1"
+      PA_AUTH_HEADER="Authorization: token ${token}"
+      PA_CLONE_PREFIX="${PA_HOST/https:\/\//https://x-access-token:${token}@}"
+      ;;
+    codeberg)
+      PA_HOST="${host_override:-https://codeberg.org}"
+      PA_API="${PA_HOST}/api/v1"
+      PA_AUTH_HEADER="Authorization: token ${token}"
+      PA_CLONE_PREFIX="${PA_HOST/https:\/\//https://x-access-token:${token}@}"
+      ;;
+    *)
+      _pa_warn "Unknown platform '${platform}'. Supported: github gitlab gitea forgejo codeberg"
+      return 1
+      ;;
+  esac
+
+  _pa_info "Initialised: platform=${PA_PLATFORM} host=${PA_HOST} api=${PA_API}"
+}
+
+# ── pa_api_get ────────────────────────────────────────────────────────────────
+pa_api_get() {
+  local url="$1"
+  local max_retries=3 attempt=0
+
+  while true; do
+    local out http_code body
+    out=$(curl -sf -w "\n%{http_code}" \
+      -D "$_PA_HEADER_TMP" \
+      -H "$PA_AUTH_HEADER" \
+      -H "Accept: application/json" \
+      "$url" 2>/dev/null) || true
+    http_code=$(echo "$out" | tail -1)
+    body=$(echo "$out" | sed '$d')
+
+    if [[ "$http_code" == "429" || "$http_code" == "403" ]]; then
+      (( attempt++ )) || true
+      if (( attempt > max_retries )); then
+        _pa_warn "API GET ${url} failed after ${max_retries} retries (HTTP ${http_code})"
+        echo ""
+        return 1
+      fi
+      # Try to read reset time from headers (GitHub: X-RateLimit-Reset, GitLab: RateLimit-Reset)
+      local reset now wait=60
+      reset=$(grep -i "x-ratelimit-reset:\|ratelimit-reset:" "$_PA_HEADER_TMP" 2>/dev/null \
+        | tr -d '\r' | awk '{print $2}' | head -1)
+      now=$(date +%s)
+      if [[ -n "$reset" && "$reset" =~ ^[0-9]+$ ]]; then
+        wait=$(( reset - now + 5 ))
+        (( wait < 5   )) && wait=5
+        (( wait > 3700 )) && wait=60
+      fi
+      _pa_warn "Rate limited (HTTP ${http_code}) — sleeping ${wait}s (attempt ${attempt}/${max_retries})"
+      sleep "$wait"
+      continue
+    fi
+
+    echo "$body"
+    [[ "$http_code" =~ ^2 ]] && return 0
+    return 1
+  done
+}
+
+# ── pa_list_repos ─────────────────────────────────────────────────────────────
+pa_list_repos() {
+  local org="$1"
+  local page=1
+
+  while true; do
+    local url repos_json names
+
+    case "$PA_PLATFORM" in
+      github)
+        # Try org endpoint first; fall back to user repos
+        url="${PA_API}/orgs/${org}/repos?per_page=100&page=${page}&type=all"
+        repos_json=$(pa_api_get "$url" 2>/dev/null)
+        if [[ -z "$repos_json" || "$repos_json" == "[]" ]]; then
+          url="${PA_API}/users/${org}/repos?per_page=100&page=${page}&type=all"
+          repos_json=$(pa_api_get "$url" 2>/dev/null || echo "[]")
+        fi
+        names=$(echo "$repos_json" | python3 -c \
+          "import sys,json; [print(r['name']) for r in json.load(sys.stdin)]" 2>/dev/null || true)
+        ;;
+      gitlab)
+        # org is a group path (e.g. openos-project or openos-project/core)
+        local encoded_org
+        encoded_org=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote('${org}',safe=''))")
+        url="${PA_API}/groups/${encoded_org}/projects?per_page=100&page=${page}&include_subgroups=false&archived=false"
+        repos_json=$(pa_api_get "$url" 2>/dev/null || echo "[]")
+        names=$(echo "$repos_json" | python3 -c \
+          "import sys,json; [print(r['path']) for r in json.load(sys.stdin)]" 2>/dev/null || true)
+        ;;
+      gitea|forgejo|codeberg)
+        url="${PA_API}/orgs/${org}/repos?limit=50&page=${page}"
+        repos_json=$(pa_api_get "$url" 2>/dev/null || echo "[]")
+        names=$(echo "$repos_json" | python3 -c \
+          "import sys,json; [print(r['name']) for r in json.load(sys.stdin)]" 2>/dev/null || true)
+        ;;
+    esac
+
+    [[ -z "$names" ]] && break
+    echo "$names"
+
+    local count
+    count=$(echo "$names" | wc -l)
+    # GitHub/GitLab page at 100; Gitea/Forgejo at 50
+    local page_size=100
+    [[ "$PA_PLATFORM" == "gitea" || "$PA_PLATFORM" == "forgejo" || "$PA_PLATFORM" == "codeberg" ]] && page_size=50
+    (( count < page_size )) && break
+    (( page++ ))
+  done
+}
+
+# ── pa_repo_exists ────────────────────────────────────────────────────────────
+pa_repo_exists() {
+  local org="$1" repo="$2"
+  local url result
+
+  case "$PA_PLATFORM" in
+    github)          url="${PA_API}/repos/${org}/${repo}" ;;
+    gitlab)
+      local encoded
+      encoded=$(python3 -c "import urllib.parse; print(urllib.parse.quote('${org}/${repo}',safe=''))")
+      url="${PA_API}/projects/${encoded}"
+      ;;
+    gitea|forgejo|codeberg) url="${PA_API}/repos/${org}/${repo}" ;;
+  esac
+
+  result=$(pa_api_get "$url" 2>/dev/null)
+  [[ -n "$result" && "$result" != "null" ]]
+}
+
+# ── pa_clone_url ──────────────────────────────────────────────────────────────
+pa_clone_url() {
+  local org="$1" repo="$2"
+  echo "${PA_CLONE_PREFIX}/${org}/${repo}.git"
+}
+
+# ── pa_push_url ───────────────────────────────────────────────────────────────
+pa_push_url() {
+  local org="$1" repo="$2"
+  pa_clone_url "$org" "$repo"
+}
+
+# ── pa_create_repo ────────────────────────────────────────────────────────────
+pa_create_repo() {
+  local org="$1" repo="$2" description="${3:-Mirrored repository}"
+  local token="${PLATFORM_TOKEN:-${GH_TOKEN:-${GITLAB_TOKEN:-}}}"
+
+  # No-op if already exists
+  if pa_repo_exists "$org" "$repo"; then
+    _pa_info "  ${org}/${repo} already exists — skipping create"
+    return 0
+  fi
+
+  _pa_info "  Creating ${org}/${repo} on ${PA_PLATFORM}"
+
+  local payload http_code
+  case "$PA_PLATFORM" in
+    github)
+      payload=$(python3 -c "import json; print(json.dumps({'name':'${repo}','description':'${description}','private':False,'auto_init':False}))")
+      http_code=$(curl -sf -o /dev/null -w "%{http_code}" \
+        -X POST \
+        -H "$PA_AUTH_HEADER" \
+        -H "Accept: application/vnd.github+json" \
+        -H "Content-Type: application/json" \
+        -d "$payload" \
+        "${PA_API}/orgs/${org}/repos" 2>/dev/null || echo "0")
+      ;;
+    gitlab)
+      local encoded_org
+      encoded_org=$(python3 -c "import urllib.parse; print(urllib.parse.quote('${org}',safe=''))")
+      local ns_id
+      ns_id=$(pa_api_get "${PA_API}/groups/${encoded_org}" 2>/dev/null | \
+        python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null || echo "")
+      [[ -z "$ns_id" ]] && { _pa_warn "Could not resolve GitLab namespace ID for ${org}"; return 1; }
+      payload=$(python3 -c "import json; print(json.dumps({'name':'${repo}','path':'${repo}','namespace_id':${ns_id},'visibility':'public','description':'${description}','initialize_with_readme':False}))")
+      http_code=$(curl -sf -o /dev/null -w "%{http_code}" \
+        -X POST \
+        -H "$PA_AUTH_HEADER" \
+        -H "Content-Type: application/json" \
+        -d "$payload" \
+        "${PA_API}/projects" 2>/dev/null || echo "0")
+      ;;
+    gitea|forgejo|codeberg)
+      payload=$(python3 -c "import json; print(json.dumps({'name':'${repo}','description':'${description}','private':False,'auto_init':False}))")
+      http_code=$(curl -sf -o /dev/null -w "%{http_code}" \
+        -X POST \
+        -H "$PA_AUTH_HEADER" \
+        -H "Content-Type: application/json" \
+        -d "$payload" \
+        "${PA_API}/orgs/${org}/repos" 2>/dev/null || echo "0")
+      ;;
+  esac
+
+  if [[ "$http_code" =~ ^2 ]]; then
+    _pa_info "  Created ${org}/${repo}"
+    return 0
+  else
+    _pa_warn "  Failed to create ${org}/${repo} (HTTP ${http_code})"
+    return 1
+  fi
+}
+
+# ── pa_rate_limit_remaining ───────────────────────────────────────────────────
+pa_rate_limit_remaining() {
+  local remaining="unknown"
+  case "$PA_PLATFORM" in
+    github)
+      remaining=$(pa_api_get "${PA_API}/rate_limit" 2>/dev/null | \
+        python3 -c "import sys,json; print(json.load(sys.stdin)['resources']['core']['remaining'])" \
+        2>/dev/null || echo "unknown")
+      ;;
+    gitlab)
+      # GitLab exposes rate limit in response headers, not a dedicated endpoint.
+      # Make a cheap call and read the header.
+      curl -sf -o /dev/null -D "$_PA_HEADER_TMP" \
+        -H "$PA_AUTH_HEADER" \
+        "${PA_API}/version" 2>/dev/null || true
+      remaining=$(grep -i "ratelimit-remaining:" "$_PA_HEADER_TMP" 2>/dev/null \
+        | tr -d '\r' | awk '{print $2}' | head -1 || echo "unknown")
+      ;;
+    gitea|forgejo|codeberg)
+      # Gitea/Forgejo: X-RateLimit-Remaining header on any response
+      curl -sf -o /dev/null -D "$_PA_HEADER_TMP" \
+        -H "$PA_AUTH_HEADER" \
+        "${PA_API}/version" 2>/dev/null || true
+      remaining=$(grep -i "x-ratelimit-remaining:" "$_PA_HEADER_TMP" 2>/dev/null \
+        | tr -d '\r' | awk '{print $2}' | head -1 || echo "unknown")
+      ;;
+  esac
+  echo "$remaining"
+}


### PR DESCRIPTION
## What changed

Replaces `sync-to-gitlab.yml` and `sync-from-gitlab.yml` with a single configurable workflow and script pair that works against any combination of GitHub, GitLab, Gitea, Forgejo, or Codeberg.

### `scripts/includes/platform-adapter.sh`

Uniform interface across all supported platforms:

| Function | Purpose |
|---|---|
| `pa_init PLATFORM [HOST]` | Initialise adapter, set `PA_HOST`, `PA_API`, `PA_AUTH_HEADER`, `PA_CLONE_PREFIX` |
| `pa_list_repos ORG` | Paginated repo listing |
| `pa_repo_exists ORG REPO` | Existence check |
| `pa_clone_url` / `pa_push_url` | Authenticated HTTPS URLs |
| `pa_create_repo ORG REPO` | Create if absent (no-op if exists) |
| `pa_api_get URL` | GET with rate-limit retry (HTTP 429/403, reset-aware backoff) |
| `pa_rate_limit_remaining` | Remaining quota (best-effort) |

Auth header format, clone URL prefix, and API base URL are all platform-specific and handled internally.

### `scripts/git-platform-sync.sh`

Bare-clone + selective push (no `--mirror` prune — preserves dest-only branches). `push` leg creates missing dest repos; `pull` leg never creates source repos. Key env vars: `SOURCE_PLATFORM`, `SOURCE_ORG`, `DEST_PLATFORM`, `DEST_ORG`, `DIRECTION` (push|pull|both).

### `git-platform-sync.yml`

Unified workflow with full dispatch inputs: `direction`, `source_platform`, `dest_platform`, `source_org`, `dest_org`, `source_host`, `dest_host`, `subgroup_filter`, `repo_filter`, `dry_run`, `force`.

Defaults to `github/Interested-Deving-1896 → gitlab/openos-project` (push) — identical behaviour to the deprecated `sync-to-gitlab.yml`.

### Deprecation

`sync-to-gitlab.yml` and `sync-from-gitlab.yml` converted to no-op stubs with redirect notices. Kept so `workflow_run` triggers referencing these names by string continue to resolve without error.

## Type

- [x] New feature / workflow
- [x] Refactor / cleanup

## Checklist

- [x] Validator passes (`validate-workflow-guards.py` — 102 workflows, all checks passed)
- [x] Config files validated (priority-tiers, quota-costs, workflow-sync)
- [x] No secrets or tokens committed