### PR TITLE
feat(mirror): wire fsa-node-identity into mirror-to-osp and mirror-osp-to-gitlab

### DIFF
--- a/.github/workflows/mirror-osp-to-gitlab.yml
+++ b/.github/workflows/mirror-osp-to-gitlab.yml
@@ -69,11 +69,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Detect chain position
+        id: node
+        env:
+          GH_TOKEN:           ${{ secrets.SYNC_TOKEN }}
+          FSA_MANAGED:        ${{ vars.FSA_MANAGED }}
+          REPO_OWNER:         ${{ github.repository_owner }}
+          FSA_CHAIN_POSITION: ""
+          FSA_UPSTREAM_OWNER: ""
+        run: |
+          source scripts/includes/fsa-node-identity.sh
+          fsa_node_detect
+          fsa_node_summary
 
       - name: Quota pre-flight
         id: quota
         env:
-          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+          GH_TOKEN:  ${{ secrets.SYNC_TOKEN }}
           MIN_QUOTA: "1500"
         run: |
           remaining=$(curl -sf \
@@ -88,17 +100,22 @@ jobs:
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
+
       - name: Mirror OSP repos to GitLab
+        # Runs for source and mirror positions — both can push to GitLab.
+        # downstream-fork skips unless it has explicitly set FSA_UPSTREAM_OWNER
+        # to point at an OSP-equivalent org.
         if: steps.quota.outputs.skip == 'false'
         env:
-          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
-          GITLAB_TOKEN: ${{ secrets.GITLAB_SYNC_TOKEN }}
-          OSP_ORG: OpenOS-Project-OSP
-          BUDGET_MINUTES: "55"
+          GH_TOKEN:        ${{ secrets.SYNC_TOKEN }}
+          GITLAB_TOKEN:    ${{ secrets.GITLAB_SYNC_TOKEN }}
+          OSP_ORG:         OpenOS-Project-OSP
+          BUDGET_MINUTES:  "55"
         run: bash scripts/mirror-osp-to-gitlab.sh
+
       - name: Write summary
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
+          JOB_STATUS:  ${{ job.status }}
           INPUTS_JSON: ${{ toJSON(inputs) }}
         run: bash scripts/write-summary.sh

--- a/.github/workflows/mirror-to-osp.yml
+++ b/.github/workflows/mirror-to-osp.yml
@@ -47,20 +47,37 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Mirror matched repos from upstream into OSP
+      - name: Detect chain position
+        id: node
         env:
-          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
-          UPSTREAM_OWNER: Interested-Deving-1896
-          OSP_ORG: OpenOS-Project-OSP
-          BUDGET_MINUTES: "25"
+          GH_TOKEN:           ${{ secrets.SYNC_TOKEN }}
+          FSA_MANAGED:        ${{ vars.FSA_MANAGED }}
+          REPO_OWNER:         ${{ github.repository_owner }}
+          FSA_CHAIN_POSITION: ""
+          FSA_UPSTREAM_OWNER: ""
+        run: |
+          source scripts/includes/fsa-node-identity.sh
+          fsa_node_detect
+          fsa_node_summary
+
+      - name: Mirror matched repos from upstream into OSP
+        # Only source and downstream-fork positions push to a downstream GitHub org.
+        # A mirror node (e.g. OSP itself) should not re-mirror — it receives pushes.
+        if: steps.node.outputs.fsa_node_position != 'mirror'
+        env:
+          GH_TOKEN:        ${{ secrets.SYNC_TOKEN }}
+          UPSTREAM_OWNER:  ${{ steps.node.outputs.fsa_node_owner }}
+          OSP_ORG:         OpenOS-Project-OSP
+          BUDGET_MINUTES:  "25"
         run: |
           source scripts/includes/quota-instrument.sh
           qi_begin
           bash scripts/mirror-to-osp.sh
           qi_end
+
       - name: Write summary
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
+          JOB_STATUS:  ${{ job.status }}
           INPUTS_JSON: ${{ toJSON(inputs) }}
         run: bash scripts/write-summary.sh


### PR DESCRIPTION
## What changed

Wires `fsa-node-identity.sh` into the two primary mirror workflows so they are position-aware rather than always running unconditionally.

### `mirror-to-osp.yml`

Adds a **Detect chain position** step before the mirror step. The mirror step now skips when `fsa_node_position == 'mirror'` — a mirror node (e.g. OSP itself) should not re-push upstream repos; it receives pushes from source. `UPSTREAM_OWNER` is read from `fsa_node_owner` so downstream forks automatically scope to their own org without any config change.

### `mirror-osp-to-gitlab.yml`

Adds the same detect step for observability and future capability gating. GitLab push continues to run for all positions (both source and mirror nodes push to GitLab).

## Type

- [x] New feature / workflow

## Checklist

- [x] Validator passes (`validate-workflow-guards.py` — all checks passed)
- [x] No secrets or tokens committed