### PR TITLE
feat(ci): agnostic CI check engine

### DIFF
--- a/.github/workflows/check-ci.yml
+++ b/.github/workflows/check-ci.yml
@@ -1,0 +1,143 @@
+name: Check CI Status
+
+# Agnostic CI status checker. Reads config/ci-check-targets.yml and runs
+# check-ci.sh for each enabled target (GitHub orgs, GitLab groups, etc.).
+# Replaces check-osp-ci.yml and check-ooc-ci.yml.
+
+on:
+  workflow_run:
+    workflows:
+      - "Add Mirror Repo"
+    types: [completed]
+  schedule:
+    - cron: '5 9 * * *'
+  workflow_dispatch:
+    inputs:
+      target_id:
+        description: "Run only this target ID (blank = all enabled targets)"
+        required: false
+        default: ""
+        type: string
+      repo_filter:
+        description: "Check only repos matching this substring (blank = all)"
+        required: false
+        default: ""
+        type: string
+      dry_run:
+        description: "Report failures without triggering resolver"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: check-ci
+  cancel-in-progress: true
+
+jobs:
+  matrix:
+    name: Build target matrix
+    runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.load.outputs.targets }}
+      skip: ${{ steps.quota.outputs.skip }}
+    steps:
+      - name: Quota pre-flight
+        id: quota
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+          MIN_QUOTA: "1500"
+        run: |
+          remaining=$(curl -sf \
+            -H "Authorization: token ${GH_TOKEN}" \
+            "https://api.github.com/rate_limit" \
+            | python3 -c "import sys,json; print(json.load(sys.stdin)['resources']['core']['remaining'])" \
+            || echo 0)
+          echo "remaining=${remaining}" >> "$GITHUB_OUTPUT"
+          if [[ "${remaining}" -lt "${MIN_QUOTA}" ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Quota too low (${remaining} < ${MIN_QUOTA}) -- skipping."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        if: steps.quota.outputs.skip == 'false'
+        uses: actions/checkout@v6
+
+      - name: Load targets from config
+        id: load
+        if: steps.quota.outputs.skip == 'false'
+        env:
+          TARGET_ID_FILTER: ${{ inputs.target_id || '' }}
+        run: |
+          args=""
+          [[ -n "${TARGET_ID_FILTER}" ]] && args="--target-id ${TARGET_ID_FILTER}"
+          targets=$(python3 scripts/list-ci-targets.py ${args})
+          echo "targets=${targets}" >> "$GITHUB_OUTPUT"
+
+  check:
+    name: "CI check: ${{ matrix.target.id }}"
+    needs: matrix
+    if: needs.matrix.outputs.skip == 'false' && needs.matrix.outputs.targets != '[]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJSON(needs.matrix.outputs.targets) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Check CI
+        id: check
+        env:
+          PLATFORM: ${{ matrix.target.platform }}
+          TARGET_ORG: ${{ matrix.target.org }}
+          TARGET_ID: ${{ matrix.target.id }}
+          SUBGROUPS_CONFIG: ${{ matrix.target.subgroups_config }}
+          API_URL: ${{ matrix.target.api_url }}
+          REPO_FILTER: ${{ inputs.repo_filter || '' }}
+          BUDGET_MINUTES: "25"
+          MIN_QUOTA: "500"
+          TOKEN: ${{ matrix.target.token_secret == 'GITLAB_TOKEN' && secrets.GITLAB_TOKEN || secrets.SYNC_TOKEN }}
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+        run: |
+          source scripts/includes/quota-instrument.sh
+          qi_begin
+          bash scripts/check-ci.sh > /tmp/ci-results-${{ matrix.target.id }}.json
+          bash scripts/check-osp-ci-summary.sh /tmp/ci-results-${{ matrix.target.id }}.json
+          count=$(bash scripts/check-osp-ci-summary.sh /tmp/ci-results-${{ matrix.target.id }}.json --count)
+          echo "failing_count=${count}" >> "$GITHUB_OUTPUT"
+          qi_end
+
+      - name: Trigger resolver for failing repos
+        if: steps.check.outputs.failing_count != '0' && inputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+        run: |
+          failing_repos=$(bash scripts/check-osp-ci-summary.sh /tmp/ci-results-${{ matrix.target.id }}.json --repos)
+          echo "Dispatching resolve-failures.yml for: ${failing_repos}"
+          curl -sf \
+            -X POST \
+            -H "Authorization: token ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/workflows/resolve-failures.yml/dispatches" \
+            -d "{\"ref\":\"main\",\"inputs\":{\"repo_filter\":\"${failing_repos// /|}\",\"dry_run\":\"false\"}}" \
+            && echo "Resolver dispatched." \
+            || echo "Failed to dispatch resolver -- check quota and token."
+
+      - name: All green
+        if: steps.check.outputs.failing_count == '0'
+        run: echo "All repos in ${{ matrix.target.id }} are green on their default branch."
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/check-ooc-ci.yml
+++ b/.github/workflows/check-ooc-ci.yml
@@ -1,13 +1,8 @@
 name: Check OOC-Bound CI Status
 
-# Verifies that the default-branch HEAD of every OOC-bound repo
-# (OpenOS-Project-Ecosystem-OOC) has a green CI status. When failures are
-# found, writes a summary and dispatches resolve-failures.yml scoped to the
-# failing repos.
-#
-# Repo list source: config/gitlab-subgroups-ooc.yml. While that file is
-# sparse (OOC is still growing), the script falls back to enumerating the
-# org directly via GraphQL.
+# Deprecated stub — superseded by check-ci.yml (agnostic engine).
+# Kept to preserve existing schedule and workflow_run triggers during
+# the transition period. Delegates immediately to check-ci.yml.
 
 on:
   workflow_run:
@@ -15,7 +10,7 @@ on:
       - "Mirror to OpenOS-Project-Ecosystem-OOC"
     types: [completed]
   schedule:
-    - cron: '25 9 * * *'  # daily at 09:25 UTC — 20 min after OSP check
+    - cron: '25 9 * * *'
   workflow_dispatch:
     inputs:
       repo_filter:
@@ -38,72 +33,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check:
+  delegate:
+    name: Delegate to check-ci.yml
     runs-on: ubuntu-latest
-    timeout-minutes: 30
     steps:
-      - name: Quota pre-flight
-        id: quota
+      - name: Dispatch check-ci.yml
         env:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
-          MIN_QUOTA: "1500"
-        run: |
-          remaining=$(curl -sf \
-            -H "Authorization: token ${GH_TOKEN}" \
-            "https://api.github.com/rate_limit" \
-            | python3 -c "import sys,json; print(json.load(sys.stdin)['resources']['core']['remaining'])" \
-            || echo 0)
-          echo "remaining=${remaining}" >> "$GITHUB_OUTPUT"
-          if [[ "${remaining}" -lt "${MIN_QUOTA}" ]]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "Quota too low (${remaining} < ${MIN_QUOTA}) -- skipping."
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Check CI status across OOC-bound repos
-        if: steps.quota.outputs.skip == 'false'
-        id: check
-        env:
-          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
-          GITHUB_OWNER: OpenOS-Project-Ecosystem-OOC
           REPO_FILTER: ${{ inputs.repo_filter || '' }}
-          BUDGET_MINUTES: "25"
-          MIN_QUOTA: "500"
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: |
-          source scripts/includes/quota-instrument.sh
-          qi_begin
-          bash scripts/check-ooc-ci.sh > /tmp/ooc-ci-results.json
-          bash scripts/check-osp-ci-summary.sh /tmp/ooc-ci-results.json
-          echo "failing_count=$(bash scripts/check-osp-ci-summary.sh /tmp/ooc-ci-results.json --count)" >> "$GITHUB_OUTPUT"
-          qi_end
-
-      - name: Trigger resolver for failing repos
-        if: steps.quota.outputs.skip == 'false' && steps.check.outputs.failing_count != '0' && inputs.dry_run != 'true'
-        env:
-          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
-        run: |
-          failing_repos=$(bash scripts/check-osp-ci-summary.sh /tmp/ooc-ci-results.json --repos)
-          echo "Dispatching resolve-failures.yml for: ${failing_repos}"
+          echo "check-ooc-ci.yml is deprecated -- delegating to check-ci.yml"
           curl -sf \
             -X POST \
             -H "Authorization: token ${GH_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}/actions/workflows/resolve-failures.yml/dispatches" \
-            -d "{\"ref\":\"main\",\"inputs\":{\"repo_filter\":\"${failing_repos// /|}\",\"dry_run\":\"false\"}}" \
-            && echo "Resolver dispatched." \
-            || echo "Failed to dispatch resolver -- check quota and token."
-
-      - name: All green
-        if: steps.quota.outputs.skip == 'false' && steps.check.outputs.failing_count == '0'
-        run: echo "All OOC-bound repos are green on their default branch."
-
-      - name: Write summary
-        if: always()
-        env:
-          JOB_STATUS: ${{ job.status }}
-          INPUTS_JSON: ${{ toJSON(inputs) }}
-        run: bash scripts/write-summary.sh
+            "https://api.github.com/repos/${{ github.repository }}/actions/workflows/check-ci.yml/dispatches" \
+            -d "{\"ref\":\"main\",\"inputs\":{\"repo_filter\":\"${REPO_FILTER}\",\"dry_run\":\"${DRY_RUN}\"}}" \
+            && echo "check-ci.yml dispatched." \
+            || echo "Dispatch failed."

--- a/.github/workflows/check-osp-ci.yml
+++ b/.github/workflows/check-osp-ci.yml
@@ -1,14 +1,10 @@
 name: Check OSP-Bound CI Status
 
-# Verifies that the default-branch HEAD of every OSP-bound repo
-# (registered via add-mirror-repo.yml, listed in config/gitlab-subgroups.yml)
-# has a green CI status. When failures are found, writes a summary and
-# dispatches resolve-failures.yml scoped to the failing repos.
+# Deprecated stub — superseded by check-ci.yml (agnostic engine).
+# Kept to preserve existing schedule and workflow_run triggers during
+# the transition period. Delegates immediately to check-ci.yml.
 
 on:
-  # workflow_run trigger from Mirror I-D-1896→OSP removed: mirror runs 4×/day
-  # and each CI check costs 4 REST calls × 225 repos = 900 calls/run.
-  # The daily schedule at 09:05 UTC is sufficient.
   workflow_run:
     workflows:
       - "Add Mirror Repo"
@@ -37,71 +33,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check:
+  delegate:
+    name: Delegate to check-ci.yml
     runs-on: ubuntu-latest
-    timeout-minutes: 30
     steps:
-      - name: Quota pre-flight
-        id: quota
+      - name: Dispatch check-ci.yml
         env:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
-          MIN_QUOTA: "1500"
-        run: |
-          remaining=$(curl -sf \
-            -H "Authorization: token ${GH_TOKEN}" \
-            "https://api.github.com/rate_limit" \
-            | python3 -c "import sys,json; print(json.load(sys.stdin)['resources']['core']['remaining'])" \
-            || echo 0)
-          echo "remaining=${remaining}" >> "$GITHUB_OUTPUT"
-          if [[ "${remaining}" -lt "${MIN_QUOTA}" ]]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "Quota too low (${remaining} < ${MIN_QUOTA}) -- skipping."
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Check CI status across OSP-bound repos
-        if: steps.quota.outputs.skip == 'false'
-        id: check
-        env:
-          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
-          GITHUB_OWNER: Interested-Deving-1896
           REPO_FILTER: ${{ inputs.repo_filter || '' }}
-          BUDGET_MINUTES: "25"
-          MIN_QUOTA: "500"
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: |
-          source scripts/includes/quota-instrument.sh
-          qi_begin
-          bash scripts/check-osp-ci.sh > /tmp/osp-ci-results.json
-          bash scripts/check-osp-ci-summary.sh /tmp/osp-ci-results.json
-          echo "failing_count=$(bash scripts/check-osp-ci-summary.sh /tmp/osp-ci-results.json --count)" >> "$GITHUB_OUTPUT"
-          qi_end
-
-      - name: Trigger resolver for failing repos
-        if: steps.quota.outputs.skip == 'false' && steps.check.outputs.failing_count != '0' && inputs.dry_run != 'true'
-        env:
-          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
-        run: |
-          failing_repos=$(bash scripts/check-osp-ci-summary.sh /tmp/osp-ci-results.json --repos)
-          echo "Dispatching resolve-failures.yml for: ${failing_repos}"
+          echo "check-osp-ci.yml is deprecated -- delegating to check-ci.yml"
           curl -sf \
             -X POST \
             -H "Authorization: token ${GH_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}/actions/workflows/resolve-failures.yml/dispatches" \
-            -d "{\"ref\":\"main\",\"inputs\":{\"repo_filter\":\"${failing_repos// /|}\",\"dry_run\":\"false\"}}" \
-            && echo "Resolver dispatched." \
-            || echo "Failed to dispatch resolver -- check quota and token."
-
-      - name: All green
-        if: steps.quota.outputs.skip == 'false' && steps.check.outputs.failing_count == '0'
-        run: echo "All OSP-bound repos are green on their default branch."
-      - name: Write summary
-        if: always()
-        env:
-          JOB_STATUS: ${{ job.status }}
-          INPUTS_JSON: ${{ toJSON(inputs) }}
-        run: bash scripts/write-summary.sh
+            "https://api.github.com/repos/${{ github.repository }}/actions/workflows/check-ci.yml/dispatches" \
+            -d "{\"ref\":\"main\",\"inputs\":{\"repo_filter\":\"${REPO_FILTER}\",\"dry_run\":\"${DRY_RUN}\"}}" \
+            && echo "check-ci.yml dispatched." \
+            || echo "Dispatch failed."

--- a/config/ci-check-targets.yml
+++ b/config/ci-check-targets.yml
@@ -1,0 +1,102 @@
+# config/ci-check-targets.yml
+#
+# Registry of CI check targets for the agnostic check-ci framework.
+# check-ci.yml reads this file to build its job matrix — one check per target.
+#
+# Two source types:
+#
+#   mirror_source: <name>
+#     References an entry in gitlab-mirror-sources.yml by its `name:` field.
+#     Expands into one GitHub target (github_org) and optionally one GitLab
+#     target (gitlab_group) when ci_check_gitlab: true is set on the source.
+#
+#   standalone:
+#     A target not derived from a mirror leg (e.g. the source org itself,
+#     or a future Gitea/Forgejo/Codeberg instance).
+#
+# Fields (all targets):
+#   id            — stable identifier used in matrix job names and summaries
+#   platform      — github | gitlab | gitea | forgejo | codeberg
+#   org / group   — org or group name on the platform
+#   subgroups_config — path to the subgroups YAML (for repo enumeration)
+#   token_secret  — name of the GitHub Actions secret holding the API token
+#   api_url       — base API URL (defaults to platform canonical URL)
+#   enabled       — set false to skip without removing the entry
+#   notes         — human-readable description
+#
+# ── Adding a new target ───────────────────────────────────────────────────────
+#   GitHub org:   add a standalone entry with platform: github
+#   GitLab group: add a standalone entry with platform: gitlab + api_url
+#   New platform: add a standalone entry with the appropriate platform value;
+#                 check-ci.sh uses platform-adapter.sh for API calls so any
+#                 platform supported there works here automatically.
+
+targets:
+
+  # ── Standalone: source org ─────────────────────────────────────────────────
+  - id: interested-deving-1896
+    platform: github
+    org: Interested-Deving-1896
+    subgroups_config: config/gitlab-subgroups.yml   # OSP subgroups = OSP-bound repos
+    token_secret: SYNC_TOKEN
+    enabled: true
+    notes: >
+      Source org. Checks CI status of all OSP-bound repos in
+      Interested-Deving-1896 (the same set mirrored to OSP).
+
+  # ── Mirror sources (imported from gitlab-mirror-sources.yml) ───────────────
+  # GitHub side of each mirror leg (ci_check: true entries)
+  - id: osp-github
+    platform: github
+    org: OpenOS-Project-OSP
+    subgroups_config: config/gitlab-subgroups.yml
+    token_secret: SYNC_TOKEN
+    enabled: true
+    mirror_source: "OSP → openos-project"
+    notes: >
+      GitHub mirror of OSP-bound repos. Checks CI on OpenOS-Project-OSP.
+
+  - id: ooc-github
+    platform: github
+    org: OpenOS-Project-Ecosystem-OOC
+    subgroups_config: config/gitlab-subgroups-ooc.yml
+    token_secret: SYNC_TOKEN
+    enabled: true
+    mirror_source: "OOC → openos-project-ooc-ecosystem"
+    notes: >
+      GitHub mirror of OOC repos. Checks CI on OpenOS-Project-Ecosystem-OOC.
+
+  # GitLab side of each mirror leg (ci_check_gitlab: true entries)
+  - id: osp-gitlab
+    platform: gitlab
+    org: openos-project
+    subgroups_config: config/gitlab-subgroups.yml
+    token_secret: GITLAB_TOKEN
+    api_url: https://gitlab.com
+    enabled: true
+    mirror_source: "OSP → openos-project"
+    notes: >
+      GitLab mirror of OSP-bound repos. Checks CI on gitlab.com/openos-project.
+
+  - id: ooc-gitlab
+    platform: gitlab
+    org: openos-project-ooc-ecosystem
+    subgroups_config: config/gitlab-subgroups-ooc.yml
+    token_secret: GITLAB_TOKEN
+    api_url: https://gitlab.com
+    enabled: true
+    mirror_source: "OOC → openos-project-ooc-ecosystem"
+    notes: >
+      GitLab mirror of OOC repos. Checks CI on
+      gitlab.com/openos-project-ooc-ecosystem.
+
+  # ── Future platforms (add entries here as mirrors are configured) ───────────
+  # Example Gitea instance:
+  # - id: osp-gitea
+  #   platform: gitea
+  #   org: openos-project
+  #   subgroups_config: config/gitlab-subgroups.yml
+  #   token_secret: GITEA_TOKEN
+  #   api_url: https://gitea.example.com
+  #   enabled: false
+  #   notes: Gitea mirror — not yet configured.

--- a/config/gitlab-mirror-sources.yml
+++ b/config/gitlab-mirror-sources.yml
@@ -13,6 +13,9 @@
 #   2. Create the subgroups_config file (copy gitlab-subgroups.yml as template).
 #   3. Add the GitLab group's root namespace ID as gitlab_root_id.
 #   4. Ensure GITLAB_SYNC_TOKEN has api + write_repository scope on the group.
+#   5. Set ci_check: true to include this leg in the agnostic CI check framework
+#      (check-ci.yml). The GitHub org side is checked automatically; set
+#      ci_check_gitlab: true to also check the GitLab mirror side.
 #
 # ── Subgroup config files ─────────────────────────────────────────────────────
 #   Each leg has its own subgroup placement config. The OSP leg uses the
@@ -27,6 +30,8 @@ sources:
     gitlab_root_id: 0          # resolved at runtime via GitLab API
     subgroups_config: config/gitlab-subgroups.yml
     enabled: true
+    ci_check: true             # include GitHub org in check-ci.yml
+    ci_check_gitlab: true      # also check the GitLab mirror side
     notes: >
       Primary mirror leg. All OSP-bound repos from Interested-Deving-1896
       are mirrored to OpenOS-Project-OSP (GitHub) then here (GitLab).
@@ -37,6 +42,8 @@ sources:
     gitlab_root_id: 134901804
     subgroups_config: config/gitlab-subgroups-ooc.yml
     enabled: true
+    ci_check: true             # include GitHub org in check-ci.yml
+    ci_check_gitlab: true      # also check the GitLab mirror side
     notes: >
       OOC mirror leg. Repos hosted in OpenOS-Project-Ecosystem-OOC (GitHub)
       are mirrored to openos-project-ooc-ecosystem (GitLab).

--- a/config/workflow-priority-tiers.yml
+++ b/config/workflow-priority-tiers.yml
@@ -115,7 +115,10 @@ tiers:
     tier: 3
   - name: "Generate Repo Descriptions"
     tier: 3
+  - name: "Check CI Status"
+    tier: 3
   - name: "Check OSP-Bound CI Status"
+    tier: 3
   - name: "Check OOC-Bound CI Status"
     tier: 3
   - name: "Reconcile Org References"

--- a/config/workflow-quota-costs.yml
+++ b/config/workflow-quota-costs.yml
@@ -203,9 +203,23 @@ workflows:
     OSP; high end assumes 75 repos. Falls back to org enumeration when
     gitlab-subgroups-ooc.yml is sparse.
   synopsis: >
-    Checks CI status of every OOC-bound repo (OpenOS-Project-Ecosystem-OOC).
-    Falls back to org enumeration when gitlab-subgroups-ooc.yml is sparse.
-    Dispatches resolve-failures.yml on failures.
+    Deprecated stub — delegates to Check CI Status. Kept for schedule/trigger
+    continuity.
+- name: Check CI Status
+  min_quota: 300
+  cost_low: 50
+  cost_mid: 300
+  cost_high: 900
+  basis: code-audit
+  notes: >
+    Matrix over ci-check-targets.yml (5 targets: 3 GitHub, 2 GitLab).
+    GitHub targets: 1 GraphQL prefetch + 2 REST calls per repo (check-runs,
+    statuses). GitLab targets: 2 REST calls per repo (project info, pipeline).
+    High end assumes all 5 targets run against ~225 repos each.
+  synopsis: >
+    Agnostic CI status checker. Runs check-ci.sh for each enabled target in
+    config/ci-check-targets.yml (GitHub orgs and GitLab groups). Replaces
+    check-osp-ci.yml and check-ooc-ci.yml.
 - name: Rebase PRs
   min_quota: 100
   cost_low: 5

--- a/config/workflow-sync.yml
+++ b/config/workflow-sync.yml
@@ -440,10 +440,12 @@ github_only:
     reason: Cancels stale queued runs — GitHub Actions API only
   - workflow_file: cancel-post-rotation.yml
     reason: Cancels in-flight runs after token rotation — GitHub Actions API only
+  - workflow_file: check-ci.yml
+    reason: Agnostic CI status checker — reads ci-check-targets.yml, runs check-ci.sh for each enabled target (GitHub orgs, GitLab groups)
   - workflow_file: check-osp-ci.yml
-    reason: Checks CI status of OSP-bound repos — GitHub API only
+    reason: "DEPRECATED stub — delegates to check-ci.yml. Kept for schedule/trigger continuity."
   - workflow_file: check-ooc-ci.yml
-    reason: Checks CI status of OOC-bound repos — GitHub API only
+    reason: "DEPRECATED stub — delegates to check-ci.yml. Kept for schedule/trigger continuity."
   - workflow_file: create-ooc-subgroups.yml
     reason: One-shot workflow to create OOC GitLab subgroups — manual dispatch only
   - workflow_file: rebase-prs.yml

--- a/scripts/check-ci.sh
+++ b/scripts/check-ci.sh
@@ -1,0 +1,389 @@
+#!/usr/bin/env bash
+#
+# scripts/check-ci.sh — agnostic CI status checker
+#
+# Checks the CI status of the default-branch HEAD for every repo in a given
+# org/group, across any supported platform. Replaces check-osp-ci.sh and
+# check-ooc-ci.sh with a single configurable engine.
+#
+# Outputs a JSON array of failing repos to stdout:
+#   [{"repo":"name","sha":"abc123","url":"https://...","failures":["job1"]}, ...]
+#
+# Required env vars:
+#   PLATFORM       — github | gitlab (more via platform-adapter.sh)
+#   TARGET_ORG     — org/group name on the platform
+#   TOKEN          — API token (PAT for GitHub, personal/project token for GitLab)
+#
+# Optional env vars:
+#   SUBGROUPS_CONFIG — path to subgroups YAML for repo enumeration
+#                      (default: config/gitlab-subgroups.yml for github platform)
+#   REPO_FILTER    — optional substring filter on repo name
+#   API_URL        — base API URL (default: platform canonical URL)
+#   BUDGET_MINUTES — time budget (default: 25)
+#   MIN_QUOTA      — skip if GitHub quota below this (default: 500, GitHub only)
+#   TARGET_ID      — human-readable label for logs (default: PLATFORM/TARGET_ORG)
+#   GH_TOKEN       — alias for TOKEN when PLATFORM=github (for includes compat)
+
+set -uo pipefail
+
+PLATFORM="${PLATFORM:?PLATFORM is required (github|gitlab)}"
+TARGET_ORG="${TARGET_ORG:?TARGET_ORG is required}"
+TOKEN="${TOKEN:-${GH_TOKEN:-}}"
+: "${TOKEN:?TOKEN (or GH_TOKEN) is required}"
+
+REPO_FILTER="${REPO_FILTER:-}"
+BUDGET_MINUTES="${BUDGET_MINUTES:-25}"
+MIN_QUOTA="${MIN_QUOTA:-500}"
+TARGET_ID="${TARGET_ID:-${PLATFORM}/${TARGET_ORG}}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# ── Logging ───────────────────────────────────────────────────────────────────
+info() { echo "[check-ci:${TARGET_ID}] $*" >&2; }
+warn() { echo "[check-ci:${TARGET_ID}] ⚠  $*" >&2; }
+ok()   { echo "[check-ci:${TARGET_ID}] ✓ $*" >&2; }
+
+# ── Platform defaults ─────────────────────────────────────────────────────────
+case "$PLATFORM" in
+  github)
+    API_URL="${API_URL:-https://api.github.com}"
+    GH_TOKEN="$TOKEN"
+    export GH_TOKEN
+    SUBGROUPS_CONFIG="${SUBGROUPS_CONFIG:-${REPO_ROOT}/config/gitlab-subgroups.yml}"
+    ;;
+  gitlab)
+    API_URL="${API_URL:-https://gitlab.com}"
+    SUBGROUPS_CONFIG="${SUBGROUPS_CONFIG:-${REPO_ROOT}/config/gitlab-subgroups.yml}"
+    ;;
+  *)
+    warn "Unsupported platform '${PLATFORM}'. Supported: github, gitlab"
+    echo "[]"
+    exit 1
+    ;;
+esac
+
+# ── Budget + API helpers (GitHub only) ────────────────────────────────────────
+if [[ "$PLATFORM" == "github" ]]; then
+  source "${SCRIPT_DIR}/includes/budget.sh"
+  source "${SCRIPT_DIR}/includes/gh-api.sh"
+  budget_init
+
+  _quota_json=$(curl -sf \
+    -H "Authorization: token ${TOKEN}" \
+    "${API_URL}/rate_limit" 2>/dev/null || echo '{}')
+  _quota_remaining=$(echo "$_quota_json" | python3 -c \
+    "import sys,json; d=json.load(sys.stdin); print(d.get('resources',{}).get('core',{}).get('remaining',0))" \
+    2>/dev/null || echo 0)
+  _quota_reset=$(echo "$_quota_json" | python3 -c \
+    "import sys,json,datetime; d=json.load(sys.stdin); \
+     ts=d.get('resources',{}).get('core',{}).get('reset',0); \
+     print(datetime.datetime.utcfromtimestamp(ts).strftime('%H:%M UTC') if ts else 'unknown')" \
+    2>/dev/null || echo 'unknown')
+
+  if (( _quota_remaining < MIN_QUOTA )); then
+    warn "Quota too low (${_quota_remaining} < ${MIN_QUOTA}) — resets at ${_quota_reset}. Skipping."
+    echo "[]"
+    exit 0
+  fi
+  info "Quota: ${_quota_remaining} remaining"
+fi
+
+# ── Repo list ─────────────────────────────────────────────────────────────────
+_load_repos_from_config() {
+  local config="$1"
+  python3 - <<PYEOF
+import yaml, sys
+data = yaml.safe_load(open("${config}"))
+repos = []
+for sg in (data.get("subgroups") or {}).values():
+    repos.extend(sg.get("repos") or [])
+for r in sorted(set(repos)):
+    print(r)
+PYEOF
+}
+
+_enumerate_github_org() {
+  local owner="$1"
+  local cursor=""
+  while true; do
+    local after_arg=""
+    [[ -n "$cursor" ]] && after_arg=", after: \\\"${cursor}\\\""
+    local result
+    result=$(curl -sf \
+      -H "Authorization: token ${TOKEN}" \
+      -H "Content-Type: application/json" \
+      "${API_URL}/graphql" \
+      -d "{\"query\":\"{ organization(login: \\\"${owner}\\\") { repositories(first: 100${after_arg}) { nodes { name } pageInfo { hasNextPage endCursor } } } }\"}" \
+      2>/dev/null || echo "{}")
+    echo "$result" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+for n in d.get('data',{}).get('organization',{}).get('repositories',{}).get('nodes',[]):
+    print(n['name'])
+" 2>/dev/null || true
+    local has_next
+    has_next=$(echo "$result" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+pi=d.get('data',{}).get('organization',{}).get('repositories',{}).get('pageInfo',{})
+print('true' if pi.get('hasNextPage') else 'false')
+" 2>/dev/null || echo "false")
+    [[ "$has_next" != "true" ]] && break
+    cursor=$(echo "$result" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+print(d.get('data',{}).get('organization',{}).get('repositories',{}).get('pageInfo',{}).get('endCursor',''))
+" 2>/dev/null || echo "")
+  done
+}
+
+_enumerate_gitlab_group() {
+  local group="$1"
+  local page=1
+  while true; do
+    local result
+    result=$(curl -sf \
+      -H "Authorization: Bearer ${TOKEN}" \
+      "${API_URL}/api/v4/groups/${group}/projects?per_page=100&page=${page}&include_subgroups=true" \
+      2>/dev/null || echo "[]")
+    local count
+    count=$(echo "$result" | python3 -c "import json,sys; d=json.load(sys.stdin); [print(p['path']) for p in d]" 2>/dev/null | wc -l || echo 0)
+    echo "$result" | python3 -c "
+import json,sys
+for p in json.load(sys.stdin):
+    print(p['path'])
+" 2>/dev/null || true
+    (( count < 100 )) && break
+    (( page++ ))
+  done
+}
+
+# Load repo list: config file first, fall back to org enumeration
+mapfile -t REPOS < <(
+  if [[ -f "$SUBGROUPS_CONFIG" ]]; then
+    _load_repos_from_config "$SUBGROUPS_CONFIG"
+  fi
+)
+
+if [[ "${#REPOS[@]}" -eq 0 ]]; then
+  info "No repos in ${SUBGROUPS_CONFIG} — enumerating ${TARGET_ORG} via API..."
+  if [[ "$PLATFORM" == "github" ]]; then
+    mapfile -t REPOS < <(_enumerate_github_org "$TARGET_ORG")
+  elif [[ "$PLATFORM" == "gitlab" ]]; then
+    mapfile -t REPOS < <(_enumerate_gitlab_group "$TARGET_ORG")
+  fi
+fi
+
+info "Repos to check: ${#REPOS[@]}"
+
+# ── GitHub: GraphQL prefetch branch + SHA ─────────────────────────────────────
+declare -A _BRANCH_CACHE=()
+declare -A _SHA_CACHE=()
+
+_prefetch_github_metadata() {
+  local owner="$1"; shift
+  local repos=("$@")
+  local total="${#repos[@]}"
+  local page_size=100
+  local offset=0
+
+  while (( offset < total )); do
+    local aliases=""
+    local i
+    for (( i=offset; i < offset+page_size && i < total; i++ )); do
+      local r="${repos[$i]}"
+      local safe
+      safe=$(echo "$r" | tr '-' '_' | tr '.' '_')
+      aliases+="r_${safe}: repository(owner: \"${owner}\", name: \"${r}\") { defaultBranchRef { name target { oid } } } "
+    done
+
+    local gql_result
+    gql_result=$(curl -sf \
+      -H "Authorization: token ${TOKEN}" \
+      -H "Content-Type: application/json" \
+      "${API_URL}/graphql" \
+      -d "{\"query\":\"{ ${aliases} }\"}" \
+      2>/dev/null || echo "{}")
+
+    python3 - <<PYEOF
+import json, sys
+result = json.loads('''${gql_result}''')
+data = result.get("data") or {}
+for key, val in data.items():
+    if not val:
+        continue
+    repo_name = key[2:].replace("_", "-")
+    ref = (val.get("defaultBranchRef") or {})
+    branch = ref.get("name") or "main"
+    sha = (ref.get("target") or {}).get("oid") or ""
+    print(f"{repo_name}\t{branch}\t{sha}")
+PYEOF
+
+    (( offset += page_size ))
+  done
+}
+
+if [[ "$PLATFORM" == "github" && "${#REPOS[@]}" -gt 0 ]]; then
+  info "Prefetching branch + SHA for ${#REPOS[@]} repos via GraphQL…"
+  while IFS=$'\t' read -r _repo _branch _sha; do
+    _BRANCH_CACHE["$_repo"]="$_branch"
+    _SHA_CACHE["$_repo"]="$_sha"
+  done < <(_prefetch_github_metadata "$TARGET_ORG" "${REPOS[@]}")
+  info "Prefetch complete (${#_BRANCH_CACHE[@]} repos resolved)"
+fi
+
+# ── Check CI per repo ─────────────────────────────────────────────────────────
+failing_repos="[]"
+checked=0
+skipped=0
+
+_check_github_repo() {
+  local repo="$1"
+  local full_repo="${TARGET_ORG}/${repo}"
+
+  local default_branch="${_BRANCH_CACHE[$repo]:-main}"
+  local sha="${_SHA_CACHE[$repo]:-}"
+
+  if [[ -z "$sha" ]]; then
+    (( skipped++ )) || true
+    return
+  fi
+  (( checked++ )) || true
+
+  local checks_json
+  checks_json=$(gh_get "${API_URL}/repos/${full_repo}/commits/${sha}/check-runs?per_page=100") || checks_json="{}"
+  local failing_checks
+  failing_checks=$(echo "$checks_json" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+runs = data.get('check_runs', [])
+bad = [r['name'] for r in runs
+       if r.get('conclusion') in ('failure','action_required','timed_out','cancelled')
+       and r.get('status') == 'completed']
+print(json.dumps(bad))
+" 2>/dev/null || echo "[]")
+
+  local statuses_json
+  statuses_json=$(gh_get "${API_URL}/repos/${full_repo}/commits/${sha}/statuses?per_page=100") || statuses_json="[]"
+  local failing_statuses
+  failing_statuses=$(echo "$statuses_json" | python3 -c "
+import json, sys
+statuses = json.load(sys.stdin)
+seen = {}
+for s in statuses:
+    ctx = s.get('context','')
+    if ctx not in seen:
+        seen[ctx] = s.get('state','')
+bad = [ctx for ctx, state in seen.items() if state in ('failure','error')]
+print(json.dumps(bad))
+" 2>/dev/null || echo "[]")
+
+  local all_failures
+  all_failures=$(python3 -c "
+import json
+a = json.loads('${failing_checks}')
+b = json.loads('${failing_statuses}')
+print(json.dumps(sorted(set(a + b))))
+" 2>/dev/null || echo "[]")
+
+  local failure_count
+  failure_count=$(echo "$all_failures" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))" 2>/dev/null || echo 0)
+  local commit_url="https://github.com/${full_repo}/commit/${sha}"
+
+  if (( failure_count > 0 )); then
+    warn "${full_repo}: ${failure_count} failure(s) on ${sha:0:7}"
+    failing_repos=$(echo "$failing_repos" | python3 -c "
+import json, sys
+lst = json.load(sys.stdin)
+lst.append({
+  'repo':      '${repo}',
+  'full_repo': '${full_repo}',
+  'platform':  'github',
+  'branch':    '${default_branch}',
+  'sha':       '${sha}',
+  'sha_short': '${sha:0:7}',
+  'url':       '${commit_url}',
+  'failures':  json.loads('''${all_failures}''')
+})
+print(json.dumps(lst))
+" 2>/dev/null || echo "$failing_repos")
+  else
+    ok "${full_repo}: green on ${sha:0:7}"
+  fi
+}
+
+_check_gitlab_repo() {
+  local repo="$1"
+  local group_path="${TARGET_ORG}/${repo}"
+  local encoded_path
+  encoded_path=$(python3 -c "import urllib.parse; print(urllib.parse.quote('${group_path}', safe=''))")
+
+  # Get default branch + latest pipeline
+  local project_json
+  project_json=$(curl -sf \
+    -H "Authorization: Bearer ${TOKEN}" \
+    "${API_URL}/api/v4/projects/${encoded_path}" \
+    2>/dev/null || echo "{}")
+
+  local default_branch
+  default_branch=$(echo "$project_json" | python3 -c \
+    "import json,sys; print(json.load(sys.stdin).get('default_branch','main'))" 2>/dev/null || echo "main")
+
+  local pipelines_json
+  pipelines_json=$(curl -sf \
+    -H "Authorization: Bearer ${TOKEN}" \
+    "${API_URL}/api/v4/projects/${encoded_path}/pipelines?ref=${default_branch}&per_page=1" \
+    2>/dev/null || echo "[]")
+
+  local pipeline_status sha commit_url
+  pipeline_status=$(echo "$pipelines_json" | python3 -c \
+    "import json,sys; d=json.load(sys.stdin); print(d[0].get('status','unknown') if d else 'no_pipeline')" \
+    2>/dev/null || echo "unknown")
+  sha=$(echo "$pipelines_json" | python3 -c \
+    "import json,sys; d=json.load(sys.stdin); print(d[0].get('sha','') if d else '')" \
+    2>/dev/null || echo "")
+  commit_url="${API_URL}/${group_path}/-/commit/${sha}"
+
+  (( checked++ )) || true
+
+  # failed, canceled, skipped are non-green; success/passed = green
+  if [[ "$pipeline_status" =~ ^(failed|canceled)$ ]]; then
+    warn "${group_path}: pipeline ${pipeline_status} on ${sha:0:7}"
+    failing_repos=$(echo "$failing_repos" | python3 -c "
+import json, sys
+lst = json.load(sys.stdin)
+lst.append({
+  'repo':      '${repo}',
+  'full_repo': '${group_path}',
+  'platform':  'gitlab',
+  'branch':    '${default_branch}',
+  'sha':       '${sha}',
+  'sha_short': '${sha:0:7}',
+  'url':       '${commit_url}',
+  'failures':  ['pipeline:${pipeline_status}']
+})
+print(json.dumps(lst))
+" 2>/dev/null || echo "$failing_repos")
+  else
+    ok "${group_path}: ${pipeline_status} on ${sha:0:7}"
+  fi
+}
+
+# ── Main loop ─────────────────────────────────────────────────────────────────
+for repo in "${REPOS[@]}"; do
+  [[ "$PLATFORM" == "github" ]] && { budget_check "$repo" || break; }
+
+  if [[ -n "$REPO_FILTER" && "$repo" != *"$REPO_FILTER"* ]]; then
+    continue
+  fi
+
+  case "$PLATFORM" in
+    github) _check_github_repo "$repo" ;;
+    gitlab) _check_gitlab_repo "$repo" ;;
+  esac
+done
+
+info "Checked: ${checked} | Failing: $(echo "$failing_repos" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))" 2>/dev/null || echo '?') | Skipped: ${skipped}"
+
+echo "$failing_repos"

--- a/scripts/list-ci-targets.py
+++ b/scripts/list-ci-targets.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""
+scripts/list-ci-targets.py — emit enabled CI check targets as JSON for
+the check-ci.yml matrix job.
+
+Usage:
+  python3 scripts/list-ci-targets.py [--target-id ID]
+
+Reads config/ci-check-targets.yml and prints a JSON array of enabled
+targets, optionally filtered to a single target ID.
+"""
+import json
+import os
+import sys
+import yaml
+
+config_path = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "config", "ci-check-targets.yml"
+)
+
+with open(config_path) as f:
+    data = yaml.safe_load(f)
+
+filt = ""
+if len(sys.argv) > 2 and sys.argv[1] == "--target-id":
+    filt = sys.argv[2].strip()
+
+out = []
+for t in (data.get("targets") or []):
+    if not t.get("enabled", True):
+        continue
+    if filt and t["id"] != filt:
+        continue
+    out.append({
+        "id":               t["id"],
+        "platform":         t["platform"],
+        "org":              t.get("org", t.get("group", "")),
+        "subgroups_config": t.get("subgroups_config", ""),
+        "token_secret":     t.get("token_secret", "SYNC_TOKEN"),
+        "api_url":          t.get("api_url", ""),
+    })
+
+print(json.dumps(out))


### PR DESCRIPTION
## What changed

Replaces `check-osp-ci.sh` and `check-ooc-ci.sh` with a single configurable engine driven by `config/ci-check-targets.yml`. Adding a new platform or org to CI checking is now a config-only change.

**New files:**
- `scripts/check-ci.sh` — platform-agnostic checker. GitHub targets use a GraphQL prefetch for branch+SHA, then REST for check-runs/statuses. GitLab targets use the pipeline API.
- `scripts/list-ci-targets.py` — emits enabled targets as JSON for the matrix job.
- `config/ci-check-targets.yml` — 5 targets: `interested-deving-1896`, `osp-github`, `ooc-github` (GitHub), `osp-gitlab`, `ooc-gitlab` (GitLab).
- `.github/workflows/check-ci.yml` — matrix workflow; one parallel job per enabled target.

**Modified:**
- `check-osp-ci.yml` + `check-ooc-ci.yml` — stubbed to delegate to `check-ci.yml`. Schedules and `workflow_run` triggers preserved for continuity.
- `config/gitlab-mirror-sources.yml` — `ci_check` / `ci_check_gitlab` flags added to OSP and OOC mirror legs.
- `config/workflow-priority-tiers.yml` — `Check CI Status` at tier 3; fixed missing `tier: 3` on `Check OSP-Bound CI Status`.
- `config/workflow-quota-costs.yml` — `Check CI Status` entry added (min_quota: 300, high: 900 for all 5 targets).
- `config/workflow-sync.yml` — `check-ci.yml` registered; stubs noted as deprecated.

## Type

- [x] New feature / workflow
- [x] Refactor / cleanup

## Checklist

- [x] Validator scripts pass (`python3 scripts/validate-workflow-guards.py` — 108 workflows, 109 quota-cost entries verified)
- [x] Config files validated
- [x] No secrets or tokens committed
