### PR TITLE
feat: dual-source GitLab mirror chain (OSP + OOC)

### DIFF
--- a/.github/workflows/mirror-osp-to-gitlab.yml
+++ b/.github/workflows/mirror-osp-to-gitlab.yml
@@ -101,17 +101,53 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Mirror OSP repos to GitLab
+      - name: Mirror all configured GitHub orgs to GitLab
+        # Iterates over config/gitlab-mirror-sources.yml and runs one mirror
+        # leg per enabled source. Each leg clones from the GitHub org and
+        # pushes to the corresponding GitLab group.
         # Runs for source and mirror positions — both can push to GitLab.
-        # downstream-fork skips unless it has explicitly set FSA_UPSTREAM_OWNER
-        # to point at an OSP-equivalent org.
         if: steps.quota.outputs.skip == 'false'
         env:
           GH_TOKEN:        ${{ secrets.SYNC_TOKEN }}
           GITLAB_TOKEN:    ${{ secrets.GITLAB_SYNC_TOKEN }}
-          OSP_ORG:         OpenOS-Project-OSP
+          REPO_FILTER:     ${{ inputs.repo_filter || '' }}
+          SUBGROUP_FILTER: ${{ inputs.subgroup_filter || '' }}
+          DRY_RUN:         ${{ inputs.dry_run || 'false' }}
           BUDGET_MINUTES:  "55"
-        run: bash scripts/mirror-osp-to-gitlab.sh
+        run: |
+          python3 - << 'PYEOF'
+          import yaml, subprocess, os, sys
+
+          sources_file = "config/gitlab-mirror-sources.yml"
+          d = yaml.safe_load(open(sources_file))
+          sources = [s for s in d.get("sources", []) if s.get("enabled", True)]
+
+          print(f"[mirror-osp-to-gitlab] {len(sources)} enabled source(s)", flush=True)
+          overall_rc = 0
+
+          for src in sources:
+              name         = src["name"]
+              github_org   = src["github_org"]
+              gitlab_group = src["gitlab_group"]
+              sg_config    = src.get("subgroups_config", "config/gitlab-subgroups.yml")
+
+              print(f"\n[mirror-osp-to-gitlab] ── {name} ──", flush=True)
+              print(f"  {github_org} → gitlab.com/{gitlab_group}", flush=True)
+
+              env = os.environ.copy()
+              env["OSP_ORG"]          = github_org
+              env["GITLAB_GROUP"]     = gitlab_group
+              env["SUBGROUPS_CONFIG"] = sg_config
+
+              rc = subprocess.run(["bash", "scripts/mirror-osp-to-gitlab.sh"], env=env).returncode
+              if rc != 0:
+                  print(f"[mirror-osp-to-gitlab] ✗ {name} failed (rc={rc})", flush=True)
+                  overall_rc = rc
+              else:
+                  print(f"[mirror-osp-to-gitlab] ✓ {name} done", flush=True)
+
+          sys.exit(overall_rc)
+          PYEOF
 
       - name: Write summary
         if: always()

--- a/config/gitlab-mirror-sources.yml
+++ b/config/gitlab-mirror-sources.yml
@@ -1,0 +1,43 @@
+# config/gitlab-mirror-sources.yml
+#
+# Defines the (GitHub org → GitLab group) pairs for the mirror-osp-to-gitlab
+# workflow. Each entry is one mirror leg: repos are cloned from the GitHub org
+# and pushed to the corresponding GitLab root group.
+#
+# Used by:
+#   .github/workflows/mirror-osp-to-gitlab.yml  — iterates over sources
+#   scripts/mirror-osp-to-gitlab.sh             — reads GITLAB_GROUP env var
+#
+# ── Adding a new mirror leg ───────────────────────────────────────────────────
+#   1. Add an entry below with github_org, gitlab_group, and subgroups_config.
+#   2. Create the subgroups_config file (copy gitlab-subgroups.yml as template).
+#   3. Add the GitLab group's root namespace ID as gitlab_root_id.
+#   4. Ensure GITLAB_SYNC_TOKEN has api + write_repository scope on the group.
+#
+# ── Subgroup config files ─────────────────────────────────────────────────────
+#   Each leg has its own subgroup placement config. The OSP leg uses the
+#   existing config/gitlab-subgroups.yml. New legs get their own file so
+#   subgroup structures can diverge independently.
+
+sources:
+
+  - name: OSP → openos-project
+    github_org: OpenOS-Project-OSP
+    gitlab_group: openos-project
+    gitlab_root_id: 0          # resolved at runtime via GitLab API
+    subgroups_config: config/gitlab-subgroups.yml
+    enabled: true
+    notes: >
+      Primary mirror leg. All OSP-bound repos from Interested-Deving-1896
+      are mirrored to OpenOS-Project-OSP (GitHub) then here (GitLab).
+
+  - name: OOC → openos-project-ooc-ecosystem
+    github_org: OpenOS-Project-Ecosystem-OOC
+    gitlab_group: openos-project-ooc-ecosystem
+    gitlab_root_id: 134901804
+    subgroups_config: config/gitlab-subgroups-ooc.yml
+    enabled: true
+    notes: >
+      OOC mirror leg. Repos hosted in OpenOS-Project-Ecosystem-OOC (GitHub)
+      are mirrored to openos-project-ooc-ecosystem (GitLab).
+      GitLab group created 2026-06-15.

--- a/config/gitlab-subgroups-ooc.yml
+++ b/config/gitlab-subgroups-ooc.yml
@@ -1,0 +1,22 @@
+# config/gitlab-subgroups-ooc.yml
+#
+# Subgroup placement for the OOC → openos-project-ooc-ecosystem GitLab mirror leg.
+# Mirrors the structure of gitlab-subgroups.yml but scoped to OOC repos.
+#
+# GitLab root group: https://gitlab.com/openos-project-ooc-ecosystem
+# Root namespace ID: 134901804
+#
+# Fallback: any repo not listed here is placed in the 'projects' subgroup.
+# Add subgroups here as the OOC org grows.
+
+default_subgroup: projects
+
+subgroups:
+
+  projects:
+    id: 134901804    # root group itself — repos land directly under the group
+    path: openos-project-ooc-ecosystem
+    repos: []        # populated as OOC repos are registered
+    notes: >
+      Default placement for all OOC repos until subgroups are defined.
+      Update id to a real subgroup ID once subgroups are created in GitLab.

--- a/scripts/mirror-osp-to-gitlab.sh
+++ b/scripts/mirror-osp-to-gitlab.sh
@@ -13,13 +13,18 @@
 #
 # Required env vars:
 #   GH_TOKEN      — GitHub PAT with repo read scope
-#   GITLAB_TOKEN  — GitLab PAT with api + write_repository scope on openos-project
-#   OSP_ORG       — GitHub org to mirror from (OpenOS-Project-OSP)
+#   GITLAB_TOKEN  — GitLab PAT with api + write_repository scope on the target group
+#   OSP_ORG       — GitHub org to mirror from (default: OpenOS-Project-OSP)
+#
+# Optional env vars:
+#   GITLAB_GROUP      — GitLab root group to mirror into (default: openos-project)
+#   SUBGROUPS_CONFIG  — path to subgroup placement config (default: config/gitlab-subgroups.yml)
 
 set -uo pipefail
 
 : "${GH_TOKEN:?GH_TOKEN is required}"
 : "${OSP_ORG:=OpenOS-Project-OSP}"
+GITLAB_GROUP="${GITLAB_GROUP:-openos-project}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/branch-name-conv.sh
@@ -45,7 +50,7 @@ GH_API="https://api.github.com"
 
 # ── Subgroup map — loaded from config/gitlab-subgroups.yml ───────────────────
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-GL_SUBGROUP_CONFIG="${REPO_ROOT}/config/gitlab-subgroups.yml"
+GL_SUBGROUP_CONFIG="${SUBGROUPS_CONFIG:-${REPO_ROOT}/config/gitlab-subgroups.yml}"
 
 if [[ ! -f "${GL_SUBGROUP_CONFIG}" ]]; then
   echo "ERROR: ${GL_SUBGROUP_CONFIG} not found" >&2
@@ -55,11 +60,12 @@ fi
 # gl_subgroup_lookup <repo_name>
 # Prints "namespace_id|subgroup_name|path" for the given repo, or the default.
 gl_subgroup_lookup() {
-  python3 - "$1" "${GL_SUBGROUP_CONFIG}" << 'PYEOF'
+  python3 - "$1" "${GL_SUBGROUP_CONFIG}" "${GITLAB_GROUP}" << 'PYEOF'
 import sys, yaml
 
 repo        = sys.argv[1]
 config_path = sys.argv[2]
+gl_group    = sys.argv[3]  # e.g. openos-project or openos-project-ooc-ecosystem
 
 with open(config_path) as f:
     config = yaml.safe_load(f)
@@ -71,7 +77,7 @@ subgroups       = config.get("subgroups", {}) or {}
 for sg_name, sg in subgroups.items():
     if repo in (sg.get("repos") or []):
         ns_id = sg.get("id", 0)
-        path  = sg.get("path") or f"openos-project/{sg_name}"
+        path  = sg.get("path") or f"{gl_group}/{sg_name}"
         print(f"{ns_id}|{sg_name}|{path}")
         sys.exit(0)
 
@@ -79,11 +85,12 @@ for sg_name, sg in subgroups.items():
 if default_sg_name in subgroups:
     sg    = subgroups[default_sg_name]
     ns_id = sg.get("id", 0)
-    path  = sg.get("path") or f"openos-project/{default_sg_name}"
+    path  = sg.get("path") or f"{gl_group}/{default_sg_name}"
     print(f"{ns_id}|{default_sg_name}|{path}")
     sys.exit(0)
 
-print("130734009|ops|openos-project/ops")  # hard fallback
+# Hard fallback — use root group itself
+print(f"0|root|{gl_group}")
 PYEOF
 }
 


### PR DESCRIPTION
## What changed

Adds `config/gitlab-mirror-sources.yml` as the single source of truth for `(GitHub org → GitLab group)` mirror pairs, and wires the OOC leg into `mirror-osp-to-gitlab.yml`.

### `config/gitlab-mirror-sources.yml`

Two enabled sources:
- `OpenOS-Project-OSP` → `openos-project` (existing leg, unchanged behaviour)
- `OpenOS-Project-Ecosystem-OOC` → `openos-project-ooc-ecosystem` (new)

GitLab group `openos-project-ooc-ecosystem` was created manually (ID: 134901804).

### `config/gitlab-subgroups-ooc.yml`

Subgroup placement config for the OOC leg. Starts with a single `projects` default subgroup pointing at the root group. Populate as OOC repos are registered.

### `scripts/mirror-osp-to-gitlab.sh`

Now accepts `GITLAB_GROUP` and `SUBGROUPS_CONFIG` env vars. `gl_subgroup_lookup` uses `GITLAB_GROUP` instead of hardcoded `openos-project` for path construction. Fully backwards-compatible — defaults to existing values.

### `.github/workflows/mirror-osp-to-gitlab.yml`

Mirror step replaced with a Python loop over `gitlab-mirror-sources.yml`. Each enabled source runs the script with `OSP_ORG`, `GITLAB_GROUP`, and `SUBGROUPS_CONFIG` set per-source. Overall exit code is non-zero if any leg fails.

### Adding future mirror legs

1. Add an entry to `config/gitlab-mirror-sources.yml`
2. Create a `config/gitlab-subgroups-{name}.yml` placement config
3. Ensure `GITLAB_SYNC_TOKEN` has scope on the new GitLab group

## Type

- [x] New feature / workflow

## Checklist

- [x] Validator passes (`validate-workflow-guards.py` — all checks passed)
- [x] Config files validated
- [x] No secrets or tokens committed