### PR TITLE
fix(quota): remove mirror-chain-dispatch schedule on canonical instance

### DIFF
--- a/.github/workflows/mirror-chain-dispatch.yml
+++ b/.github/workflows/mirror-chain-dispatch.yml
@@ -69,10 +69,12 @@ on:
         default: false
         type: boolean
 
-  # Scheduled leg — runs as source on the canonical instance, as a no-op
-  # (position=mirror, no write ops) on downstream mirrors.
-  schedule:
-    - cron: '47 */6 * * *'   # Every 6h at :47 — staggered from mirror-to-osp (:13)
+  # No schedule on the canonical instance — the dedicated mirror workflows
+  # (mirror-to-osp.yml, mirror-osp-to-gitlab.yml, etc.) own the schedules
+  # and avoid duplication. mirror-chain-dispatch is dispatch-only here.
+  #
+  # Downstream forks that don't have the dedicated workflows can add a
+  # schedule here via FSA_CHAIN_POSITION=downstream-fork.
 
 concurrency:
   group: mirror-chain-dispatch-${{ github.ref }}

--- a/config/workflow-quota-costs.yml
+++ b/config/workflow-quota-costs.yml
@@ -908,9 +908,9 @@ workflows:
   synopsis: Multi-layer accessibility audit — CODEOWNERS coverage, README screen-reader scan, WCAG 2.1 AA HTML check, audio overview (espeak-ng), and Braille output (liblouis). Commits README.audio.mp3 and README.brl artifacts.
 - name: Mirror Chain Dispatch
   min_quota: 1200
-  cost_low: 50
-  cost_mid: 300
+  cost_low: 5
+  cost_mid: 50
   cost_high: 800
   basis: code-audit
-  notes: 1 quota pre-flight + 1 node-identity detect (1–3 API calls). Mirror legs delegate to mirror-to-osp.sh and mirror-osp-to-gitlab.sh — costs scale with number of repos and enabled operations. Low = single-repo filter, dry-run. Mid = full GitHub mirror leg only. High = all legs (GitHub + GitLab + source-ops + translate) across all repos.
-  synopsis: "Agnostic mirror-chain backend. Auto-detects chain position (source/mirror/downstream-fork) and runs only the operations appropriate for that position. Configurable via dispatch inputs: source_owner, dest_backends, operations, repo_filter."
+  notes: "Dispatch-only on canonical instance (no schedule). 1 quota pre-flight + 1 node-identity detect (1-3 API calls). When dispatched with operations, delegates to mirror-to-osp.sh / mirror-osp-to-gitlab.sh. Low = detect-only dry-run. High = all legs across all repos."
+  synopsis: "Agnostic mirror-chain backend. Dispatch-only on canonical instance — dedicated mirror workflows own schedules. Downstream forks without dedicated workflows may add a schedule."


### PR DESCRIPTION
## What changed

Removes the every-6h schedule from `mirror-chain-dispatch.yml` on the canonical instance.

### Root cause

`mirror-chain-dispatch.yml` was running every 6h and executing the full mirror stack (`mirror-to-osp.sh` + `mirror-osp-to-gitlab.sh` + source-ops + translate) when `operations` was blank — duplicating the work of the dedicated mirror workflows that already run on their own schedules. This was the **primary cause of quota exhaustion** after the OSP/OOC workflow disables earlier this session.

### Fix

`mirror-chain-dispatch` is now dispatch-only on the canonical instance. The dedicated workflows (`mirror-to-osp.yml`, `mirror-osp-to-gitlab.yml`, etc.) own the schedules. Downstream forks that don't have the dedicated workflows can add a schedule via `FSA_CHAIN_POSITION=downstream-fork`.

Updated quota-costs entry to reflect dispatch-only usage.

## Type

- [x] Bug fix

## Checklist

- [x] Validator passes
- [x] No secrets or tokens committed