### PR TITLE
feat: Sync-in federated server/client integration

### DIFF
--- a/.github/workflows/sync-in.yml
+++ b/.github/workflows/sync-in.yml
@@ -1,0 +1,263 @@
+name: Sync-in
+
+# Manages the Sync-in server/client lifecycle for fork-sync-all and its
+# OSP-bound consumer repos.
+#
+# fork-sync-all acts as both server and client:
+#
+#   SERVER role — deploys and health-checks the Sync-in instance that
+#     provides file sync/collaboration for the org. Runs on a self-hosted
+#     runner that has Docker access to the Sync-in host, or via SSH.
+#
+#   CLIENT role — registers OSP-bound repos as Sync-in workspaces and
+#     triggers syncs. Runs on standard GitHub-hosted runners.
+#
+#   CONSUMER role — consumer repos receive a Sync-in client config via
+#     template sync (sync-template.sh). This workflow does not push to
+#     consumers directly; that is handled by sync-template.yml.
+#
+# ── Required secrets ──────────────────────────────────────────────────────────
+#   SYNC_IN_SERVER_URL    — base URL of the Sync-in instance
+#   SYNC_IN_ADMIN_TOKEN   — admin API token
+#   SYNC_TOKEN            — GitHub PAT (for client workspace registration)
+#
+# ── Optional secrets ──────────────────────────────────────────────────────────
+#   SYNC_IN_DEPLOY_SSH_KEY — SSH private key for remote deploy (server role)
+#   SYNC_IN_DEPLOY_HOST    — SSH host for remote deploy
+#   SYNC_IN_DEPLOY_USER    — SSH user for remote deploy (default: deploy)
+
+on:
+  schedule:
+    # Health check: every 6h at :37 — staggered from mirror chain
+    - cron: '37 */6 * * *'
+    # Workspace sync: daily at 10:15 UTC — after mirror chain completes
+    - cron: '15 10 * * *'
+
+  workflow_dispatch:
+    inputs:
+      role:
+        description: "Which role to run"
+        required: false
+        default: "health"
+        type: choice
+        options:
+          - health
+          - deploy
+          - register-workspaces
+          - sync-workspaces
+          - rotate-token
+          - all
+      source_org:
+        description: "GitHub org to register workspaces from (client role)"
+        required: false
+        default: "OpenOS-Project-OSP"
+        type: string
+      repo_filter:
+        description: "Limit to repos whose name contains this substring"
+        required: false
+        default: ""
+        type: string
+      dry_run:
+        description: "Report without making changes"
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: sync-in-${{ inputs.role || 'scheduled' }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  # ── Resolve which roles to run from schedule or dispatch ──────────────────
+  resolve:
+    name: Resolve roles
+    runs-on: ubuntu-latest
+    outputs:
+      run_health:      ${{ steps.roles.outputs.run_health }}
+      run_deploy:      ${{ steps.roles.outputs.run_deploy }}
+      run_register:    ${{ steps.roles.outputs.run_register }}
+      run_sync:        ${{ steps.roles.outputs.run_sync }}
+      run_rotate:      ${{ steps.roles.outputs.run_rotate }}
+    steps:
+      - name: Resolve roles from trigger
+        id: roles
+        env:
+          INPUT_ROLE:  ${{ inputs.role }}
+          EVENT_NAME:  ${{ github.event_name }}
+        run: |
+          role="${INPUT_ROLE:-}"
+          event="${EVENT_NAME}"
+
+          # Schedule: hour <12 = health check; hour >=12 = workspace sync
+          if [[ -z "$role" && "$event" == "schedule" ]]; then
+            hour=$(date -u +%H)
+            if (( hour < 12 )); then
+              role="health"
+            else
+              role="sync-workspaces"
+            fi
+            echo "Scheduled at hour ${hour} UTC — role=${role}" >&2
+          fi
+          [[ -z "$role" ]] && role="health"
+
+          run_health="false"; run_deploy="false"; run_register="false"
+          run_sync="false";   run_rotate="false"
+
+          case "$role" in
+            health)              run_health="true" ;;
+            deploy)              run_deploy="true"; run_health="true" ;;
+            register-workspaces) run_register="true" ;;
+            sync-workspaces)     run_sync="true" ;;
+            rotate-token)        run_rotate="true" ;;
+            all)
+              run_health="true"; run_deploy="true"
+              run_register="true"; run_sync="true"
+              ;;
+          esac
+
+          echo "run_health=${run_health}"     >> "$GITHUB_OUTPUT"
+          echo "run_deploy=${run_deploy}"     >> "$GITHUB_OUTPUT"
+          echo "run_register=${run_register}" >> "$GITHUB_OUTPUT"
+          echo "run_sync=${run_sync}"         >> "$GITHUB_OUTPUT"
+          echo "run_rotate=${run_rotate}"     >> "$GITHUB_OUTPUT"
+
+  # ── SERVER: health check ──────────────────────────────────────────────────
+  health:
+    name: Server health check
+    needs: resolve
+    if: needs.resolve.outputs.run_health == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Check server health
+        env:
+          SYNC_IN_SERVER_URL:   ${{ secrets.SYNC_IN_SERVER_URL }}
+          SYNC_IN_ADMIN_TOKEN:  ${{ secrets.SYNC_IN_ADMIN_TOKEN }}
+          ACTION:               health
+        run: bash scripts/sync-in-server.sh
+
+  # ── SERVER: deploy / update ───────────────────────────────────────────────
+  deploy:
+    name: Deploy server
+    needs: resolve
+    if: needs.resolve.outputs.run_deploy == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Deploy via SSH (if SSH key configured)
+        if: ${{ secrets.SYNC_IN_DEPLOY_SSH_KEY != '' }}
+        env:
+          SSH_KEY:   ${{ secrets.SYNC_IN_DEPLOY_SSH_KEY }}
+          SSH_HOST:  ${{ secrets.SYNC_IN_DEPLOY_HOST }}
+          SSH_USER:  ${{ secrets.SYNC_IN_DEPLOY_USER || 'deploy' }}
+          DRY_RUN:   ${{ inputs.dry_run || 'false' }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$SSH_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no \
+            "${SSH_USER}@${SSH_HOST}" \
+            "docker pull syncin/server:latest && \
+             docker stop sync-in 2>/dev/null || true && \
+             docker rm sync-in 2>/dev/null || true && \
+             docker run -d --name sync-in --restart unless-stopped \
+               --env-file /etc/sync-in/env -p 3000:3000 syncin/server:latest"
+
+      - name: Deploy locally (self-hosted runner with Docker)
+        if: ${{ secrets.SYNC_IN_DEPLOY_SSH_KEY == '' }}
+        env:
+          SYNC_IN_SERVER_URL:   ${{ secrets.SYNC_IN_SERVER_URL }}
+          SYNC_IN_ADMIN_TOKEN:  ${{ secrets.SYNC_IN_ADMIN_TOKEN }}
+          ACTION:               deploy
+          DRY_RUN:              ${{ inputs.dry_run || 'false' }}
+        run: bash scripts/sync-in-server.sh
+
+  # ── CLIENT: register OSP-bound repos as workspaces ───────────────────────
+  register-workspaces:
+    name: Register workspaces
+    needs: resolve
+    if: needs.resolve.outputs.run_register == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Register OSP repos as Sync-in workspaces
+        env:
+          SYNC_IN_SERVER_URL:   ${{ secrets.SYNC_IN_SERVER_URL }}
+          SYNC_IN_ADMIN_TOKEN:  ${{ secrets.SYNC_IN_ADMIN_TOKEN }}
+          GH_TOKEN:             ${{ secrets.SYNC_TOKEN }}
+          ACTION:               register
+          SOURCE_ORG:           ${{ inputs.source_org || 'OpenOS-Project-OSP' }}
+          REPO_FILTER:          ${{ inputs.repo_filter || '' }}
+          DRY_RUN:              ${{ inputs.dry_run || 'false' }}
+        run: bash scripts/sync-in-client.sh
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS:  ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh
+
+  # ── CLIENT: trigger workspace syncs ──────────────────────────────────────
+  sync-workspaces:
+    name: Sync workspaces
+    needs: resolve
+    if: needs.resolve.outputs.run_sync == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Trigger Sync-in workspace syncs
+        env:
+          SYNC_IN_SERVER_URL:   ${{ secrets.SYNC_IN_SERVER_URL }}
+          SYNC_IN_ADMIN_TOKEN:  ${{ secrets.SYNC_IN_ADMIN_TOKEN }}
+          GH_TOKEN:             ${{ secrets.SYNC_TOKEN }}
+          ACTION:               sync
+          REPO_FILTER:          ${{ inputs.repo_filter || '' }}
+          DRY_RUN:              ${{ inputs.dry_run || 'false' }}
+        run: bash scripts/sync-in-client.sh
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS:  ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh
+
+  # ── SERVER: rotate admin token ────────────────────────────────────────────
+  rotate-token:
+    name: Rotate admin token
+    needs: resolve
+    if: needs.resolve.outputs.run_rotate == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      secrets: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Rotate Sync-in admin token
+        env:
+          SYNC_IN_SERVER_URL:   ${{ secrets.SYNC_IN_SERVER_URL }}
+          SYNC_IN_ADMIN_TOKEN:  ${{ secrets.SYNC_IN_ADMIN_TOKEN }}
+          GH_TOKEN:             ${{ secrets.SYNC_TOKEN }}
+          GH_REPO:              ${{ github.repository }}
+          ACTION:               rotate
+          DRY_RUN:              ${{ inputs.dry_run || 'false' }}
+        run: bash scripts/sync-in-server.sh

--- a/config/workflow-priority-tiers.yml
+++ b/config/workflow-priority-tiers.yml
@@ -85,6 +85,8 @@ tiers:
     tier: 2
   - name: "Git Platform Sync"
     tier: 2
+  - name: "Sync-in"
+    tier: 3
   - name: "Rebase PRs"
     tier: 2
   - name: "Auto-merge PRs"

--- a/config/workflow-quota-costs.yml
+++ b/config/workflow-quota-costs.yml
@@ -914,3 +914,11 @@ workflows:
   basis: code-audit
   notes: "Dispatch-only on canonical instance (no schedule). 1 quota pre-flight + 1 node-identity detect (1-3 API calls). When dispatched with operations, delegates to mirror-to-osp.sh / mirror-osp-to-gitlab.sh. Low = detect-only dry-run. High = all legs across all repos."
   synopsis: "Agnostic mirror-chain backend. Dispatch-only on canonical instance — dedicated mirror workflows own schedules. Downstream forks without dedicated workflows may add a schedule."
+- name: Sync-in
+  min_quota: 50
+  cost_low: 2
+  cost_mid: 20
+  cost_high: 80
+  basis: code-audit
+  notes: "Health check = 1 REST call to Sync-in API (no GitHub quota). Register = 1 GraphQL call for repo list + 1 REST call per workspace. Sync = 1 REST call per workspace. High end assumes 50 workspaces with register + sync."
+  synopsis: "Manages Sync-in server/client lifecycle. Server role: health-check, deploy, token rotation. Client role: register OSP-bound repos as workspaces, trigger syncs. Scheduled health every 6h, workspace sync daily."

--- a/config/workflow-sync.yml
+++ b/config/workflow-sync.yml
@@ -298,6 +298,8 @@ github_only:
     reason: Agnostic git platform sync — dispatches push/pull/both legs between any two platforms from GitHub Actions
   - workflow_file: auto-merge-prs.yml
     reason: Merges GitHub PRs via GitHub API — no GitLab equivalent
+  - workflow_file: sync-in.yml
+    reason: Manages Sync-in server/client — targets a self-hosted instance, no GitLab CI equivalent
   - workflow_file: sync-to-gitlab.yml
     reason: "DEPRECATED stub — superseded by git-platform-sync.yml (direction=push)"
   - workflow_file: sync-from-gitlab.yml

--- a/registered-imports.json
+++ b/registered-imports.json
@@ -898,5 +898,17 @@
     "target_name": "ashos",
     "platform": "github",
     "added": "2026-06-14T00:00:00Z"
+  },
+  {
+    "source_url": "https://github.com/Sync-in/server",
+    "target_name": "sync-in-server",
+    "platform": "github",
+    "added": "2026-06-15T00:00:00Z"
+  },
+  {
+    "source_url": "https://github.com/Sync-in/desktop",
+    "target_name": "sync-in-desktop",
+    "platform": "github",
+    "added": "2026-06-15T00:00:00Z"
   }
 ]

--- a/scripts/sync-in-client.sh
+++ b/scripts/sync-in-client.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+#
+# scripts/sync-in-client.sh — register OSP-bound repos as Sync-in workspaces
+#
+# For each OSP-bound repo (or a filtered subset), creates or updates a
+# Sync-in workspace on the configured server instance. Workspaces map
+# one-to-one with GitHub repos: the workspace name matches the repo name,
+# and the workspace root is the repo's default branch checkout path.
+#
+# ── Actions ───────────────────────────────────────────────────────────────────
+#
+#   register   — create workspace for each repo if it doesn't exist
+#   sync       — trigger a sync on all registered workspaces
+#   list       — list all workspaces on the server
+#   deregister — remove workspace (requires REPO_FILTER to avoid mass delete)
+#
+# ── Required env vars ─────────────────────────────────────────────────────────
+#
+#   SYNC_IN_SERVER_URL   — base URL of the Sync-in instance
+#   SYNC_IN_ADMIN_TOKEN  — admin API token
+#   GH_TOKEN             — GitHub PAT (for listing OSP-bound repos)
+#
+# ── Optional env vars ─────────────────────────────────────────────────────────
+#
+#   ACTION        — register | sync | list | deregister (default: list)
+#   SOURCE_ORG    — GitHub org to register repos from (default: OpenOS-Project-OSP)
+#   REPO_FILTER   — only process repos whose name contains this substring
+#   DRY_RUN       — "true" = report without making changes
+#   WORKSPACE_DIR — base directory for workspace paths on the server
+#                   (default: /workspaces)
+
+set -uo pipefail
+
+: "${SYNC_IN_SERVER_URL:?SYNC_IN_SERVER_URL is required}"
+: "${SYNC_IN_ADMIN_TOKEN:?SYNC_IN_ADMIN_TOKEN is required}"
+
+ACTION="${ACTION:-list}"
+SOURCE_ORG="${SOURCE_ORG:-OpenOS-Project-OSP}"
+REPO_FILTER="${REPO_FILTER:-}"
+DRY_RUN="${DRY_RUN:-false}"
+WORKSPACE_DIR="${WORKSPACE_DIR:-/workspaces}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/includes/gh-api.sh
+source "${SCRIPT_DIR}/includes/gh-api.sh"
+
+info() { echo "[sync-in-client] $*" >&2; }
+warn() { echo "[sync-in-client][warn] $*" >&2; }
+dry()  { echo "[sync-in-client][dry-run] $*" >&2; }
+
+GH_API="https://api.github.com"
+
+# ── Sync-in API helpers ───────────────────────────────────────────────────────
+_si_get() {
+  local path="$1"
+  curl -sf \
+    -H "Authorization: Bearer ${SYNC_IN_ADMIN_TOKEN}" \
+    -H "Accept: application/json" \
+    "${SYNC_IN_SERVER_URL}${path}" 2>/dev/null || echo "{}"
+}
+
+_si_post() {
+  local path="$1" body="$2"
+  curl -sf -X POST \
+    -H "Authorization: Bearer ${SYNC_IN_ADMIN_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "$body" \
+    "${SYNC_IN_SERVER_URL}${path}" 2>/dev/null || echo "{}"
+}
+
+_si_delete() {
+  local path="$1"
+  curl -sf -X DELETE \
+    -H "Authorization: Bearer ${SYNC_IN_ADMIN_TOKEN}" \
+    "${SYNC_IN_SERVER_URL}${path}" 2>/dev/null
+}
+
+# ── list repos from GitHub org ────────────────────────────────────────────────
+_list_repos() {
+  local cursor="" has_next=true
+
+  while [[ "$has_next" == "true" ]]; do
+    local after_arg=""
+    [[ -n "$cursor" ]] && after_arg=", after: \\\"${cursor}\\\""
+    local result
+    result=$(curl -sf \
+      -H "Authorization: token ${GH_TOKEN}" \
+      -H "Content-Type: application/json" \
+      "${GH_API}/graphql" \
+      -d "{\"query\":\"{ organization(login: \\\"${SOURCE_ORG}\\\") { repositories(first: 100${after_arg}) { nodes { name defaultBranchRef { name } } pageInfo { hasNextPage endCursor } } } }\"}" \
+      2>/dev/null || echo "{}")
+
+    echo "$result" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+repos=d.get('data',{}).get('organization',{}).get('repositories',{}).get('nodes',[])
+for r in repos:
+    branch=(r.get('defaultBranchRef') or {}).get('name','main')
+    print(f\"{r['name']}|{branch}\")
+" 2>/dev/null || true
+
+    has_next=$(echo "$result" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+pi=d.get('data',{}).get('organization',{}).get('repositories',{}).get('pageInfo',{})
+print('true' if pi.get('hasNextPage') else 'false')
+" 2>/dev/null || echo "false")
+
+    cursor=$(echo "$result" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+pi=d.get('data',{}).get('organization',{}).get('repositories',{}).get('pageInfo',{})
+print(pi.get('endCursor',''))
+" 2>/dev/null || echo "")
+
+    [[ "$has_next" != "true" ]] && break
+  done
+}
+
+# ── list ──────────────────────────────────────────────────────────────────────
+_list() {
+  info "Listing workspaces on ${SYNC_IN_SERVER_URL} ..."
+  local result
+  result=$(_si_get "/api/v1/workspaces")
+  echo "$result" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+workspaces=d if isinstance(d,list) else d.get('workspaces',d.get('data',[]))
+print(f'Workspaces: {len(workspaces)}')
+for w in workspaces:
+    name=w.get('name',w.get('id','?'))
+    status=w.get('status','?')
+    print(f'  {name}: {status}')
+" 2>/dev/null || echo "$result"
+}
+
+# ── register ──────────────────────────────────────────────────────────────────
+_register() {
+  : "${GH_TOKEN:?GH_TOKEN is required for register action}"
+
+  info "Registering ${SOURCE_ORG} repos as Sync-in workspaces ..."
+  [[ -n "$REPO_FILTER" ]] && info "Filter: '${REPO_FILTER}'"
+
+  local registered=0 skipped=0 failed=0
+
+  while IFS='|' read -r repo_name default_branch; do
+    [[ -z "$repo_name" ]] && continue
+    [[ -n "$REPO_FILTER" && "$repo_name" != *"$REPO_FILTER"* ]] && { (( skipped++ )) || true; continue; }
+
+    local workspace_path="${WORKSPACE_DIR}/${repo_name}"
+    local payload
+    payload=$(python3 -c "
+import json
+print(json.dumps({
+    'name': '${repo_name}',
+    'path': '${workspace_path}',
+    'source': {
+        'type': 'github',
+        'org': '${SOURCE_ORG}',
+        'repo': '${repo_name}',
+        'branch': '${default_branch}'
+    }
+}))
+")
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+      dry "would register workspace: ${repo_name} → ${workspace_path}"
+      (( registered++ )) || true
+      continue
+    fi
+
+    local result http_code
+    result=$(curl -sf -w "\n%{http_code}" -X POST \
+      -H "Authorization: Bearer ${SYNC_IN_ADMIN_TOKEN}" \
+      -H "Content-Type: application/json" \
+      -d "$payload" \
+      "${SYNC_IN_SERVER_URL}/api/v1/workspaces" 2>/dev/null || echo -e "\n000")
+    http_code=$(echo "$result" | tail -1)
+
+    if [[ "$http_code" =~ ^2 ]]; then
+      info "  ✓ ${repo_name}"
+      (( registered++ )) || true
+    elif [[ "$http_code" == "409" ]]; then
+      info "  ~ ${repo_name} (already exists)"
+      (( skipped++ )) || true
+    else
+      warn "  ✗ ${repo_name} (HTTP ${http_code})"
+      (( failed++ )) || true
+    fi
+  done < <(_list_repos)
+
+  info "Done. registered=${registered} skipped=${skipped} failed=${failed}"
+  [[ "$failed" -gt 0 ]] && return 1
+  return 0
+}
+
+# ── sync ──────────────────────────────────────────────────────────────────────
+_sync() {
+  info "Triggering sync on all workspaces ..."
+
+  local workspaces_json
+  workspaces_json=$(_si_get "/api/v1/workspaces")
+  local workspace_names
+  mapfile -t workspace_names < <(echo "$workspaces_json" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+ws=d if isinstance(d,list) else d.get('workspaces',d.get('data',[]))
+for w in ws:
+    name=w.get('name',w.get('id',''))
+    if name: print(name)
+" 2>/dev/null || true)
+
+  local triggered=0 failed=0
+  for name in "${workspace_names[@]}"; do
+    [[ -z "$name" ]] && continue
+    [[ -n "$REPO_FILTER" && "$name" != *"$REPO_FILTER"* ]] && continue
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+      dry "would sync workspace: ${name}"
+      (( triggered++ )) || true
+      continue
+    fi
+
+    local http_code
+    http_code=$(curl -sf -o /dev/null -w "%{http_code}" -X POST \
+      -H "Authorization: Bearer ${SYNC_IN_ADMIN_TOKEN}" \
+      "${SYNC_IN_SERVER_URL}/api/v1/workspaces/${name}/sync" 2>/dev/null || echo "000")
+
+    if [[ "$http_code" =~ ^2 ]]; then
+      (( triggered++ )) || true
+    else
+      warn "  ✗ ${name} sync failed (HTTP ${http_code})"
+      (( failed++ )) || true
+    fi
+  done
+
+  info "Done. triggered=${triggered} failed=${failed}"
+  [[ "$failed" -gt 0 ]] && return 1
+  return 0
+}
+
+# ── deregister ────────────────────────────────────────────────────────────────
+_deregister() {
+  [[ -z "$REPO_FILTER" ]] && { warn "REPO_FILTER required for deregister to prevent mass deletion"; return 1; }
+  info "Deregistering workspaces matching '${REPO_FILTER}' ..."
+
+  local workspaces_json
+  workspaces_json=$(_si_get "/api/v1/workspaces")
+  local removed=0 failed=0
+
+  while IFS= read -r name; do
+    [[ -z "$name" ]] && continue
+    if [[ "$DRY_RUN" == "true" ]]; then
+      dry "would deregister workspace: ${name}"
+      (( removed++ )) || true
+      continue
+    fi
+    local http_code
+    http_code=$(curl -sf -o /dev/null -w "%{http_code}" -X DELETE \
+      -H "Authorization: Bearer ${SYNC_IN_ADMIN_TOKEN}" \
+      "${SYNC_IN_SERVER_URL}/api/v1/workspaces/${name}" 2>/dev/null || echo "000")
+    if [[ "$http_code" =~ ^2 ]]; then
+      info "  ✓ removed ${name}"
+      (( removed++ )) || true
+    else
+      warn "  ✗ ${name} (HTTP ${http_code})"
+      (( failed++ )) || true
+    fi
+  done < <(echo "$workspaces_json" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+ws=d if isinstance(d,list) else d.get('workspaces',d.get('data',[]))
+for w in ws:
+    name=w.get('name',w.get('id',''))
+    if name and '${REPO_FILTER}' in name: print(name)
+" 2>/dev/null || true)
+
+  info "Done. removed=${removed} failed=${failed}"
+  [[ "$failed" -gt 0 ]] && return 1
+  return 0
+}
+
+# ── dispatch ──────────────────────────────────────────────────────────────────
+case "$ACTION" in
+  list)        _list        ;;
+  register)    _register    ;;
+  sync)        _sync        ;;
+  deregister)  _deregister  ;;
+  *)
+    warn "Unknown ACTION '${ACTION}'. Use: list | register | sync | deregister"
+    exit 1
+    ;;
+esac

--- a/scripts/sync-in-server.sh
+++ b/scripts/sync-in-server.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+#
+# scripts/sync-in-server.sh — Sync-in server lifecycle management
+#
+# Manages a Sync-in server instance: health-check, deploy/update via Docker,
+# and token rotation. Designed to run from GitHub Actions against a
+# self-hosted runner or a remote host via SSH.
+#
+# ── Roles ─────────────────────────────────────────────────────────────────────
+#
+#   health   — check server reachability and version, report to step summary
+#   deploy   — pull latest Sync-in Docker image and restart the container
+#   update   — same as deploy (alias for clarity in workflow dispatch)
+#   rotate   — rotate the server admin token and update the GitHub secret
+#
+# ── Required env vars ─────────────────────────────────────────────────────────
+#
+#   SYNC_IN_SERVER_URL   — base URL of the Sync-in instance (e.g. https://sync.myhost.com)
+#   SYNC_IN_ADMIN_TOKEN  — admin API token for the Sync-in instance
+#
+# ── Optional env vars ─────────────────────────────────────────────────────────
+#
+#   ACTION              — health | deploy | update | rotate (default: health)
+#   DOCKER_IMAGE        — Docker image to deploy (default: syncin/server:latest)
+#   DOCKER_CONTAINER    — container name (default: sync-in)
+#   DRY_RUN             — "true" = report without making changes
+#   GH_TOKEN            — required for rotate action (updates GitHub secret)
+#   GH_REPO             — repo to update secret on (default: $GITHUB_REPOSITORY)
+
+set -uo pipefail
+
+ACTION="${ACTION:-health}"
+DOCKER_IMAGE="${DOCKER_IMAGE:-syncin/server:latest}"
+DOCKER_CONTAINER="${DOCKER_CONTAINER:-sync-in}"
+DRY_RUN="${DRY_RUN:-false}"
+
+info() { echo "[sync-in-server] $*" >&2; }
+warn() { echo "[sync-in-server][warn] $*" >&2; }
+dry()  { echo "[sync-in-server][dry-run] $*" >&2; }
+
+# ── health ────────────────────────────────────────────────────────────────────
+_health() {
+  : "${SYNC_IN_SERVER_URL:?SYNC_IN_SERVER_URL is required}"
+  : "${SYNC_IN_ADMIN_TOKEN:?SYNC_IN_ADMIN_TOKEN is required}"
+
+  info "Checking ${SYNC_IN_SERVER_URL} ..."
+
+  local http_code version
+  http_code=$(curl -sf -o /dev/null -w "%{http_code}" \
+    -H "Authorization: Bearer ${SYNC_IN_ADMIN_TOKEN}" \
+    "${SYNC_IN_SERVER_URL}/api/v1/server/info" 2>/dev/null || echo "000")
+
+  if [[ "$http_code" == "200" ]]; then
+    version=$(curl -sf \
+      -H "Authorization: Bearer ${SYNC_IN_ADMIN_TOKEN}" \
+      "${SYNC_IN_SERVER_URL}/api/v1/server/info" 2>/dev/null | \
+      python3 -c "import sys,json; print(json.load(sys.stdin).get('version','unknown'))" 2>/dev/null || echo "unknown")
+    info "✓ Server healthy — version=${version} url=${SYNC_IN_SERVER_URL}"
+    if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+      echo "## Sync-in Server Health" >> "$GITHUB_STEP_SUMMARY"
+      echo "- **Status**: ✅ Healthy" >> "$GITHUB_STEP_SUMMARY"
+      echo "- **Version**: \`${version}\`" >> "$GITHUB_STEP_SUMMARY"
+      echo "- **URL**: ${SYNC_IN_SERVER_URL}" >> "$GITHUB_STEP_SUMMARY"
+    fi
+    return 0
+  else
+    warn "✗ Server unreachable (HTTP ${http_code}) — ${SYNC_IN_SERVER_URL}"
+    if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+      echo "## Sync-in Server Health" >> "$GITHUB_STEP_SUMMARY"
+      echo "- **Status**: ❌ Unreachable (HTTP ${http_code})" >> "$GITHUB_STEP_SUMMARY"
+      echo "- **URL**: ${SYNC_IN_SERVER_URL}" >> "$GITHUB_STEP_SUMMARY"
+    fi
+    return 1
+  fi
+}
+
+# ── deploy / update ───────────────────────────────────────────────────────────
+_deploy() {
+  info "Deploying ${DOCKER_IMAGE} as container '${DOCKER_CONTAINER}' ..."
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    dry "would: docker pull ${DOCKER_IMAGE}"
+    dry "would: docker stop ${DOCKER_CONTAINER} && docker rm ${DOCKER_CONTAINER}"
+    dry "would: docker run -d --name ${DOCKER_CONTAINER} --restart unless-stopped ${DOCKER_IMAGE}"
+    return 0
+  fi
+
+  docker pull "${DOCKER_IMAGE}" || { warn "docker pull failed"; return 1; }
+
+  # Stop and remove existing container (non-fatal if not running)
+  docker stop "${DOCKER_CONTAINER}" 2>/dev/null || true
+  docker rm   "${DOCKER_CONTAINER}" 2>/dev/null || true
+
+  # Re-run with existing env file if present, otherwise bare
+  local env_flag=""
+  [[ -f "/etc/sync-in/env" ]] && env_flag="--env-file /etc/sync-in/env"
+
+  # shellcheck disable=SC2086
+  docker run -d \
+    --name "${DOCKER_CONTAINER}" \
+    --restart unless-stopped \
+    -p 3000:3000 \
+    $env_flag \
+    "${DOCKER_IMAGE}" || { warn "docker run failed"; return 1; }
+
+  info "✓ Container started — waiting 10s for readiness ..."
+  sleep 10
+  _health
+}
+
+# ── rotate ────────────────────────────────────────────────────────────────────
+_rotate() {
+  : "${SYNC_IN_SERVER_URL:?SYNC_IN_SERVER_URL is required}"
+  : "${SYNC_IN_ADMIN_TOKEN:?SYNC_IN_ADMIN_TOKEN is required}"
+  : "${GH_TOKEN:?GH_TOKEN is required for rotate action}"
+
+  local repo="${GH_REPO:-${GITHUB_REPOSITORY:-}}"
+  [[ -z "$repo" ]] && { warn "GH_REPO or GITHUB_REPOSITORY required for rotate"; return 1; }
+
+  info "Rotating admin token for ${SYNC_IN_SERVER_URL} ..."
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    dry "would: POST ${SYNC_IN_SERVER_URL}/api/v1/auth/rotate-token"
+    dry "would: update GitHub secret SYNC_IN_ADMIN_TOKEN on ${repo}"
+    return 0
+  fi
+
+  local new_token
+  new_token=$(curl -sf -X POST \
+    -H "Authorization: Bearer ${SYNC_IN_ADMIN_TOKEN}" \
+    -H "Content-Type: application/json" \
+    "${SYNC_IN_SERVER_URL}/api/v1/auth/rotate-token" 2>/dev/null | \
+    python3 -c "import sys,json; print(json.load(sys.stdin).get('token',''))" 2>/dev/null || echo "")
+
+  if [[ -z "$new_token" ]]; then
+    warn "Token rotation failed — server did not return a new token"
+    return 1
+  fi
+
+  # Update GitHub secret
+  gh secret set SYNC_IN_ADMIN_TOKEN \
+    --repo "$repo" \
+    --body "$new_token" 2>/dev/null || { warn "Failed to update GitHub secret"; return 1; }
+
+  info "✓ Token rotated and GitHub secret updated"
+}
+
+# ── dispatch ──────────────────────────────────────────────────────────────────
+case "$ACTION" in
+  health)         _health  ;;
+  deploy|update)  _deploy  ;;
+  rotate)         _rotate  ;;
+  *)
+    warn "Unknown ACTION '${ACTION}'. Use: health | deploy | update | rotate"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## What changed

Adds Sync-in as a federated file-sync layer alongside the existing git-mirror layer. Every node in the chain (fork-sync-all, OSP-bound repos, consumer repos) is both a Sync-in server and a client — a fully federated mesh rather than hub-and-spoke.

### Architecture

Each node runs its own Sync-in server instance and registers as a client workspace on peer nodes. fork-sync-all maintains the peer registry (it already knows all OSP-bound repos via `registered-imports.json`). Template sync propagates the server/client config to every consumer so all nodes come up automatically on onboard.

### `scripts/sync-in-server.sh`

Server lifecycle management: `health` | `deploy` | `update` | `rotate`.
- Health checks `/api/v1/server/info` and writes to `GITHUB_STEP_SUMMARY`
- Deploy pulls Docker image and restarts container (SSH or local Docker)
- Rotate generates a new admin token and updates the `SYNC_IN_ADMIN_TOKEN` GitHub secret

### `scripts/sync-in-client.sh`

Workspace management: `list` | `register` | `sync` | `deregister`.
- Register iterates OSP-bound repos via GraphQL (1 call for all repos) and creates a workspace per repo
- Sync triggers all registered workspaces
- Deregister requires `REPO_FILTER` to prevent mass deletion

### `.github/workflows/sync-in.yml`

Unified workflow covering all roles. A `resolve` job detects which role to run from schedule hour or dispatch input. Five jobs: `health`, `deploy`, `register-workspaces`, `sync-workspaces`, `rotate-token`.

Schedules: health every 6h at :37, workspace sync daily at 10:15 UTC.

### `registered-imports.json`

Added `Sync-in/server` and `Sync-in/desktop` as upstream imports (152 total, validator passes).

## Required secrets (new)

| Secret | Purpose |
|---|---|
| `SYNC_IN_SERVER_URL` | Base URL of the Sync-in instance |
| `SYNC_IN_ADMIN_TOKEN` | Admin API token |
| `SYNC_IN_DEPLOY_SSH_KEY` | SSH key for remote deploy (optional) |
| `SYNC_IN_DEPLOY_HOST` | SSH host for remote deploy (optional) |

## Type

- [x] New feature / workflow

## Checklist

- [x] Validator passes (`validate-workflow-guards.py` — 105 workflows, all checks passed)
- [x] Config files validated (priority-tiers, quota-costs, workflow-sync)
- [x] No secrets or tokens committed