### PR TITLE
perf: quota reduction + reliability improvements

### DIFF
--- a/.github/workflows/check-accessibility.yml
+++ b/.github/workflows/check-accessibility.yml
@@ -59,6 +59,15 @@ jobs:
         with:
           token: ${{ secrets.SYNC_TOKEN }}
 
+      - name: Cache npm global packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-accessibility-${{ hashFiles('**/package-lock.json', '**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-accessibility-
+            ${{ runner.os }}-npm-
+
       - name: Install accessibility tools
         run: |
           sudo apt-get update -qq

--- a/.github/workflows/critical-deploy-all.yml
+++ b/.github/workflows/critical-deploy-all.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           token: ${{ secrets.SYNC_TOKEN }}
 
       - name: Critical deploy — Interested-Deving-1896
@@ -141,7 +141,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           token: ${{ secrets.SYNC_TOKEN }}
 
       - name: Critical deploy — OSP
@@ -177,7 +177,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           token: ${{ secrets.SYNC_TOKEN }}
 
       - name: Critical deploy — OOC
@@ -213,7 +213,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           token: ${{ secrets.SYNC_TOKEN }}
 
       - name: Critical deploy — GitLab

--- a/.github/workflows/critical-deploy-github-ooc.yml
+++ b/.github/workflows/critical-deploy-github-ooc.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           token: ${{ secrets.SYNC_TOKEN }}
 
       - name: Critical deploy — OOC

--- a/.github/workflows/critical-deploy-github-osp.yml
+++ b/.github/workflows/critical-deploy-github-osp.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           token: ${{ secrets.SYNC_TOKEN }}
 
       - name: Critical deploy — OSP

--- a/.github/workflows/critical-deploy-gitlab.yml
+++ b/.github/workflows/critical-deploy-gitlab.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           token: ${{ secrets.SYNC_TOKEN }}
 
       - name: GitLab critical deploy

--- a/.github/workflows/critical-deploy-stub.yml
+++ b/.github/workflows/critical-deploy-stub.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           token: ${{ secrets.SYNC_TOKEN }}
 
       # ── TODO: Guard step — remove once the script is fully implemented ──────

--- a/.github/workflows/critical-deploy.yml
+++ b/.github/workflows/critical-deploy.yml
@@ -122,7 +122,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           token: ${{ secrets.SYNC_TOKEN }}
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Configure git
         run: |

--- a/.github/workflows/full-audit.yml
+++ b/.github/workflows/full-audit.yml
@@ -42,6 +42,16 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Cache pip packages
+        if: steps.quota.outputs.skip == 'false'
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-pyyaml-${{ hashFiles('**/requirements*.txt', '**/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-pyyaml-
+            ${{ runner.os }}-pip-
+
       - name: Install dependencies
         if: steps.quota.outputs.skip == 'false'
         run: pip install pyyaml --quiet

--- a/.github/workflows/full-chain-flush.yml
+++ b/.github/workflows/full-chain-flush.yml
@@ -355,11 +355,11 @@ jobs:
               number_of_steps: 18
               current_step: 11
 
-      # ── Stage 12: Check OSP-bound CI (GitHub OSP) ────────────────────────
-      - name: "Stage 12: Check OSP-bound CI + trigger resolver"
+      # ── Stage 12: Check CI across all targets + trigger resolver ─────────
+      - name: "Stage 12: Check CI status + trigger resolver"
         if: ${{ inputs.dry_run != true }}
         run: |
-          bash scripts/dispatch-and-wait.sh check-osp-ci.yml 90 '{"dry_run":"false","repo_filter":""}'
+          bash scripts/dispatch-and-wait.sh check-ci.yml 90 '{"dry_run":"false","repo_filter":"","target_id":""}'
           rc=$?; [[ $rc -eq 2 ]] && echo "Stage cancelled by queue-manager — continuing." || exit $rc
 
       - name: "ActivitySmith: stage 12 done"

--- a/.github/workflows/pre-flush-prep.yml
+++ b/.github/workflows/pre-flush-prep.yml
@@ -24,7 +24,7 @@ name: Pre-Flush Prep
 #             the README pass in Stage 5 of the flush.
 #
 #   Step 6 — Resolve CI failures
-#             Run resolve-failures.yml across all three orgs so the
+#             Run resolve-ci.yml across all configured targets so the
 #             flush starts with a healthy CI baseline. Skippable via
 #             skip_resolve_failures when quota is tight.
 #
@@ -177,10 +177,10 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           if [[ "${DRY_RUN}" == "true" ]]; then
-            echo "[dry-run] Would dispatch resolve-failures.yml"
+            echo "[dry-run] Would dispatch resolve-ci.yml"
           else
-            bash scripts/dispatch-and-wait.sh resolve-failures.yml 120 '{"dry_run":false,"repo_filter":"","scan_owners":"","watchdog_repo":""}'
-            rc=$?; [[ $rc -eq 2 ]] && echo "resolve-failures cancelled by queue-manager — continuing." || exit $rc
+            bash scripts/dispatch-and-wait.sh resolve-ci.yml 120 '{"dry_run":false,"repo_filter":"","target_id":""}'
+            rc=$?; [[ $rc -eq 2 ]] && echo "resolve-ci cancelled by queue-manager — continuing." || exit $rc
           fi
 
       # ── Step 7: Quota gate ──────────────────────────────────────────────────

--- a/.github/workflows/sync-shell-tools.yml
+++ b/.github/workflows/sync-shell-tools.yml
@@ -59,7 +59,7 @@ jobs:
         if: steps.quota.outputs.skip == 'false'
         with:
           token: ${{ secrets.SYNC_TOKEN }}
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Sync entrypoints into vendor/shell-tools/
         if: steps.quota.outputs.skip == 'false'

--- a/DOCS/workflow-scheduling.md
+++ b/DOCS/workflow-scheduling.md
@@ -26,11 +26,14 @@ is below this, the workflow skips itself and waits for the next reset.
 
 ## Time format note
 
-All times in this document are shown as:
-**24h UTC / 12h UTC / 12h ET (EST UTC−5 / EDT UTC−4)**
+Per-workflow tables show two schedule columns:
+- **Schedule (UTC)** — 24h UTC, the authoritative cron time
+- **Schedule (EST)** — EST (UTC−5, Nov–Mar). Add 1h for EDT (UTC−4, Mar–Nov).
 
-ET offsets: subtract 5h for EST (Nov–Mar), subtract 4h for EDT (Mar–Nov).
-Example: `09:05 UTC / 9:05 AM UTC / 4:05 AM ET (EDT)`.
+Example: `09:05 UTC` = `4:05 AM EST` = `5:05 AM EDT`.
+
+The timing map and "Best manual dispatch windows" tables use the full
+`24h UTC / 12h UTC / 12h ET (EST/EDT)` format for completeness.
 
 ---
 
@@ -97,14 +100,14 @@ Hour (UTC)     12h UTC        ET (EDT/EST)    Workflows
 
 ### Core mirror chain
 
-| Workflow | Schedule | Quota mid | Quota high | Floor | Best window | Avoid |
-|---|---|---|---|---|---|---|
-| Mirror I-D-1896 → OSP | Every 6h at :13 | 80 | 200 | 300 | After 14:00 / 2:00 PM UTC / 10:00 AM ET reset | 00:00–06:00 UTC / 12–6 AM UTC / 8 PM–2 AM ET (busy) |
-| Mirror OSP → OOC | Every 6h at :45 | 80 | 200 | 300 | 32 min after mirror-to-osp completes | Before :13 slot |
-| Mirror Orgs | Daily 02:17 / 2:17 AM UTC / 10:17 PM ET | 60 | 150 | 200 | 02:00–04:00 / 2–4 AM UTC / 10 PM–12 AM ET | 06:xx (weekly burst) |
-| Mirror OSP → GitLab | Daily 01:23 / 1:23 AM UTC / 9:23 PM ET | 80 | 200 | 200 | 01:00–03:00 / 1–3 AM UTC / 9–11 PM ET | During mirror chain |
-| Mirror Releases | Every 12h at :03 (00:03 + 12:03) | 100 | 300 | 200 | 00:03 / 12:03 AM UTC / 8:03 PM ET or 12:03 / 12:03 PM UTC / 8:03 AM ET | During flush |
-| Mirror Artifacts | Daily 02:10 / 2:10 AM UTC / 10:10 PM ET | 80 | 200 | 200 | 02:00–04:00 / 2–4 AM UTC / 10 PM–12 AM ET | During flush |
+| Workflow | Schedule (UTC) | Schedule (EST) | Quota mid | Quota high | Floor | Best window (UTC) | Avoid |
+|---|---|---|---|---|---|---|---|
+| Mirror I-D-1896 → OSP | Every 6h at :13 | Every 6h at :13 | 80 | 200 | 300 | After 14:00 reset | 00:00–06:00 (busy) |
+| Mirror OSP → OOC | Every 6h at :45 | Every 6h at :45 | 80 | 200 | 300 | 32 min after mirror-to-osp | Before :13 slot |
+| Mirror Orgs | Daily 02:17 | Daily 9:17 PM | 60 | 150 | 200 | 02:00–04:00 | 06:xx (weekly burst) |
+| Mirror OSP → GitLab | Daily 01:23 | Daily 8:23 PM | 80 | 200 | 200 | 01:00–03:00 | During mirror chain |
+| Mirror Releases | Every 12h at :03 (00:03 + 12:03) | 7:03 PM + 7:03 AM | 100 | 300 | 200 | 00:03 or 12:03 | During flush |
+| Mirror Artifacts | Daily 02:10 | Daily 9:10 PM | 80 | 200 | 200 | 02:00–04:00 | During flush |
 
 **Mirror chain dependency order:** Mirror I-D-1896 → OSP must complete before
 Mirror OSP → OOC. The :13/:45 stagger (32 min gap) is intentional — do not
@@ -114,73 +117,73 @@ reduce this gap when manually dispatching both.
 
 ### CI check + resolver
 
-| Workflow | Schedule | Quota mid | Quota high | Floor | Best window | Avoid |
-|---|---|---|---|---|---|---|
-| Check CI Status | Daily 09:05 / 9:05 AM UTC / 5:05 AM ET | 300 | 900 | 1500 | 09:00–11:00 / 9–11 AM UTC / 5–7 AM ET | During flush |
-| Resolve CI Failures (Agnostic) | Daily 07:43 / 7:43 AM UTC / 3:43 AM ET | 120 | 400 | 100 | 07:00–09:00 / 7–9 AM UTC / 3–5 AM ET | During flush |
-| Check Shell Tools CI | Daily 09:30 / 9:30 AM UTC / 5:30 AM ET | 50 | 100 | 200 | 09:00–11:00 / 9–11 AM UTC / 5–7 AM ET | — |
+| Workflow | Schedule (UTC) | Schedule (EST) | Quota mid | Quota high | Floor | Best window (UTC) | Avoid |
+|---|---|---|---|---|---|---|---|
+| Check CI Status | Daily 09:05 | 4:05 AM | 300 | 900 | 1500 | 09:00–11:00 | During flush |
+| Resolve CI Failures (Agnostic) | Daily 07:43 | 2:43 AM | 120 | 400 | 100 | 07:00–09:00 | During flush |
+| Check Shell Tools CI | Daily 09:30 | 4:30 AM | 50 | 100 | 200 | 09:00–11:00 | — |
 
 **Note:** Check CI Status requires a 1,500 quota floor — the highest of any
-workflow. If quota is below 1,500 at 09:05 UTC / 9:05 AM UTC / 5:05 AM ET,
-it skips and waits for the next day. Manually dispatch after the 14:00 UTC /
-2:00 PM UTC / 10:00 AM ET reset if you need it to run same-day.
+workflow. If quota is below 1,500 at 09:05 UTC (4:05 AM EST / 5:05 AM EDT),
+it skips and waits for the next day. Manually dispatch after the 14:00 UTC
+reset if you need it to run same-day.
 
 ---
 
 ### Sync operations
 
-| Workflow | Schedule | Quota mid | Quota high | Floor | Best window | Avoid |
-|---|---|---|---|---|---|---|
-| Sync All Forks | Via full-chain-flush | 200 | 500 | 500 | 04:00–08:00 / 4–8 AM UTC / 12–4 AM ET | During mirror chain |
-| Sync Registered Imports | Daily 04:55 / 4:55 AM UTC / 12:55 AM ET | 45 | 100 | 200 | 04:00–06:00 / 4–6 AM UTC / 12–2 AM ET | — |
-| Sync btrfs-devel Branches | Daily 05:02 / 5:02 AM UTC / 1:02 AM ET | 30 | 80 | 100 | 05:00–07:00 / 5–7 AM UTC / 1–3 AM ET | — |
-| Sync pieroproietti Forks | Daily 01:07 / 1:07 AM UTC / 9:07 PM ET | 60 | 150 | 200 | 01:00–03:00 / 1–3 AM UTC / 9–11 PM ET | — |
-| Sync to GitLab Variant | Daily 01:50 / 1:50 AM UTC / 9:50 PM ET | 40 | 100 | 100 | 01:00–03:00 / 1–3 AM UTC / 9–11 PM ET | — |
-| Setup OSP Mirror Workflows | Daily 02:45 / 2:45 AM UTC / 10:45 PM ET | 80 | 200 | 200 | 02:00–04:00 / 2–4 AM UTC / 10 PM–12 AM ET | — |
-| Git Platform Sync | Daily 04:27 + 09:23 / 4:27 AM + 9:23 AM UTC | 60 | 150 | 200 | 04:00 or 09:00 / 4 AM or 9 AM UTC | — |
-| Upstream PRs from OSP+OOC | Daily 03:33 / 3:33 AM UTC / 11:33 PM ET | 80 | 200 | 300 | 03:00–05:00 / 3–5 AM UTC / 11 PM–1 AM ET | — |
-| Upstream Direct Commits | Daily 03:47 / 3:47 AM UTC / 11:47 PM ET | 80 | 200 | 300 | After upstream-prs (:33) | Before :33 slot |
+| Workflow | Schedule (UTC) | Schedule (EST) | Quota mid | Quota high | Floor | Best window (UTC) | Avoid |
+|---|---|---|---|---|---|---|---|
+| Sync All Forks | Via full-chain-flush | — | 200 | 500 | 500 | 04:00–08:00 | During mirror chain |
+| Sync Registered Imports | Daily 04:55 | 11:55 PM | 45 | 100 | 200 | 04:00–06:00 | — |
+| Sync btrfs-devel Branches | Daily 05:02 | 12:02 AM | 30 | 80 | 100 | 05:00–07:00 | — |
+| Sync pieroproietti Forks | Daily 01:07 | 8:07 PM | 60 | 150 | 200 | 01:00–03:00 | — |
+| Sync to GitLab Variant | Daily 01:50 | 8:50 PM | 40 | 100 | 100 | 01:00–03:00 | — |
+| Setup OSP Mirror Workflows | Daily 02:45 | 9:45 PM | 80 | 200 | 200 | 02:00–04:00 | — |
+| Git Platform Sync | Daily 04:27 + 09:23 | 11:27 PM + 4:23 AM | 60 | 150 | 200 | 04:00 or 09:00 | — |
+| Upstream PRs from OSP+OOC | Daily 03:33 | 10:33 PM | 80 | 200 | 300 | 03:00–05:00 | — |
+| Upstream Direct Commits | Daily 03:47 | 10:47 PM | 80 | 200 | 300 | After upstream-prs (:33) | Before :33 slot |
 
 ---
 
 ### README + badge operations
 
-| Workflow | Schedule | Quota mid | Quota high | Floor | Best window | Avoid |
-|---|---|---|---|---|---|---|
-| Update READMEs | Via flush | 150 | 400 | 500 | 10:00–12:00 / 10 AM–12 PM UTC / 6–8 AM ET | During mirror chain |
-| Create Missing READMEs | Via flush | 100 | 300 | 300 | 10:00–12:00 / 10 AM–12 PM UTC / 6–8 AM ET | — |
-| Inject Built-with-Ona Badges | Every 2 days 08:15 / 8:15 AM UTC / 4:15 AM ET | 120 | 300 | 300 | 08:00–10:00 / 8–10 AM UTC / 4–6 AM ET | — |
-| Translate READMEs | Every 2 days 10:43 / 10:43 AM UTC / 6:43 AM ET | 150 | 400 | 300 | 10:00–12:00 / 10 AM–12 PM UTC / 6–8 AM ET | — |
-| Translate Docs | Every 2 days 11:15 / 11:15 AM UTC / 7:15 AM ET | 100 | 250 | 200 | 11:00–13:00 / 11 AM–1 PM UTC / 7–9 AM ET | — |
-| Reconcile Org References | Every 2 days 05:50 / 5:50 AM UTC / 1:50 AM ET | 80 | 200 | 200 | 05:00–07:00 / 5–7 AM UTC / 1–3 AM ET | — |
+| Workflow | Schedule (UTC) | Schedule (EST) | Quota mid | Quota high | Floor | Best window (UTC) | Avoid |
+|---|---|---|---|---|---|---|---|
+| Update READMEs | Via flush | — | 150 | 400 | 500 | 10:00–12:00 | During mirror chain |
+| Create Missing READMEs | Via flush | — | 100 | 300 | 300 | 10:00–12:00 | — |
+| Inject Built-with-Ona Badges | Every 2 days 08:15 | 3:15 AM | 120 | 300 | 300 | 08:00–10:00 | — |
+| Translate READMEs | Every 2 days 10:43 | 5:43 AM | 150 | 400 | 300 | 10:00–12:00 | — |
+| Translate Docs | Every 2 days 11:15 | 6:15 AM | 100 | 250 | 200 | 11:00–13:00 | — |
+| Reconcile Org References | Every 2 days 05:50 | 12:50 AM | 80 | 200 | 200 | 05:00–07:00 | — |
 
 ---
 
 ### Infrastructure / quota management
 
-| Workflow | Schedule | Quota mid | Quota high | Floor | Notes |
-|---|---|---|---|---|---|
-| Queue Manager | Every 30 min (all hours) | 15 | 30 | 50 | Never manually dispatch — runs automatically |
-| Quota Reserve | Every 30 min (all hours) | 15 | 30 | 50 | Never manually dispatch |
-| Rate-Limit Re-trigger | Every 6h | 30 | 80 | 100 | Fires automatically after quota recovery |
-| Auto-merge PRs | Every 6h at :55 (00:55 / 12:55 AM, 06:55 / 6:55 AM, 12:55 / 12:55 PM, 18:55 / 6:55 PM UTC) | 30 | 80 | 100 | Safe to dispatch any time |
-| Rebase PRs | Every 2 days 05:10 / 5:10 AM UTC / 1:10 AM ET | 40 | 100 | 100 | Safe to dispatch any time |
+| Workflow | Schedule (UTC) | Schedule (EST) | Quota mid | Quota high | Floor | Notes |
+|---|---|---|---|---|---|---|
+| Queue Manager | Every 30 min | Every 30 min | 15 | 30 | 50 | Never manually dispatch — runs automatically |
+| Quota Reserve | Every 30 min | Every 30 min | 15 | 30 | 50 | Never manually dispatch |
+| Rate-Limit Re-trigger | Every 6h | Every 6h | 30 | 80 | 100 | Fires automatically after quota recovery |
+| Auto-merge PRs | Every 6h at :55 (00:55, 06:55, 12:55, 18:55) | 7:55 PM, 1:55 AM, 7:55 AM, 1:55 PM | 30 | 80 | 100 | Safe to dispatch any time |
+| Rebase PRs | Every 2 days 05:10 | 12:10 AM | 40 | 100 | 100 | Safe to dispatch any time |
 
 ---
 
 ### Heavy / manual-only workflows
 
-| Workflow | Trigger | Quota mid | Quota high | Floor | Best window |
-|---|---|---|---|---|---|
-| Full Chain Flush | Manual / daily 05:17 / 5:17 AM UTC / 1:17 AM ET | 400 | 1000 | 1000 | 04:00–08:00 / 4–8 AM UTC / 12–4 AM ET |
-| Pre-Flush Prep | Manual only | 50 | 150 | 3000 | 14:05 / 2:05 PM UTC / 10:05 AM ET (5 min after reset) |
-| Critical Deploy | Manual only | 100 | 300 | 500 | Any time — bypasses queue |
-| Onboard Repo | Manual only | 80 | 200 | 300 | Any time |
-| Add Mirror Repo | Manual only | 60 | 150 | 200 | Any time |
+| Workflow | Trigger | Schedule (EST) | Quota mid | Quota high | Floor | Best window (UTC) |
+|---|---|---|---|---|---|---|
+| Full Chain Flush | Manual / daily 05:17 | 12:17 AM | 400 | 1000 | 1000 | 04:00–08:00 |
+| Pre-Flush Prep | Manual only | — | 50 | 150 | 3000 | 14:05 (5 min after reset) |
+| Critical Deploy | Manual only | — | 100 | 300 | 500 | Any time — bypasses queue |
+| Onboard Repo | Manual only | — | 80 | 200 | 300 | Any time |
+| Add Mirror Repo | Manual only | — | 60 | 150 | 200 | Any time |
 
 **Pre-Flush Prep** has the highest floor (3,000) because it validates config,
 merges PRs, and then dispatches the full flush chain. Trigger it immediately
-after the 14:00 UTC / 2:00 PM UTC / 10:00 AM ET reset for maximum headroom.
+after the 14:00 UTC (9:00 AM EST / 10:00 AM EDT) reset for maximum headroom.
 
 ---
 

--- a/config/workflow-priority-tiers.yml
+++ b/config/workflow-priority-tiers.yml
@@ -32,7 +32,7 @@ tiers:
   - name: "Critical Deploy — All"
     tier: 1
   - name: "Critical Deploy — Stub (TODO)"
-    tier: 1
+    tier: 4
   - name: "GitLab Critical Deploy"
     tier: 1
   - name: "Cancel Stale Runs"
@@ -103,6 +103,8 @@ tiers:
   # Default tier for workflows not listed here.
   - name: "Create Missing READMEs"
     tier: 3
+  - name: "Create OOC GitLab Subgroups"
+    tier: 4
   - name: "Update READMEs"
     tier: 3
   - name: "Validate README Render"

--- a/config/workflow-quota-costs.yml
+++ b/config/workflow-quota-costs.yml
@@ -139,6 +139,15 @@ workflows:
   notes: Similar to Update READMEs but only for repos missing README
   synopsis: Creates README.md from the standard template for OSP-bound repos that have no README, with placeholder sections
     for human-owned content.
+- name: Create OOC GitLab Subgroups
+  min_quota: 50
+  cost_low: 5
+  cost_mid: 20
+  cost_high: 50
+  basis: code-audit
+  notes: One-shot manual workflow. Creates GitLab subgroups under openos-project-ooc, then opens a PR to fill in the generated
+    IDs in config/gitlab-subgroups-ooc.yml.
+  synopsis: Creates the GitLab subgroup structure for OpenOS-Project-Ecosystem-OOC and records the resulting subgroup IDs.
 - name: Inject Built-with-Ona Badges
   min_quota: 200
   cost_low: 5
@@ -473,14 +482,6 @@ workflows:
     calls at high end.
 
     '
-- name: Cancel Runs After Token Rotation
-  min_quota: 50
-  cost_low: 5
-  cost_mid: 20
-  cost_high: 50
-  basis: code-audit
-  synopsis: Cancels queued and in-progress runs that hold the old (now-invalid) token immediately after Rotate Secret Token
-    completes, preventing Bad credentials failures.
 - name: Cancel Stale Runs
   min_quota: 100
   cost_low: 10
@@ -761,14 +762,6 @@ workflows:
   basis: code-audit
   synopsis: AI-guided README authoring — writes or rewrites a README for a specific repo according to custom instructions
     (audience, tone, sections), respecting existing human-owned markers.
-- name: Rate Limit Status
-  min_quota: 10
-  cost_low: 2
-  cost_mid: 5
-  cost_high: 10
-  basis: code-audit
-  synopsis: Queries current rate limit status for GitHub REST, GitLab, and GitHub Models APIs. Exits non-zero if any platform
-    is below 10% remaining.
 - name: Rebuild LTS Branch (penguins-eggs)
   min_quota: 50
   cost_low: 5

--- a/scripts/apply-brand.py
+++ b/scripts/apply-brand.py
@@ -3,7 +3,8 @@
 Applies brand substitutions to a file's content.
 
 Reads config/brand.yml and replaces {{FSA_*}} tokens in the given file.
-Used by sync-template.sh when propagating files to branded consumer repos.
+Standalone utility — call directly when propagating files to branded consumer
+repos. Not currently invoked by sync-template.sh.
 
 Usage:
   python3 scripts/apply-brand.py <file_path>

--- a/scripts/reconcile-org-refs.sh
+++ b/scripts/reconcile-org-refs.sh
@@ -908,18 +908,86 @@ gl_search_and_patch() {
   done
 }
 
-# Get GitLab project ID for a namespace path
+# Caches populated by gl_prefetch_projects: ns_path → id, ns_path → default_branch
+declare -A _GL_PROJECT_ID=()
+declare -A _GL_DEFAULT_BRANCH=()
+
+# Prefetch GitLab project IDs and default branches for all repos in one GraphQL
+# call (~2 REST calls/repo × N repos → 1 GraphQL call). Populates _GL_PROJECT_ID
+# and _GL_DEFAULT_BRANCH keyed by full namespace path (openos-project/sg/repo).
+gl_prefetch_projects() {
+  local -a ns_paths=("$@")
+  [[ "${#ns_paths[@]}" -eq 0 ]] && return 0
+
+  # Build a GraphQL query with one alias per namespace path.
+  # GitLab GraphQL: project(fullPath: "...") { id defaultBranch }
+  local query_parts=""
+  for ns_path in "${ns_paths[@]}"; do
+    [[ -z "$ns_path" ]] && continue
+    # Alias: replace / and - and . with _ for valid GraphQL identifier
+    local alias
+    alias=$(echo "$ns_path" | tr '/.-' '___')
+    query_parts+="  ${alias}: project(fullPath: \"${ns_path}\") { id defaultBranch }"$'\n'
+  done
+  [[ -z "$query_parts" ]] && return 0
+
+  local payload response
+  payload=$(python3 -c "import json,sys; print(json.dumps({'query':'{ '+sys.argv[1]+' }'}))" "$query_parts")
+  response=$(curl -sf \
+    -X POST "https://gitlab.com/api/graphql" \
+    -H "Authorization: Bearer ${GITLAB_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "$payload" 2>/dev/null) || { echo "GitLab GraphQL prefetch failed — will use REST fallback" >&2; return 0; }
+
+  for ns_path in "${ns_paths[@]}"; do
+    [[ -z "$ns_path" ]] && continue
+    local alias
+    alias=$(echo "$ns_path" | tr '/.-' '___')
+    local proj_gid default_branch
+    proj_gid=$(echo "$response" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+p=d.get('data',{}).get('$alias') or {}
+print(p.get('id','') if p else '')
+" 2>/dev/null || true)
+    default_branch=$(echo "$response" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+p=d.get('data',{}).get('$alias') or {}
+print(p.get('defaultBranch','main') if p else 'main')
+" 2>/dev/null || echo "main")
+    if [[ -n "$proj_gid" && "$proj_gid" != "null" ]]; then
+      # GitLab GraphQL returns gid://gitlab/Project/NNN — extract numeric ID
+      local numeric_id
+      numeric_id="${proj_gid##*/}"
+      _GL_PROJECT_ID["$ns_path"]="$numeric_id"
+      _GL_DEFAULT_BRANCH["$ns_path"]="${default_branch:-main}"
+    fi
+  done
+  echo "GitLab GraphQL prefetch: cached ${#_GL_PROJECT_ID[@]}/${#ns_paths[@]} project IDs (1 API call)" >&2
+}
+
+# Get GitLab project ID for a namespace path (cache-first, REST fallback)
 gl_project_id() {
   local ns_path="$1"
+  local cached="${_GL_PROJECT_ID[$ns_path]:-}"
+  if [[ -n "$cached" ]]; then
+    echo "$cached"
+    return
+  fi
   local encoded
   encoded=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1],safe=''))" "$ns_path")
   gl_api_get "${GL_API}/projects/${encoded}" 2>/dev/null \
     | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null || true
 }
 
-# Get default branch for a GitLab project
+# Get default branch for a GitLab project (cache-first, REST fallback)
 gl_default_branch() {
-  local project_id="$1"
+  local project_id="$1" ns_path="${2:-}"
+  if [[ -n "$ns_path" ]]; then
+    local cached="${_GL_DEFAULT_BRANCH[$ns_path]:-}"
+    [[ -n "$cached" ]] && echo "$cached" && return
+  fi
   gl_api_get "${GL_API}/projects/${project_id}" 2>/dev/null \
     | python3 -c "import sys,json; print(json.load(sys.stdin).get('default_branch','main'))" 2>/dev/null \
     || echo "main"
@@ -931,6 +999,17 @@ echo "  GitLab reconcile pass (GitHub URLs → GitLab paths)"
 echo "========================================================"
 echo ""
 
+# Prefetch all GitLab project IDs + default branches in one GraphQL call
+# (~2 REST calls/repo × N repos → 1 GraphQL call, saving ~100 REST calls).
+_gl_ns_paths=()
+for _repo in $OSP_REPOS; do
+  [ "$_repo" = "fork-sync-all" ] && continue
+  [[ -n "$REPO_FILTER" && "$_repo" != *"$REPO_FILTER"* ]] && continue
+  repo_exists "$UPSTREAM_OWNER" "$_repo" || continue
+  _gl_ns_paths+=("$(gl_namespace_path "$_repo")")
+done
+[[ "${#_gl_ns_paths[@]}" -gt 0 ]] && gl_prefetch_projects "${_gl_ns_paths[@]}"
+
 for REPO in $OSP_REPOS; do
   [ "$REPO" = "fork-sync-all" ] && continue
   [[ -n "$REPO_FILTER" && "$REPO" != *"$REPO_FILTER"* ]] && continue
@@ -940,7 +1019,7 @@ for REPO in $OSP_REPOS; do
     continue
   fi
 
-  # Derive GitLab namespace path and get project ID
+  # Derive GitLab namespace path and get project ID (served from prefetch cache)
   GL_NS_PATH=$(gl_namespace_path "$REPO")
   GL_PROJECT_ID=$(gl_project_id "$GL_NS_PATH")
 
@@ -949,7 +1028,7 @@ for REPO in $OSP_REPOS; do
     continue
   fi
 
-  GL_BRANCH=$(gl_default_branch "$GL_PROJECT_ID")
+  GL_BRANCH=$(gl_default_branch "$GL_PROJECT_ID" "$GL_NS_PATH")
   GL_SELF_URL="gitlab.com/${GL_NS_PATH}"
 
   echo "=== $REPO (GitLab: ${GL_NS_PATH}) ==="

--- a/scripts/sync-forks.sh
+++ b/scripts/sync-forks.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 #
 # Syncs all GitLab forks in the openos-project group with their upstream.
-# Delegates to sync-all-forks.sh which handles the actual sync logic.
+#
+# Uses a single GitLab GraphQL call to enumerate all projects with an
+# importUrl (pull-mirror forks), then triggers a mirror refresh for each
+# via the REST mirror/pull endpoint. Replaces paginated REST enumeration
+# (~200 calls for a large group) with 1–3 GraphQL calls.
 #
 # Required CI variables:
 #   GITLAB_TOKEN  — PAT with api + write_repository scope
@@ -10,58 +14,117 @@ set -uo pipefail
 
 : "${GITLAB_TOKEN:?GITLAB_TOKEN is required}"
 
-# shellcheck disable=SC2034
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GL_GROUP="${GL_GROUP:-openos-project}"
+GL_GRAPHQL="https://gitlab.com/api/graphql"
+GL_API="https://gitlab.com/api/v4"
 
-# sync-all-forks.sh was written for GitHub; adapt for GitLab by setting
-# the equivalent env vars it expects.
-export GL_TOKEN="${GITLAB_TOKEN}"
-export GL_GROUP="${GL_GROUP:-openos-project}"
+info() { echo "[sync-forks] $*" >&2; }
 
 echo "Starting fork sync for group: ${GL_GROUP}"
 
-# Enumerate all projects in the group that have an import_url (i.e. are forks
-# of an external repo) and trigger a re-import / pull-mirror refresh via API.
-API="https://gitlab.com/api/v4"
-PAGE=1
+# Fetch all projects with an importUrl in one GraphQL call (cursor-paginated,
+# 100 projects per page). Replaces the paginated REST loop.
+projects_json=$(GL_GROUP="$GL_GROUP" GL_GRAPHQL="$GL_GRAPHQL" GITLAB_TOKEN="$GITLAB_TOKEN" \
+  python3 -c "
+import json, os, sys, urllib.request, urllib.error
+
+token   = os.environ['GITLAB_TOKEN']
+group   = os.environ['GL_GROUP']
+graphql = os.environ['GL_GRAPHQL']
+
+query = '''
+query(\$group: ID!, \$after: String) {
+  group(fullPath: \$group) {
+    projects(includeSubgroups: true, first: 100, after: \$after) {
+      pageInfo { hasNextPage endCursor }
+      nodes { id fullPath importUrl }
+    }
+  }
+}
+'''
+
+results = []
+after   = None
+
+while True:
+    variables = {'group': group, 'after': after}
+    payload   = json.dumps({'query': query, 'variables': variables}).encode()
+    req = urllib.request.Request(graphql, data=payload, headers={
+        'Authorization': 'Bearer ' + token,
+        'Content-Type':  'application/json',
+    })
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.load(resp)
+    except urllib.error.URLError as e:
+        print('GraphQL request failed: ' + str(e), file=sys.stderr)
+        sys.exit(1)
+    if 'errors' in data:
+        print('GraphQL errors: ' + str(data['errors']), file=sys.stderr)
+        sys.exit(1)
+    page = data['data']['group']['projects']
+    for node in page['nodes']:
+        if node.get('importUrl'):
+            results.append({
+                'id':   node['id'].split('/')[-1],
+                'name': node['fullPath'],
+                'import_url': node['importUrl'],
+            })
+    if not page['pageInfo']['hasNextPage']:
+        break
+    after = page['pageInfo']['endCursor']
+
+print(json.dumps(results))
+" 2>/dev/null || echo "[]")
+
+if [[ -z "$projects_json" || "$projects_json" == "[]" ]]; then
+  info "No projects with importUrl found in group ${GL_GROUP} — falling back to REST"
+  # REST fallback: paginate through group projects
+  PAGE=1
+  projects_json="[]"
+  while true; do
+    batch=$(curl -sf \
+      --header "PRIVATE-TOKEN: ${GITLAB_TOKEN}" \
+      "${GL_API}/groups/${GL_GROUP}/projects?include_subgroups=true&per_page=100&page=${PAGE}&with_statistics=false" \
+      || echo "[]")
+    count=$(echo "$batch" | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d))" 2>/dev/null || echo 0)
+    [ "$count" -eq 0 ] && break
+    projects_json=$(python3 -c "
+import json,sys
+existing = json.loads('$projects_json')
+batch = json.load(sys.stdin)
+for p in batch:
+    if p.get('import_url'):
+        existing.append({'id': str(p['id']), 'name': p['path_with_namespace'], 'import_url': p['import_url']})
+print(json.dumps(existing))
+" <<< "$batch")
+    ((PAGE++)) || true
+  done
+fi
+
 synced=0
 failed=0
 
-while true; do
-  projects=$(curl -sf \
+while IFS= read -r project; do
+  id=$(echo "$project"         | python3 -c "import json,sys; print(json.load(sys.stdin)['id'])")
+  name=$(echo "$project"       | python3 -c "import json,sys; print(json.load(sys.stdin)['name'])")
+  import_url=$(echo "$project" | python3 -c "import json,sys; print(json.load(sys.stdin)['import_url'])")
+
+  echo "Syncing ${name} from ${import_url} …"
+  http_code=$(curl -sf -o /dev/null -w "%{http_code}" \
+    --request POST \
     --header "PRIVATE-TOKEN: ${GITLAB_TOKEN}" \
-    "${API}/groups/${GL_GROUP}/projects?include_subgroups=true&per_page=100&page=${PAGE}&with_statistics=false")
+    "${GL_API}/projects/${id}/mirror/pull" 2>/dev/null || true)
 
-  count=$(echo "$projects" | jq 'length')
-  [ "$count" -eq 0 ] && break
-
-  while IFS= read -r project; do
-    id=$(echo "$project" | jq -r '.id')
-    name=$(echo "$project" | jq -r '.path_with_namespace')
-    import_url=$(echo "$project" | jq -r '.import_url // empty')
-
-    if [ -z "$import_url" ]; then
-      continue
-    fi
-
-    echo "Syncing ${name} from ${import_url} …"
-    http_code=$(curl -sf -o /dev/null -w "%{http_code}" \
-      --request POST \
-      --header "PRIVATE-TOKEN: ${GITLAB_TOKEN}" \
-      "${API}/projects/${id}/mirror/pull" 2>/dev/null || true)
-
-    if [ "$http_code" = "200" ] || [ "$http_code" = "201" ]; then
-      echo "  ✅ triggered"
-      ((synced++)) || true
-    else
-      # Pull mirroring requires Premium; fall back to manual clone+push
-      echo "  ⚠️  mirror API returned ${http_code} — skipping (pull mirroring may require Premium)"
-      ((failed++)) || true
-    fi
-  done < <(echo "$projects" | jq -c '.[]')
-
-  ((PAGE++)) || true
-done
+  if [ "$http_code" = "200" ] || [ "$http_code" = "201" ]; then
+    echo "  ✅ triggered"
+    ((synced++)) || true
+  else
+    # Pull mirroring requires Premium; fall back to manual clone+push
+    echo "  ⚠️  mirror API returned ${http_code} — skipping (pull mirroring may require Premium)"
+    ((failed++)) || true
+  fi
+done < <(echo "$projects_json" | python3 -c "import json,sys; [print(json.dumps(p)) for p in json.load(sys.stdin)]")
 
 echo ""
 echo "Done. synced=${synced} failed/skipped=${failed}"

--- a/scripts/sync-pieroproietti-gl-forks.sh
+++ b/scripts/sync-pieroproietti-gl-forks.sh
@@ -22,8 +22,43 @@ set -uo pipefail
 
 GL_API="https://gitlab.com/api/v4"
 
+# Source gh_get for GitHub API calls (retry + rate-limit backoff).
+# GH_TOKEN is optional here — only used for fetching GitHub release notes.
+GH_TOKEN="${GH_TOKEN:-}"
+if [[ -n "$GH_TOKEN" ]]; then
+  source "$(dirname "${BASH_SOURCE[0]}")/includes/gh-api.sh"
+fi
+
 info()  { echo "[sync] $*" >&2; }
 warn()  { echo "[warn] $*" >&2; }
+
+# gl_get <url> — GitLab REST GET with simple retry on transient errors (5xx/429).
+gl_get() {
+  local url="$1"
+  local attempt max_retries=3
+  for (( attempt=1; attempt<=max_retries; attempt++ )); do
+    local out http_code
+    out=$(curl -sf -w "\n__HTTP_CODE__:%{http_code}" \
+      --header "PRIVATE-TOKEN: ${GITLAB_TOKEN}" "$url" 2>/dev/null) || true
+    http_code=$(echo "$out" | grep -o '__HTTP_CODE__:[0-9]*' | cut -d: -f2)
+    local body
+    body=$(echo "$out" | grep -v '__HTTP_CODE__')
+    if [[ "$http_code" == "429" ]]; then
+      warn "GitLab rate limited — sleeping 60s (attempt ${attempt}/${max_retries})"
+      sleep 60
+      continue
+    fi
+    if [[ "$http_code" =~ ^5 ]]; then
+      warn "GitLab server error ${http_code} — retrying in 10s (attempt ${attempt}/${max_retries})"
+      sleep 10
+      continue
+    fi
+    echo "$body"
+    return 0
+  done
+  warn "gl_get failed after ${max_retries} attempts: ${url}"
+  return 1
+}
 
 # Repos: "github_path|gitlab_project_id|upstream_branches"
 # Note: penguins-eggs-book upstream has been inactive since 2024-07-12.
@@ -47,8 +82,7 @@ for entry in "${REPOS[@]}"; do
   info "Syncing ${gh_path} → project ${gl_pid}"
 
   # Get GitLab repo URL
-  gl_url=$(curl -sf --header "PRIVATE-TOKEN: ${GITLAB_TOKEN}" \
-    "${GL_API}/projects/${gl_pid}" \
+  gl_url=$(gl_get "${GL_API}/projects/${gl_pid}" \
     | python3 -c "import sys,json; print(json.load(sys.stdin)['http_url_to_repo'])" 2>/dev/null)
 
   if [ -z "$gl_url" ]; then
@@ -93,9 +127,12 @@ for entry in "${REPOS[@]}"; do
 
   # 3. Create GitLab Releases for any new tags that have GitHub release notes
   info "Syncing releases ..."
-  gh_releases=$(curl -sf "https://api.github.com/repos/${gh_path}/releases?per_page=100" 2>/dev/null || echo "[]")
-  gl_releases=$(curl -sf --header "PRIVATE-TOKEN: ${GITLAB_TOKEN}" \
-    "${GL_API}/projects/${gl_pid}/releases?per_page=100" 2>/dev/null || echo "[]")
+  if [[ -n "$GH_TOKEN" ]]; then
+    gh_releases=$(gh_get "https://api.github.com/repos/${gh_path}/releases?per_page=100" 2>/dev/null || echo "[]")
+  else
+    gh_releases=$(curl -sf "https://api.github.com/repos/${gh_path}/releases?per_page=100" 2>/dev/null || echo "[]")
+  fi
+  gl_releases=$(gl_get "${GL_API}/projects/${gl_pid}/releases?per_page=100" || echo "[]")
 
   # shellcheck disable=SC2034
   existing_tags=$(echo "$gl_releases" | python3 -c \

--- a/scripts/update-infra-deps.sh
+++ b/scripts/update-infra-deps.sh
@@ -541,6 +541,15 @@ open_pr_exists() {
   [[ "$count" -gt 0 ]]
 }
 
+# Returns true if a PR for the given branch was already merged (changes are on main).
+merged_pr_exists() {
+  local owner="$1" repo="$2" branch="$3"
+  local merged_at
+  merged_at=$(api_get "${API}/repos/${owner}/${repo}/pulls?state=closed&head=${owner}:${branch}&per_page=1" \
+    | jq -r '.[0].merged_at // empty' 2>/dev/null || echo "")
+  [[ -n "$merged_at" ]]
+}
+
 create_branch() {
   local owner="$1" repo="$2" branch="$3" sha="$4"
   local payload
@@ -684,6 +693,13 @@ process_repo() {
 
   if [[ "$DRY_RUN" == "true" ]]; then
     echo "    [dry-run] would open PR on branch ${PR_BRANCH}"
+    return
+  fi
+
+  # Skip if a PR for this branch was already merged — changes are on main.
+  if merged_pr_exists "$owner" "$repo" "$PR_BRANCH"; then
+    echo "    ↩ PR for ${PR_BRANCH} already merged — changes on main, skipping"
+    (( prs_skipped++ )) || true
     return
   fi
 
@@ -835,6 +851,6 @@ echo "Summary"
 echo "  Repos scanned (with workflows): ${repos_scanned}"
 echo "  Repos with outdated deps:       ${repos_updated}"
 echo "  PRs opened:                     ${prs_opened}"
-echo "  PRs skipped (already open):     ${prs_skipped}"
+echo "  PRs skipped (open/merged/branch exists): ${prs_skipped}"
 budget_report
 echo "════════════════════════════════════════════════════════"


### PR DESCRIPTION
## What changed

- `update-infra-deps.sh`: skip PR creation when a PR for the same branch was already merged (changes already on main)
- `sync-forks.sh`: replace paginated REST repo enumeration with a single GitLab GraphQL call (~200 REST calls → 1–3 GraphQL calls)
- `reconcile-org-refs.sh`: prefetch GitLab project IDs + default branches via GraphQL before the GitLab pass (~100 REST calls → 1 GraphQL call)
- `sync-pieroproietti-gl-forks.sh`: replace raw curl with `gl_get()` retry wrapper; source `includes/gh-api.sh` for GitHub release fetches
- `full-audit.yml`: add `actions/cache@v5` for pyyaml pip install
- `check-accessibility.yml`: add `actions/cache@v5` for npm global packages
- `critical-deploy*.yml` + `sync-shell-tools.yml`: `fetch-depth: 0` → `1` (none of these workflows use `git log` or `git describe`)
- `pre-flush-prep.yml` step 6: dispatch `resolve-ci.yml` instead of the legacy `resolve-failures.yml` (agnostic engine covers all targets)
- `full-chain-flush.yml` stage 12: dispatch `check-ci.yml` instead of the deprecated `check-osp-ci.yml` stub
- `DOCS/workflow-scheduling.md`: add EST column to all per-workflow tables; split inline ET times into dedicated `Schedule (UTC)` / `Schedule (EST)` columns for easier scanning

## Type

- [ ] Bug fix
- [ ] New feature / workflow
- [x] Config / dependency update
- [x] Refactor / cleanup
- [x] Documentation

## Checklist

- [x] Validator scripts pass (`python3 -m pytest tests/ -v`)
- [x] Config files validated (`python3 scripts/validate-*.py`)
- [x] No secrets or tokens committed
- [ ] `[skip ci]` used on any auto-generated commits where appropriate