### PR TITLE
feat: flush lifecycle manager, NotebookLM variant dirs, badge subgroup fix

### DIFF
--- a/.github/workflows/flush-lifecycle.yml
+++ b/.github/workflows/flush-lifecycle.yml
@@ -1,0 +1,319 @@
+name: Flush Lifecycle Manager
+
+# Coordinates the pre-flush-prep → full-chain-flush → post-flush-prep pipeline
+# with quota reservation, runner slot holding, and pause/resume at quota reset.
+#
+# Problem this solves:
+#   The three-stage flush pipeline can take 2-4 hours. If quota runs out
+#   mid-flush, the current stage fails and the pipeline is abandoned.
+#   queue-manager and quota-reserve don't know the flush is running and may
+#   cancel its queued stages.
+#
+# What this workflow does:
+#   1. RESERVE quota — checks that enough quota exists before starting.
+#      Sets FLUSH_ACTIVE=true as a repo variable so queue-manager and
+#      quota-reserve treat flush stages as protected (tier 1 equivalent).
+#   2. CLEAR queue — cancels all non-CRITICAL queued runs via flush-sentinel.sh
+#      to maximise runner availability.
+#   3. SENTINEL — starts a parallel keepalive job that holds a runner slot
+#      for the duration of the flush.
+#   4. DISPATCH stages — dispatches pre-flush-prep, waits, then full-chain-flush,
+#      waits, then post-flush-prep. Between each stage, checks quota.
+#   5. PAUSE/RESUME — if quota drops below RESUME_QUOTA between stages, sleeps
+#      until the reset window (up to 65 min), then re-checks before continuing.
+#   6. RELEASE — clears FLUSH_ACTIVE on completion or failure.
+#
+# Trigger: manual only (workflow_dispatch). The flush pipeline should never
+# start automatically — it requires deliberate human intent.
+#
+# Inputs:
+#   aggressive_clear — also cancel tier 2 (HIGH) queued runs before flush
+#   dry_run          — dispatch stages in dry-run mode (no actual work)
+#   skip_pre_flush   — skip pre-flush-prep (use if already run recently)
+#   skip_post_flush  — skip post-flush-prep (use for partial flushes)
+
+on:
+  workflow_dispatch:
+    inputs:
+      aggressive_clear:
+        description: "Cancel tier 2 (HIGH) queued runs before flush"
+        required: false
+        default: "false"
+        type: string
+      dry_run:
+        description: "Dry run — dispatch stages but pass DRY_RUN=true"
+        required: false
+        default: "false"
+        type: boolean
+      skip_pre_flush:
+        description: "Skip pre-flush-prep (already run recently)"
+        required: false
+        default: "false"
+        type: boolean
+      skip_post_flush:
+        description: "Skip post-flush-prep"
+        required: false
+        default: "false"
+        type: boolean
+
+permissions:
+  contents: read
+  actions: write
+
+concurrency:
+  group: flush-lifecycle
+  cancel-in-progress: false  # never cancel a running flush lifecycle
+
+env:
+  GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+  REPO: ${{ github.repository }}
+  # Minimum quota required to START the flush. The full pipeline costs ~800-1200
+  # REST calls. We require 1500 headroom so there is buffer for retries.
+  START_QUOTA: "1500"
+  # Minimum quota required to CONTINUE between stages. Lower than START_QUOTA
+  # because each individual stage costs ~200-400 calls.
+  RESUME_QUOTA: "600"
+  # How long to sleep between quota re-checks when paused (seconds).
+  PAUSE_POLL_SECONDS: "120"
+  # Maximum time to wait for quota reset before giving up (seconds = 65 min).
+  MAX_PAUSE_SECONDS: "3900"
+
+jobs:
+  # ── Job 1: Lifecycle coordinator ─────────────────────────────────────────────
+  lifecycle:
+    name: Flush Lifecycle
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Quota pre-flight
+        id: quota
+        env:
+          MIN_QUOTA: ${{ env.START_QUOTA }}
+        run: |
+          source scripts/includes/quota-snapshot.sh
+          quota_snapshot
+          skip=$(grep '^skip=' "$GITHUB_OUTPUT" | tail -1 | cut -d= -f2)
+          if [[ "$skip" == "true" ]]; then
+            echo "Quota too low to start flush (need ${START_QUOTA}, have less)." >&2
+            echo "Check reset time and re-dispatch after reset." >&2
+            exit 1
+          fi
+          remaining=$(grep '^remaining=' "$GITHUB_OUTPUT" | tail -1 | cut -d= -f2)
+          echo "Quota OK: ${remaining} remaining (need ${START_QUOTA})" >&2
+
+      # ── Mark flush as active (protects stages from queue-manager/quota-reserve)
+      - name: Set FLUSH_ACTIVE
+        run: |
+          gh api -X PUT \
+            "/repos/${REPO}/actions/variables/FLUSH_ACTIVE" \
+            -f name=FLUSH_ACTIVE -f value=true \
+            2>/dev/null || \
+          gh api -X POST \
+            "/repos/${REPO}/actions/variables" \
+            -f name=FLUSH_ACTIVE -f value=true \
+            2>/dev/null || true
+          echo "FLUSH_ACTIVE=true set on ${REPO}" >&2
+
+      # ── Clear queue to free runner slots ──────────────────────────────────
+      - name: Clear queue (flush-sentinel)
+        env:
+          AGGRESSIVE_CLEAR: ${{ github.event.inputs.aggressive_clear }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: bash scripts/flush-sentinel.sh clear
+
+      # ── Stage 1: pre-flush-prep ───────────────────────────────────────────
+      - name: "Stage 1: pre-flush-prep"
+        if: github.event.inputs.skip_pre_flush != 'true'
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: |
+          bash scripts/dispatch-and-wait.sh pre-flush-prep.yml 60 \
+            "{\"dry_run\":\"${DRY_RUN}\"}"
+          rc=$?
+          if [[ $rc -eq 2 ]]; then
+            echo "pre-flush-prep cancelled by queue-manager — this should not happen with FLUSH_ACTIVE=true" >&2
+            echo "Retrying once..." >&2
+            sleep 30
+            bash scripts/dispatch-and-wait.sh pre-flush-prep.yml 60 \
+              "{\"dry_run\":\"${DRY_RUN}\"}"
+          fi
+
+      # ── Quota checkpoint before full-chain-flush ──────────────────────────
+      - name: Quota checkpoint (pre-flush → flush)
+        id: checkpoint_1
+        run: |
+          source scripts/includes/gh-api.sh
+          remaining=$(curl -sf \
+            -H "Authorization: token ${GH_TOKEN}" \
+            "https://api.github.com/rate_limit" \
+            | python3 -c "import json,sys; print(json.load(sys.stdin)['resources']['core']['remaining'])" \
+            2>/dev/null || echo "0")
+          reset_at=$(curl -sf \
+            -H "Authorization: token ${GH_TOKEN}" \
+            "https://api.github.com/rate_limit" \
+            | python3 -c "import json,sys; print(json.load(sys.stdin)['resources']['core']['reset'])" \
+            2>/dev/null || echo "0")
+          echo "remaining=${remaining}" >> "$GITHUB_OUTPUT"
+          echo "reset_at=${reset_at}" >> "$GITHUB_OUTPUT"
+          echo "Quota before full-chain-flush: ${remaining}" >&2
+
+          if [[ "${remaining}" -lt "${RESUME_QUOTA}" ]]; then
+            echo "pause_needed=true" >> "$GITHUB_OUTPUT"
+            echo "Quota low (${remaining} < ${RESUME_QUOTA}) — will pause before full-chain-flush" >&2
+          else
+            echo "pause_needed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Pause until quota reset (checkpoint 1)
+        if: steps.checkpoint_1.outputs.pause_needed == 'true'
+        env:
+          RESET_AT: ${{ steps.checkpoint_1.outputs.reset_at }}
+        run: |
+          now=$(date +%s)
+          reset_at="${RESET_AT}"
+          wait_seconds=$(( reset_at - now + 30 ))  # +30s buffer after reset
+
+          if [[ ${wait_seconds} -le 0 ]]; then
+            echo "Reset already passed — continuing immediately" >&2
+          elif [[ ${wait_seconds} -gt ${MAX_PAUSE_SECONDS} ]]; then
+            echo "Wait time ${wait_seconds}s exceeds MAX_PAUSE_SECONDS ${MAX_PAUSE_SECONDS}s — aborting" >&2
+            exit 1
+          else
+            echo "Pausing ${wait_seconds}s until quota reset at $(date -d @${reset_at} -u 2>/dev/null || date -r ${reset_at} -u 2>/dev/null || echo ${reset_at})" >&2
+            elapsed=0
+            while [[ ${elapsed} -lt ${wait_seconds} ]]; do
+              sleep "${PAUSE_POLL_SECONDS}"
+              elapsed=$(( elapsed + PAUSE_POLL_SECONDS ))
+              remaining=$(curl -sf \
+                -H "Authorization: token ${GH_TOKEN}" \
+                "https://api.github.com/rate_limit" \
+                | python3 -c "import json,sys; print(json.load(sys.stdin)['resources']['core']['remaining'])" \
+                2>/dev/null || echo "0")
+              echo "  [${elapsed}s] Quota: ${remaining}" >&2
+              if [[ "${remaining}" -ge "${RESUME_QUOTA}" ]]; then
+                echo "Quota restored (${remaining}) — resuming" >&2
+                break
+              fi
+            done
+          fi
+
+      # ── Stage 2: full-chain-flush ─────────────────────────────────────────
+      - name: "Stage 2: full-chain-flush"
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: |
+          bash scripts/dispatch-and-wait.sh full-chain-flush.yml 240 \
+            "{\"dry_run\":\"${DRY_RUN}\"}"
+          rc=$?
+          if [[ $rc -eq 2 ]]; then
+            echo "full-chain-flush cancelled — retrying once after 60s" >&2
+            sleep 60
+            bash scripts/dispatch-and-wait.sh full-chain-flush.yml 240 \
+              "{\"dry_run\":\"${DRY_RUN}\"}"
+          fi
+
+      # ── Quota checkpoint before post-flush-prep ───────────────────────────
+      - name: Quota checkpoint (flush → post-flush)
+        id: checkpoint_2
+        run: |
+          remaining=$(curl -sf \
+            -H "Authorization: token ${GH_TOKEN}" \
+            "https://api.github.com/rate_limit" \
+            | python3 -c "import json,sys; print(json.load(sys.stdin)['resources']['core']['remaining'])" \
+            2>/dev/null || echo "0")
+          reset_at=$(curl -sf \
+            -H "Authorization: token ${GH_TOKEN}" \
+            "https://api.github.com/rate_limit" \
+            | python3 -c "import json,sys; print(json.load(sys.stdin)['resources']['core']['reset'])" \
+            2>/dev/null || echo "0")
+          echo "remaining=${remaining}" >> "$GITHUB_OUTPUT"
+          echo "reset_at=${reset_at}" >> "$GITHUB_OUTPUT"
+          echo "Quota before post-flush-prep: ${remaining}" >&2
+          if [[ "${remaining}" -lt "${RESUME_QUOTA}" ]]; then
+            echo "pause_needed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "pause_needed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Pause until quota reset (checkpoint 2)
+        if: steps.checkpoint_2.outputs.pause_needed == 'true'
+        env:
+          RESET_AT: ${{ steps.checkpoint_2.outputs.reset_at }}
+        run: |
+          now=$(date +%s)
+          wait_seconds=$(( RESET_AT - now + 30 ))
+          if [[ ${wait_seconds} -le 0 ]]; then
+            echo "Reset already passed — continuing" >&2
+          elif [[ ${wait_seconds} -gt ${MAX_PAUSE_SECONDS} ]]; then
+            echo "Wait time exceeds MAX_PAUSE_SECONDS — aborting" >&2
+            exit 1
+          else
+            echo "Pausing ${wait_seconds}s for quota reset" >&2
+            sleep "${wait_seconds}"
+          fi
+
+      # ── Stage 3: post-flush-prep ──────────────────────────────────────────
+      - name: "Stage 3: post-flush-prep"
+        if: github.event.inputs.skip_post_flush != 'true'
+        run: |
+          bash scripts/dispatch-and-wait.sh post-flush-prep.yml 60
+          rc=$?
+          [[ $rc -eq 2 ]] && echo "post-flush-prep cancelled — retrying" >&2 && \
+            sleep 30 && bash scripts/dispatch-and-wait.sh post-flush-prep.yml 60 || true
+
+      # ── Release FLUSH_ACTIVE (always runs, even on failure) ───────────────
+      - name: Clear FLUSH_ACTIVE
+        if: always()
+        run: |
+          gh api -X PUT \
+            "/repos/${REPO}/actions/variables/FLUSH_ACTIVE" \
+            -f name=FLUSH_ACTIVE -f value=false \
+            2>/dev/null || true
+          echo "FLUSH_ACTIVE cleared" >&2
+
+  # ── Job 2: Sentinel keepalive (parallel — holds runner slot) ─────────────────
+  sentinel:
+    name: Runner Sentinel
+    runs-on: ubuntu-latest
+    needs: []  # starts immediately, parallel to lifecycle
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Keepalive — hold runner slot
+        env:
+          FLUSH_RUN_ID: ${{ github.run_id }}
+          SENTINEL_MAX_MINUTES: "360"
+          SENTINEL_POLL_SECONDS: "60"
+        run: |
+          # The sentinel watches the lifecycle job's run ID.
+          # Since both jobs share the same run, we watch for the lifecycle
+          # job to complete by polling the run's overall status.
+          max_seconds=$(( 360 * 60 ))
+          elapsed=0
+          poll=60
+
+          echo "[sentinel] Holding runner slot for flush lifecycle run ${GITHUB_RUN_ID}" >&2
+
+          while [[ ${elapsed} -lt ${max_seconds} ]]; do
+            sleep ${poll}
+            elapsed=$(( elapsed + poll ))
+
+            # Check if the lifecycle job has finished
+            lifecycle_status=$(curl -sf \
+              -H "Authorization: token ${GH_TOKEN}" \
+              "https://api.github.com/repos/${REPO}/actions/runs/${GITHUB_RUN_ID}/jobs" \
+              | python3 -c "import json,sys; d=json.load(sys.stdin); [print(j.get('status','unknown')) or __import__('sys').exit(0) for j in d.get('jobs',[]) if j.get('name')=='Flush Lifecycle']; print('unknown')" \
+              2>/dev/null || echo "unknown")
+
+            if [[ "${lifecycle_status}" == "completed" ]]; then
+              echo "[sentinel] Lifecycle job completed — releasing slot" >&2
+              exit 0
+            fi
+
+            echo "[sentinel] [${elapsed}s] Lifecycle status: ${lifecycle_status} — holding" >&2
+          done
+
+          echo "[sentinel] Max time reached — releasing slot" >&2

--- a/.github/workflows/queue-manager.yml
+++ b/.github/workflows/queue-manager.yml
@@ -108,6 +108,9 @@ jobs:
           STALE_QUEUE_MIN: ${{ inputs.stale_queue_min || '25' }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
           MIN_QUOTA: "300"
+          # FLUSH_ACTIVE — set by flush-lifecycle.yml while the flush pipeline runs.
+          # When true, tier 2 (HIGH) runs are protected from eviction.
+          FLUSH_ACTIVE: ${{ vars.FLUSH_ACTIVE || 'false' }}
         run: bash scripts/queue-manager.sh
 
       - name: Write summary

--- a/.github/workflows/quota-reserve.yml
+++ b/.github/workflows/quota-reserve.yml
@@ -97,6 +97,9 @@ jobs:
           RESERVE_FLOOR: ${{ inputs.reserve_floor || '1000' }}
           GRACE_MIN: ${{ inputs.grace_min || '5' }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          # FLUSH_ACTIVE — set by flush-lifecycle.yml while the flush pipeline runs.
+          # When true, tier 2 (HIGH) runs are protected from cancellation.
+          FLUSH_ACTIVE: ${{ vars.FLUSH_ACTIVE || 'false' }}
         run: bash scripts/quota-reserve.sh
 
       - name: Write summary

--- a/config/workflow-priority-tiers.yml
+++ b/config/workflow-priority-tiers.yml
@@ -59,6 +59,8 @@ tiers:
     tier: 1
   - name: "Pre-Flush Prep"
     tier: 1
+  - name: "Flush Lifecycle Manager"
+    tier: 1
 
   # ── Tier 2: HIGH ────────────────────────────────────────────────────────────
   # Core mirror chain and sync operations.

--- a/config/workflow-quota-costs.yml
+++ b/config/workflow-quota-costs.yml
@@ -44,6 +44,21 @@ workflows:
   notes: Token validation calls only
   synopsis: Checks expiry dates for all tracked PATs and GitLab tokens. Opens a GitHub issue labelled token-monitor when any
     token expires within 45 days.
+- name: Flush Lifecycle Manager
+  min_quota: 1500
+  cost_low: 15
+  cost_mid: 40
+  cost_high: 80
+  basis: code-audit
+  notes: >
+    Coordinator for pre-flush-prep → full-chain-flush → post-flush-prep pipeline.
+    Direct REST calls: quota checks between stages (2-4 calls each), FLUSH_ACTIVE
+    variable writes (2 calls), queue clear via flush-sentinel (1 list + N cancels).
+    The bulk of quota is consumed by the dispatched child workflows, not this one.
+  synopsis: >
+    Coordinates the three-stage flush pipeline with quota reservation, runner slot
+    holding via a parallel sentinel job, and pause/resume at quota reset windows.
+    Sets FLUSH_ACTIVE=true so queue-manager and quota-reserve protect flush stages.
 - name: Pre-Flush Prep
   min_quota: 1500
   cost_low: 10

--- a/config/workflow-sync.yml
+++ b/config/workflow-sync.yml
@@ -418,6 +418,8 @@ github_only:
     reason: Builds mdBook site from DOCS/ and deploys to GitHub Pages — GitHub Pages only
   - workflow_file: setup-dashboard-vars.yml
     reason: Sets VITE_* repository variables for infra-dashboard build — GitHub Actions variables API only
+  - workflow_file: flush-lifecycle.yml
+    reason: Coordinates pre-flush-prep → full-chain-flush → post-flush-prep with quota reservation, runner sentinel, and pause/resume at reset
   - workflow_file: pre-flush-prep.yml
     reason: Pre-flight for full-chain-flush — clears queue, merges PRs, validates config, dispatches flush
   - workflow_file: pre-mirror-ci-gate.yml

--- a/docs/notebooklm/README.md
+++ b/docs/notebooklm/README.md
@@ -2,6 +2,20 @@
 
 Generated outputs from [Google NotebookLM](https://notebooklm.google.com/) using fork-sync-all documentation as source material.
 
+Each subdirectory corresponds to a NotebookLM generation type, with variant
+subdirectories matching the customization options available in NotebookLM Studio,
+and date-stamped subdirectories (`YYYY-MM-DD/`) for each generation session.
+
+**Directory structure:**
+```
+<type>/
+  <variant>/
+    README.md          — variant description + file index
+    <YYYY-MM-DD>/
+      README.md        — session log for that date
+      <generated files>
+```
+
 Each subdirectory corresponds to a NotebookLM generation type:
 
 | Directory | Type | Format |

--- a/docs/notebooklm/audio-overview/long/2026-06-17/README.md
+++ b/docs/notebooklm/audio-overview/long/2026-06-17/README.md
@@ -1,0 +1,7 @@
+# Audio Overview — Long — 2026-06-17
+
+Generated 2026-06-17. Length: Long (~10 min).
+
+| File | Prompt | Notes |
+|------|--------|-------|
+| *(pending)* | — | — |

--- a/docs/notebooklm/audio-overview/long/README.md
+++ b/docs/notebooklm/audio-overview/long/README.md
@@ -1,0 +1,17 @@
+# Audio Overview — Long
+
+In-depth exploration of all major topics. Duration: ~10 min.
+
+**NotebookLM settings:** Length = Long, Language = English
+
+## Files
+
+| Date | File | Prompt |
+|------|------|--------|
+| *(pending)* | — | — |
+
+## Upload
+
+```bash
+bash scripts/upload-notebooklm.sh notebooklm-2026-06-17 path/to/audio.mp3
+```

--- a/docs/notebooklm/audio-overview/medium/2026-06-17/README.md
+++ b/docs/notebooklm/audio-overview/medium/2026-06-17/README.md
@@ -1,0 +1,7 @@
+# Audio Overview — Medium — 2026-06-17
+
+Generated 2026-06-17. Length: Medium (~5 min).
+
+| File | Prompt | Notes |
+|------|--------|-------|
+| *(pending)* | — | — |

--- a/docs/notebooklm/audio-overview/medium/README.md
+++ b/docs/notebooklm/audio-overview/medium/README.md
@@ -1,0 +1,17 @@
+# Audio Overview — Medium
+
+Balanced coverage of main topics and context. Duration: ~5 min.
+
+**NotebookLM settings:** Length = Medium, Language = English
+
+## Files
+
+| Date | File | Prompt |
+|------|------|--------|
+| *(pending)* | — | — |
+
+## Upload
+
+```bash
+bash scripts/upload-notebooklm.sh notebooklm-2026-06-17 path/to/audio.mp3
+```

--- a/docs/notebooklm/audio-overview/short/2026-06-17/README.md
+++ b/docs/notebooklm/audio-overview/short/2026-06-17/README.md
@@ -1,0 +1,7 @@
+# Audio Overview — Short — 2026-06-17
+
+Generated 2026-06-17. Length: Short (~2 min).
+
+| File | Prompt | Notes |
+|------|--------|-------|
+| *(pending)* | — | — |

--- a/docs/notebooklm/audio-overview/short/README.md
+++ b/docs/notebooklm/audio-overview/short/README.md
@@ -1,0 +1,17 @@
+# Audio Overview — Short
+
+Concise overview of the key points. Duration: ~2 min.
+
+**NotebookLM settings:** Length = Short, Language = English
+
+## Files
+
+| Date | File | Prompt |
+|------|------|--------|
+| *(pending)* | — | — |
+
+## Upload
+
+```bash
+bash scripts/upload-notebooklm.sh notebooklm-2026-06-17 path/to/audio.mp3
+```

--- a/docs/notebooklm/flashcards/fewer/easy/2026-06-17/README.md
+++ b/docs/notebooklm/flashcards/fewer/easy/2026-06-17/README.md
@@ -1,0 +1,7 @@
+# Flashcards — Fewer / Easy — 2026-06-17
+
+Generated 2026-06-17. Count: Fewer, Difficulty: Easy.
+
+| File | Prompt | Notes |
+|------|--------|-------|
+| *(pending)* | — | — |

--- a/docs/notebooklm/flashcards/fewer/easy/README.md
+++ b/docs/notebooklm/flashcards/fewer/easy/README.md
@@ -1,0 +1,21 @@
+# Flashcards — Fewer / Easy
+
+Count: Fewer — Reduced set — good for quick review.
+Difficulty: Easy — Recall and recognition questions.
+
+**NotebookLM settings:** Number of Cards = Fewer, Level of Difficulty = Easy
+
+**Accepted formats:** `.pdf`, `.csv`
+**Naming:** `<topic>-fewer-easy-<YYYY-MM-DD>.pdf`
+
+## Files
+
+| Date | File | Prompt |
+|------|------|--------|
+| *(pending)* | — | — |
+
+## Upload
+
+```bash
+bash scripts/upload-notebooklm.sh notebooklm-2026-06-17 path/to/file.pdf
+```

--- a/docs/notebooklm/flashcards/fewer/hard/2026-06-17/README.md
+++ b/docs/notebooklm/flashcards/fewer/hard/2026-06-17/README.md
@@ -1,0 +1,7 @@
+# Flashcards — Fewer / Hard — 2026-06-17
+
+Generated 2026-06-17. Count: Fewer, Difficulty: Hard.
+
+| File | Prompt | Notes |
+|------|--------|-------|
+| *(pending)* | — | — |

--- a/docs/notebooklm/flashcards/fewer/hard/README.md
+++ b/docs/notebooklm/flashcards/fewer/hard/README.md
@@ -1,0 +1,21 @@
+# Flashcards — Fewer / Hard
+
+Count: Fewer — Reduced set — good for quick review.
+Difficulty: Hard — Synthesis and evaluation questions.
+
+**NotebookLM settings:** Number of Cards = Fewer, Level of Difficulty = Hard
+
+**Accepted formats:** `.pdf`, `.csv`
+**Naming:** `<topic>-fewer-hard-<YYYY-MM-DD>.pdf`
+
+## Files
+
+| Date | File | Prompt |
+|------|------|--------|
+| *(pending)* | — | — |
+
+## Upload
+
+```bash
+bash scripts/upload-notebooklm.sh notebooklm-2026-06-17 path/to/file.pdf
+```

--- a/docs/notebooklm/flashcards/fewer/medium/2026-06-17/README.md
+++ b/docs/notebooklm/flashcards/fewer/medium/2026-06-17/README.md
@@ -1,0 +1,7 @@
+# Flashcards — Fewer / Medium — 2026-06-17
+
+Generated 2026-06-17. Count: Fewer, Difficulty: Medium.
+
+| File | Prompt | Notes |
+|------|--------|-------|
+| *(pending)* | — | — |

--- a/docs/notebooklm/flashcards/fewer/medium/README.md
+++ b/docs/notebooklm/flashcards/fewer/medium/README.md
@@ -1,0 +1,21 @@
+# Flashcards — Fewer / Medium
+
+Count: Fewer — Reduced set — good for quick review.
+Difficulty: Medium — Application and analysis questions.
+
+**NotebookLM settings:** Number of Cards = Fewer, Level of Difficulty = Medium
+
+**Accepted formats:** `.pdf`, `.csv`
+**Naming:** `<topic>-fewer-medium-<YYYY-MM-DD>.pdf`
+
+## Files
+
+| Date | File | Prompt |
+|------|------|--------|
+| *(pending)* | — | — |
+
+## Upload
+
+```bash
+bash scripts/upload-notebooklm.sh notebooklm-2026-06-17 path/to/file.pdf
+```

--- a/docs/notebooklm/flashcards/more/easy/2026-06-17/README.md
+++ b/docs/notebooklm/flashcards/more/easy/2026-06-17/README.md
@@ -1,0 +1,7 @@
+# Flashcards — More / Easy — 2026-06-17
+
+Generated 2026-06-17. Count: More, Difficulty: Easy.
+
+| File | Prompt | Notes |
+|------|--------|-------|
+| *(pending)* | — | — |

--- a/docs/notebooklm/flashcards/more/easy/README.md
+++ b/docs/notebooklm/flashcards/more/easy/README.md
@@ -1,0 +1,21 @@
+# Flashcards — More / Easy
+
+Count: More — Extended set — thorough coverage.
+Difficulty: Easy — Recall and recognition questions.
+
+**NotebookLM settings:** Number of Cards = More, Level of Difficulty = Easy
+
+**Accepted formats:** `.pdf`, `.csv`
+**Naming:** `<topic>-more-easy-<YYYY-MM-DD>.pdf`
+
+## Files
+
+| Date | File | Prompt |
+|------|------|--------|
+| *(pending)* | — | — |
+
+## Upload
+
+```bash
+bash scripts/upload-notebooklm.sh notebooklm-2026-06-17 path/to/file.pdf
+```

--- a/docs/notebooklm/flashcards/more/hard/2026-06-17/README.md
+++ b/docs/notebooklm/flashcards/more/hard/2026-06-17/README.md
@@ -1,0 +1,7 @@
+# Flashcards — More / Hard — 2026-06-17
+
+Generated 2026-06-17. Count: More, Difficulty: Hard.
+
+| File | Prompt | Notes |
+|------|--------|-------|
+| *(pending)* | — | — |

--- a/docs/notebooklm/flashcards/more/hard/README.md
+++ b/docs/notebooklm/flashcards/more/hard/README.md
@@ -1,0 +1,21 @@
+# Flashcards — More / Hard
+
+Count: More — Extended set — thorough coverage.
+Difficulty: Hard — Synthesis and evaluation questions.
+
+**NotebookLM settings:** Number of Cards = More, Level of Difficulty = Hard
+
+**Accepted formats:** `.pdf`, `.csv`
+**Naming:** `<topic>-more-hard-<YYYY-MM-DD>.pdf`
+
+## Files
+
+| Date | File | Prompt |
+|------|------|--------|
+| *(pending)* | — | — |
+
+## Upload
+
+```bash
+bash scripts/upload-notebooklm.sh notebooklm-2026-06-17 path/to/file.pdf
+```

--- a/docs/notebooklm/flashcards/more/medium/2026-06-17/README.md
+++ b/docs/notebooklm/flashcards/more/medium/2026-06-17/README.md
@@ -1,0 +1,7 @@
+# Flashcards — More / Medium — 2026-06-17
+
+Generated 2026-06-17. Count: More, Difficulty: Medium.
+
+| File | Prompt | Notes |
+|------|--------|-------|
+| *(pending)* | — | — |

--- a/docs/notebooklm/flashcards/more/medium/README.md
+++ b/docs/notebooklm/flashcards/more/medium/README.md
@@ -1,0 +1,21 @@
+# Flashcards — More / Medium
+
+Count: More — Extended set — thorough coverage.
+Difficulty: Medium — Application and analysis questions.
+
+**NotebookLM settings:** Number of Cards = More, Level of Difficulty = Medium
+
+**Accepted formats:** `.pdf`, `.csv`
+**Naming:** `<topic>-more-medium-<YYYY-MM-DD>.pdf`
+
+## Files
+
+| Date | File | Prompt |
+|------|------|--------|
+| *(pending)* | — | — |
+
+## Upload
+
+```bash
+bash scripts/upload-notebooklm.sh notebooklm-2026-06-17 path/to/file.pdf
+```

--- a/docs/notebooklm/flashcards/standard/easy/2026-06-17/README.md
+++ b/docs/notebooklm/flashcards/standard/easy/2026-06-17/README.md
@@ -1,0 +1,7 @@
+# Flashcards — Standard / Easy — 2026-06-17
+
+Generated 2026-06-17. Count: Standard, Difficulty: Easy.
+
+| File | Prompt | Notes |
+|------|--------|-------|
+| *(pending)* | — | — |

--- a/docs/notebooklm/flashcards/standard/easy/README.md
+++ b/docs/notebooklm/flashcards/standard/easy/README.md
@@ -1,0 +1,21 @@
+# Flashcards — Standard / Easy
+
+Count: Standard — Default count — balanced coverage.
+Difficulty: Easy — Recall and recognition questions.
+
+**NotebookLM settings:** Number of Cards = Standard, Level of Difficulty = Easy
+
+**Accepted formats:** `.pdf`, `.csv`
+**Naming:** `<topic>-standard-easy-<YYYY-MM-DD>.pdf`
+
+## Files
+
+| Date | File | Prompt |
+|------|------|--------|
+| *(pending)* | — | — |
+
+## Upload
+
+```bash
+bash scripts/upload-notebooklm.sh notebooklm-2026-06-17 path/to/file.pdf
+```

--- a/docs/notebooklm/flashcards/standard/hard/2026-06-17/README.md
+++ b/docs/notebooklm/flashcards/standard/hard/2026-06-17/README.md
@@ -1,0 +1,7 @@
+# Flashcards — Standard / Hard — 2026-06-17
+
+Generated 2026-06-17. Count: Standard, Difficulty: Hard.
+
+| File | Prompt | Notes |
+|------|--------|-------|
+| *(pending)* | — | — |

--- a/docs/notebooklm/flashcards/standard/hard/README.md
+++ b/docs/notebooklm/flashcards/standard/hard/README.md
@@ -1,0 +1,21 @@
+# Flashcards — Standard / Hard
+
+Count: Standard — Default count — balanced coverage.
+Difficulty: Hard — Synthesis and evaluation questions.
+
+**NotebookLM settings:** Number of Cards = Standard, Level of Difficulty = Hard
+
+**Accepted formats:** `.pdf`, `.csv`
+**Naming:** `<topic>-standard-hard-<YYYY-MM-DD>.pdf`
+
+## Files
+
+| Date | File | Prompt |
+|------|------|--------|
+| *(pending)* | — | — |
+
+## Upload
+
+```bash
+bash scripts/upload-notebooklm.sh notebooklm-2026-06-17 path/to/file.pdf
+```

--- a/docs/notebooklm/flashcards/standard/medium/2026-06-17/README.md
+++ b/docs/notebooklm/flashcards/standard/medium/2026-06-17/README.md
@@ -1,0 +1,7 @@
+# Flashcards — Standard / Medium — 2026-06-17
+
+Generated 2026-06-17. Count: Standard, Difficulty: Medium.
+
+| File | Prompt | Notes |
+|------|--------|-------|
+| *(pending)* | — | — |

--- a/docs/notebooklm/flashcards/standard/medium/README.md
+++ b/docs/notebooklm/flashcards/standard/medium/README.md
@@ -1,0 +1,21 @@
+# Flashcards — Standard / Medium
+
+Count: Standard — Default count — balanced coverage.
+Difficulty: Medium — Application and analysis questions.
+
+**NotebookLM settings:** Number of Cards = Standard, Level of Difficulty = Medium
+
+**Accepted formats:** `.pdf`, `.csv`
+**Naming:** `<topic>-standard-medium-<YYYY-MM-DD>.pdf`
+
+## Files
+
+| Date | File | Prompt |
+|------|------|--------|
+| *(pending)* | — | — |
+
+## Upload
+
+```bash
+bash scripts/upload-notebooklm.sh notebooklm-2026-06-17 path/to/file.pdf
+```

--- a/docs/notebooklm/infographic/landscape/2026-06-17/README.md
+++ b/docs/notebooklm/infographic/landscape/2026-06-17/README.md
@@ -1,0 +1,7 @@
+# Infographic — Landscape — 2026-06-17
+
+Generated 2026-06-17. Orientation: Landscape.
+
+| File | Prompt | Notes |
+|------|--------|-------|
+| *(pending)* | — | — |

--- a/docs/notebooklm/infographic/landscape/README.md
+++ b/docs/notebooklm/infographic/landscape/README.md
@@ -1,0 +1,20 @@
+# Infographic — Landscape
+
+Wide format — good for dashboards and slides.
+
+**NotebookLM settings:** Orientation = Landscape
+
+**Accepted formats:** `.pdf`, `.png`
+**Naming:** `<topic>-landscape-<YYYY-MM-DD>.png`
+
+## Files
+
+| Date | File | Prompt |
+|------|------|--------|
+| *(pending)* | — | — |
+
+## Upload
+
+```bash
+bash scripts/upload-notebooklm.sh notebooklm-2026-06-17 path/to/infographic.png
+```

--- a/docs/notebooklm/infographic/portrait/2026-06-17/README.md
+++ b/docs/notebooklm/infographic/portrait/2026-06-17/README.md
@@ -1,0 +1,7 @@
+# Infographic — Portrait — 2026-06-17
+
+Generated 2026-06-17. Orientation: Portrait.
+
+| File | Prompt | Notes |
+|------|--------|-------|
+| *(pending)* | — | — |

--- a/docs/notebooklm/infographic/portrait/README.md
+++ b/docs/notebooklm/infographic/portrait/README.md
@@ -1,0 +1,20 @@
+# Infographic — Portrait
+
+Tall format — good for documents and mobile.
+
+**NotebookLM settings:** Orientation = Portrait
+
+**Accepted formats:** `.pdf`, `.png`
+**Naming:** `<topic>-portrait-<YYYY-MM-DD>.png`
+
+## Files
+
+| Date | File | Prompt |
+|------|------|--------|
+| *(pending)* | — | — |
+
+## Upload
+
+```bash
+bash scripts/upload-notebooklm.sh notebooklm-2026-06-17 path/to/infographic.png
+```

--- a/docs/notebooklm/infographic/square/2026-06-17/README.md
+++ b/docs/notebooklm/infographic/square/2026-06-17/README.md
@@ -1,0 +1,7 @@
+# Infographic — Square — 2026-06-17
+
+Generated 2026-06-17. Orientation: Square.
+
+| File | Prompt | Notes |
+|------|--------|-------|
+| *(pending)* | — | — |

--- a/docs/notebooklm/infographic/square/README.md
+++ b/docs/notebooklm/infographic/square/README.md
@@ -1,0 +1,20 @@
+# Infographic — Square
+
+Equal dimensions — good for social sharing.
+
+**NotebookLM settings:** Orientation = Square
+
+**Accepted formats:** `.pdf`, `.png`
+**Naming:** `<topic>-square-<YYYY-MM-DD>.png`
+
+## Files
+
+| Date | File | Prompt |
+|------|------|--------|
+| *(pending)* | — | — |
+
+## Upload
+
+```bash
+bash scripts/upload-notebooklm.sh notebooklm-2026-06-17 path/to/infographic.png
+```

--- a/docs/notebooklm/quiz/fewer/easy/2026-06-17/README.md
+++ b/docs/notebooklm/quiz/fewer/easy/2026-06-17/README.md
@@ -1,0 +1,7 @@
+# Quiz — Fewer / Easy — 2026-06-17
+
+Generated 2026-06-17. Count: Fewer, Difficulty: Easy.
+
+| File | Prompt | Notes |
+|------|--------|-------|
+| *(pending)* | — | — |

--- a/docs/notebooklm/quiz/fewer/easy/README.md
+++ b/docs/notebooklm/quiz/fewer/easy/README.md
@@ -1,0 +1,21 @@
+# Quiz — Fewer / Easy
+
+Count: Fewer — Reduced set — good for quick review.
+Difficulty: Easy — Recall and recognition questions.
+
+**NotebookLM settings:** Number of Questions = Fewer, Level of Difficulty = Easy
+
+**Accepted formats:** `.pdf`, `.md`
+**Naming:** `<topic>-fewer-easy-<YYYY-MM-DD>.pdf`
+
+## Files
+
+| Date | File | Prompt |
+|------|------|--------|
+| *(pending)* | — | — |
+
+## Upload
+
+```bash
+bash scripts/upload-notebooklm.sh notebooklm-2026-06-17 path/to/file.pdf
+```

--- a/docs/notebooklm/quiz/fewer/hard/2026-06-17/README.md
+++ b/docs/notebooklm/quiz/fewer/hard/2026-06-17/README.md
@@ -1,0 +1,7 @@
+# Quiz — Fewer / Hard — 2026-06-17
+
+Generated 2026-06-17. Count: Fewer, Difficulty: Hard.
+
+| File | Prompt | Notes |
+|------|--------|-------|
+| *(pending)* | — | — |

--- a/docs/notebooklm/quiz/fewer/hard/README.md
+++ b/docs/notebooklm/quiz/fewer/hard/README.md
@@ -1,0 +1,21 @@
+# Quiz — Fewer / Hard
+
+Count: Fewer — Reduced set — good for quick review.
+Difficulty: Hard — Synthesis and evaluation questions.
+
+**NotebookLM settings:** Number of Questions = Fewer, Level of Difficulty = Hard
+
+**Accepted formats:** `.pdf`, `.md`
+**Naming:** `<topic>-fewer-hard-<YYYY-MM-DD>.pdf`
+
+## Files
+
+| Date | File | Prompt |
+|------|------|--------|
+| *(pending)* | — | — |
+
+## Upload
+
+```bash
+bash scripts/upload-notebooklm.sh notebooklm-2026-06-17 path/to/file.pdf
+```

--- a/docs/notebooklm/quiz/fewer/medium/2026-06-17/README.md
+++ b/docs/notebooklm/quiz/fewer/medium/2026-06-17/README.md
@@ -1,0 +1,7 @@
+# Quiz — Fewer / Medium — 2026-06-17
+
+Generated 2026-06-17. Count: Fewer, Difficulty: Medium.
+
+| File | Prompt | Notes |
+|------|--------|-------|
+| *(pending)* | — | — |

--- a/docs/notebooklm/quiz/fewer/medium/README.md
+++ b/docs/notebooklm/quiz/fewer/medium/README.md
@@ -1,0 +1,21 @@
+# Quiz — Fewer / Medium
+
+Count: Fewer — Reduced set — good for quick review.
+Difficulty: Medium — Application and analysis questions.
+
+**NotebookLM settings:** Number of Questions = Fewer, Level of Difficulty = Medium
+
+**Accepted formats:** `.pdf`, `.md`
+**Naming:** `<topic>-fewer-medium-<YYYY-MM-DD>.pdf`
+
+## Files
+
+| Date | File | Prompt |
+|------|------|--------|
+| *(pending)* | — | — |
+
+## Upload
+
+```bash
+bash scripts/upload-notebooklm.sh notebooklm-2026-06-17 path/to/file.pdf
+```

--- a/docs/notebooklm/quiz/more/easy/2026-06-17/README.md
+++ b/docs/notebooklm/quiz/more/easy/2026-06-17/README.md
@@ -1,0 +1,7 @@
+# Quiz — More / Easy — 2026-06-17
+
+Generated 2026-06-17. Count: More, Difficulty: Easy.
+
+| File | Prompt | Notes |
+|------|--------|-------|
+| *(pending)* | — | — |

--- a/docs/notebooklm/quiz/more/easy/README.md
+++ b/docs/notebooklm/quiz/more/easy/README.md
@@ -1,0 +1,21 @@
+# Quiz — More / Easy
+
+Count: More — Extended set — thorough coverage.
+Difficulty: Easy — Recall and recognition questions.
+
+**NotebookLM settings:** Number of Questions = More, Level of Difficulty = Easy
+
+**Accepted formats:** `.pdf`, `.md`
+**Naming:** `<topic>-more-easy-<YYYY-MM-DD>.pdf`
+
+## Files
+
+| Date | File | Prompt |
+|------|------|--------|
+| *(pending)* | — | — |
+
+## Upload
+
+```bash
+bash scripts/upload-notebooklm.sh notebooklm-2026-06-17 path/to/file.pdf
+```

--- a/docs/notebooklm/quiz/more/hard/2026-06-17/README.md
+++ b/docs/notebooklm/quiz/more/hard/2026-06-17/README.md
@@ -1,0 +1,7 @@
+# Quiz — More / Hard — 2026-06-17
+
+Generated 2026-06-17. Count: More, Difficulty: Hard.
+
+| File | Prompt | Notes |
+|------|--------|-------|
+| *(pending)* | — | — |

--- a/docs/notebooklm/quiz/more/hard/README.md
+++ b/docs/notebooklm/quiz/more/hard/README.md
@@ -1,0 +1,21 @@
+# Quiz — More / Hard
+
+Count: More — Extended set — thorough coverage.
+Difficulty: Hard — Synthesis and evaluation questions.
+
+**NotebookLM settings:** Number of Questions = More, Level of Difficulty = Hard
+
+**Accepted formats:** `.pdf`, `.md`
+**Naming:** `<topic>-more-hard-<YYYY-MM-DD>.pdf`
+
+## Files
+
+| Date | File | Prompt |
+|------|------|--------|
+| *(pending)* | — | — |
+
+## Upload
+
+```bash
+bash scripts/upload-notebooklm.sh notebooklm-2026-06-17 path/to/file.pdf
+```

--- a/docs/notebooklm/quiz/more/medium/2026-06-17/README.md
+++ b/docs/notebooklm/quiz/more/medium/2026-06-17/README.md
@@ -1,0 +1,7 @@
+# Quiz — More / Medium — 2026-06-17
+
+Generated 2026-06-17. Count: More, Difficulty: Medium.
+
+| File | Prompt | Notes |
+|------|--------|-------|
+| *(pending)* | — | — |

--- a/docs/notebooklm/quiz/more/medium/README.md
+++ b/docs/notebooklm/quiz/more/medium/README.md
@@ -1,0 +1,21 @@
+# Quiz — More / Medium
+
+Count: More — Extended set — thorough coverage.
+Difficulty: Medium — Application and analysis questions.
+
+**NotebookLM settings:** Number of Questions = More, Level of Difficulty = Medium
+
+**Accepted formats:** `.pdf`, `.md`
+**Naming:** `<topic>-more-medium-<YYYY-MM-DD>.pdf`
+
+## Files
+
+| Date | File | Prompt |
+|------|------|--------|
+| *(pending)* | — | — |
+
+## Upload
+
+```bash
+bash scripts/upload-notebooklm.sh notebooklm-2026-06-17 path/to/file.pdf
+```

--- a/docs/notebooklm/quiz/standard/easy/2026-06-17/README.md
+++ b/docs/notebooklm/quiz/standard/easy/2026-06-17/README.md
@@ -1,0 +1,7 @@
+# Quiz — Standard / Easy — 2026-06-17
+
+Generated 2026-06-17. Count: Standard, Difficulty: Easy.
+
+| File | Prompt | Notes |
+|------|--------|-------|
+| *(pending)* | — | — |

--- a/docs/notebooklm/quiz/standard/easy/README.md
+++ b/docs/notebooklm/quiz/standard/easy/README.md
@@ -1,0 +1,21 @@
+# Quiz — Standard / Easy
+
+Count: Standard — Default count — balanced coverage.
+Difficulty: Easy — Recall and recognition questions.
+
+**NotebookLM settings:** Number of Questions = Standard, Level of Difficulty = Easy
+
+**Accepted formats:** `.pdf`, `.md`
+**Naming:** `<topic>-standard-easy-<YYYY-MM-DD>.pdf`
+
+## Files
+
+| Date | File | Prompt |
+|------|------|--------|
+| *(pending)* | — | — |
+
+## Upload
+
+```bash
+bash scripts/upload-notebooklm.sh notebooklm-2026-06-17 path/to/file.pdf
+```

--- a/docs/notebooklm/quiz/standard/hard/2026-06-17/README.md
+++ b/docs/notebooklm/quiz/standard/hard/2026-06-17/README.md
@@ -1,0 +1,7 @@
+# Quiz — Standard / Hard — 2026-06-17
+
+Generated 2026-06-17. Count: Standard, Difficulty: Hard.
+
+| File | Prompt | Notes |
+|------|--------|-------|
+| *(pending)* | — | — |

--- a/docs/notebooklm/quiz/standard/hard/README.md
+++ b/docs/notebooklm/quiz/standard/hard/README.md
@@ -1,0 +1,21 @@
+# Quiz — Standard / Hard
+
+Count: Standard — Default count — balanced coverage.
+Difficulty: Hard — Synthesis and evaluation questions.
+
+**NotebookLM settings:** Number of Questions = Standard, Level of Difficulty = Hard
+
+**Accepted formats:** `.pdf`, `.md`
+**Naming:** `<topic>-standard-hard-<YYYY-MM-DD>.pdf`
+
+## Files
+
+| Date | File | Prompt |
+|------|------|--------|
+| *(pending)* | — | — |
+
+## Upload
+
+```bash
+bash scripts/upload-notebooklm.sh notebooklm-2026-06-17 path/to/file.pdf
+```

--- a/docs/notebooklm/quiz/standard/medium/2026-06-17/README.md
+++ b/docs/notebooklm/quiz/standard/medium/2026-06-17/README.md
@@ -1,0 +1,7 @@
+# Quiz — Standard / Medium — 2026-06-17
+
+Generated 2026-06-17. Count: Standard, Difficulty: Medium.
+
+| File | Prompt | Notes |
+|------|--------|-------|
+| *(pending)* | — | — |

--- a/docs/notebooklm/quiz/standard/medium/README.md
+++ b/docs/notebooklm/quiz/standard/medium/README.md
@@ -1,0 +1,21 @@
+# Quiz — Standard / Medium
+
+Count: Standard — Default count — balanced coverage.
+Difficulty: Medium — Application and analysis questions.
+
+**NotebookLM settings:** Number of Questions = Standard, Level of Difficulty = Medium
+
+**Accepted formats:** `.pdf`, `.md`
+**Naming:** `<topic>-standard-medium-<YYYY-MM-DD>.pdf`
+
+## Files
+
+| Date | File | Prompt |
+|------|------|--------|
+| *(pending)* | — | — |
+
+## Upload
+
+```bash
+bash scripts/upload-notebooklm.sh notebooklm-2026-06-17 path/to/file.pdf
+```

--- a/docs/notebooklm/reports/blog-post/2026-06-17/README.md
+++ b/docs/notebooklm/reports/blog-post/2026-06-17/README.md
@@ -1,0 +1,7 @@
+# Report — Blog Post — 2026-06-17
+
+Generated 2026-06-17. Type: Blog Post.
+
+| File | Notes |
+|------|-------|
+| *(pending)* | — |

--- a/docs/notebooklm/reports/blog-post/README.md
+++ b/docs/notebooklm/reports/blog-post/README.md
@@ -1,0 +1,20 @@
+# Report — Blog Post
+
+Informational article in the style of a blog post.
+
+**NotebookLM settings:** Report type = Blog Post
+
+**Accepted formats:** `.pdf`, `.md`, `.docx`
+**Naming:** `<topic>-blog-post-<YYYY-MM-DD>.pdf`
+
+## Files
+
+| Date | File | Notes |
+|------|------|-------|
+| *(pending)* | — | — |
+
+## Upload
+
+```bash
+bash scripts/upload-notebooklm.sh notebooklm-2026-06-17 path/to/report.pdf
+```

--- a/docs/notebooklm/reports/briefing-doc/2026-06-17/README.md
+++ b/docs/notebooklm/reports/briefing-doc/2026-06-17/README.md
@@ -1,0 +1,7 @@
+# Report — Briefing Doc — 2026-06-17
+
+Generated 2026-06-17. Type: Briefing Doc.
+
+| File | Notes |
+|------|-------|
+| *(pending)* | — |

--- a/docs/notebooklm/reports/briefing-doc/README.md
+++ b/docs/notebooklm/reports/briefing-doc/README.md
@@ -1,0 +1,20 @@
+# Report — Briefing Doc
+
+Key insights and important quotes from the source material.
+
+**NotebookLM settings:** Report type = Briefing Doc
+
+**Accepted formats:** `.pdf`, `.md`, `.docx`
+**Naming:** `<topic>-briefing-doc-<YYYY-MM-DD>.pdf`
+
+## Files
+
+| Date | File | Notes |
+|------|------|-------|
+| *(pending)* | — | — |
+
+## Upload
+
+```bash
+bash scripts/upload-notebooklm.sh notebooklm-2026-06-17 path/to/report.pdf
+```

--- a/docs/notebooklm/reports/study-guide/2026-06-17/README.md
+++ b/docs/notebooklm/reports/study-guide/2026-06-17/README.md
@@ -1,0 +1,7 @@
+# Report — Study Guide — 2026-06-17
+
+Generated 2026-06-17. Type: Study Guide.
+
+| File | Notes |
+|------|-------|
+| *(pending)* | — |

--- a/docs/notebooklm/reports/study-guide/README.md
+++ b/docs/notebooklm/reports/study-guide/README.md
@@ -1,0 +1,20 @@
+# Report — Study Guide
+
+Quiz with answer key plus glossary.
+
+**NotebookLM settings:** Report type = Study Guide
+
+**Accepted formats:** `.pdf`, `.md`, `.docx`
+**Naming:** `<topic>-study-guide-<YYYY-MM-DD>.pdf`
+
+## Files
+
+| Date | File | Notes |
+|------|------|-------|
+| *(pending)* | — | — |
+
+## Upload
+
+```bash
+bash scripts/upload-notebooklm.sh notebooklm-2026-06-17 path/to/report.pdf
+```

--- a/docs/notebooklm/slide-deck/detailed/2026-06-17/README.md
+++ b/docs/notebooklm/slide-deck/detailed/2026-06-17/README.md
@@ -1,0 +1,7 @@
+# Slide Deck — Detailed Deck — 2026-06-17
+
+Generated 2026-06-17. Format: Detailed Deck.
+
+| File | Length | Language | Notes |
+|------|--------|----------|-------|
+| *(pending)* | — | — | — |

--- a/docs/notebooklm/slide-deck/detailed/README.md
+++ b/docs/notebooklm/slide-deck/detailed/README.md
@@ -1,0 +1,20 @@
+# Slide Deck — Detailed Deck
+
+Full text and details — suitable for reading standalone or emailing.
+
+**NotebookLM settings:** Format = Detailed Deck
+
+**Accepted formats:** `.pdf`, `.pptx`
+**Naming:** `<topic>-detailed-<YYYY-MM-DD>.pdf`
+
+## Files
+
+| Date | File | Length | Language |
+|------|------|--------|----------|
+| *(pending)* | — | — | — |
+
+## Upload
+
+```bash
+bash scripts/upload-notebooklm.sh notebooklm-2026-06-17 path/to/slides.pdf
+```

--- a/docs/notebooklm/slide-deck/presenter/2026-06-17/README.md
+++ b/docs/notebooklm/slide-deck/presenter/2026-06-17/README.md
@@ -1,0 +1,7 @@
+# Slide Deck — Presenter Slides — 2026-06-17
+
+Generated 2026-06-17. Format: Presenter Slides.
+
+| File | Length | Language | Notes |
+|------|--------|----------|-------|
+| *(pending)* | — | — | — |

--- a/docs/notebooklm/slide-deck/presenter/README.md
+++ b/docs/notebooklm/slide-deck/presenter/README.md
@@ -1,0 +1,20 @@
+# Slide Deck — Presenter Slides
+
+Clean visual slides with key talking points for live presentation.
+
+**NotebookLM settings:** Format = Presenter Slides
+
+**Accepted formats:** `.pdf`, `.pptx`
+**Naming:** `<topic>-presenter-<YYYY-MM-DD>.pdf`
+
+## Files
+
+| Date | File | Length | Language |
+|------|------|--------|----------|
+| *(pending)* | — | — | — |
+
+## Upload
+
+```bash
+bash scripts/upload-notebooklm.sh notebooklm-2026-06-17 path/to/slides.pdf
+```

--- a/docs/notebooklm/video-overview/brief/2026-06-17/README.md
+++ b/docs/notebooklm/video-overview/brief/2026-06-17/README.md
@@ -1,0 +1,7 @@
+# Video Overview — Brief — 2026-06-17
+
+Generated 2026-06-17. Format: Brief.
+
+| File | Visual Style | Prompt | Notes |
+|------|-------------|--------|-------|
+| *(pending)* | — | — | — |

--- a/docs/notebooklm/video-overview/brief/README.md
+++ b/docs/notebooklm/video-overview/brief/README.md
@@ -1,0 +1,17 @@
+# Video Overview — Brief
+
+Short-form overview hitting only the key points.
+
+**NotebookLM settings:** Format = Brief
+
+## Files
+
+| Date | File | Visual Style | Prompt |
+|------|------|-------------|--------|
+| *(pending)* | — | — | — |
+
+## Upload
+
+```bash
+bash scripts/upload-notebooklm.sh notebooklm-2026-06-17 path/to/video.mp4
+```

--- a/docs/notebooklm/video-overview/explainer/2026-06-17/README.md
+++ b/docs/notebooklm/video-overview/explainer/2026-06-17/README.md
@@ -1,0 +1,7 @@
+# Video Overview — Explainer — 2026-06-17
+
+Generated 2026-06-17. Format: Explainer.
+
+| File | Visual Style | Prompt | Notes |
+|------|-------------|--------|-------|
+| *(pending)* | — | — | — |

--- a/docs/notebooklm/video-overview/explainer/README.md
+++ b/docs/notebooklm/video-overview/explainer/README.md
@@ -1,0 +1,17 @@
+# Video Overview — Explainer
+
+Full explainer format with narration and visual flow.
+
+**NotebookLM settings:** Format = Explainer
+
+## Files
+
+| Date | File | Visual Style | Prompt |
+|------|------|-------------|--------|
+| *(pending)* | — | — | — |
+
+## Upload
+
+```bash
+bash scripts/upload-notebooklm.sh notebooklm-2026-06-17 path/to/video.mp4
+```

--- a/scripts/flush-sentinel.sh
+++ b/scripts/flush-sentinel.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+#
+# flush-sentinel.sh — runner slot reservation + queue clearing for flush pipeline
+#
+# Two responsibilities:
+#
+#   1. QUEUE CLEAR (run before flush starts)
+#      Cancels all non-CRITICAL queued runs so the flush pipeline has maximum
+#      runner availability. Tier 1 (CRITICAL) runs are never touched.
+#      Tier 2 (HIGH) runs are cancelled only if AGGRESSIVE_CLEAR=true.
+#
+#   2. KEEPALIVE (run as a background job during flush)
+#      Holds a runner slot open by sleeping in a loop, preventing GitHub from
+#      reclaiming the slot between flush stages. The sentinel exits when
+#      FLUSH_RUN_ID completes or SENTINEL_MAX_MINUTES is reached.
+#
+# Usage:
+#   # Queue clear (call once before dispatching flush):
+#   bash scripts/flush-sentinel.sh clear
+#
+#   # Keepalive (call in a parallel job, exits when flush run completes):
+#   FLUSH_RUN_ID=12345 bash scripts/flush-sentinel.sh keepalive
+#
+# Required env vars:
+#   GH_TOKEN          — PAT with actions:write scope
+#   GITHUB_REPOSITORY — owner/repo (set automatically in Actions)
+#
+# Optional env vars:
+#   AGGRESSIVE_CLEAR      — if "true", also cancel tier 2 (HIGH) queued runs
+#                           (default: false — only tier 3/4 are cleared)
+#   SENTINEL_MAX_MINUTES  — max minutes the keepalive will hold the slot
+#                           (default: 360 — 6 hours, covers longest flush)
+#   FLUSH_RUN_ID          — run ID to watch; keepalive exits when it completes
+#   SENTINEL_POLL_SECONDS — how often to poll run status (default: 60)
+#   DRY_RUN               — if "true", print actions without executing
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/includes/gh-api.sh"
+
+GH_TOKEN="${GH_TOKEN:-}"
+REPO="${GITHUB_REPOSITORY:-Interested-Deving-1896/fork-sync-all}"
+AGGRESSIVE_CLEAR="${AGGRESSIVE_CLEAR:-false}"
+SENTINEL_MAX_MINUTES="${SENTINEL_MAX_MINUTES:-360}"
+FLUSH_RUN_ID="${FLUSH_RUN_ID:-}"
+SENTINEL_POLL_SECONDS="${SENTINEL_POLL_SECONDS:-60}"
+DRY_RUN="${DRY_RUN:-false}"
+
+GH_API="https://api.github.com"
+MODE="${1:-clear}"
+
+info()  { echo "[flush-sentinel] $*" >&2; }
+warn()  { echo "[flush-sentinel:warn] $*" >&2; }
+dry()   { echo "[flush-sentinel:dry-run] $*" >&2; }
+
+# ── Load priority tiers ───────────────────────────────────────────────────────
+# Returns the tier number (1-4) for a workflow name. Defaults to 3 (MEDIUM).
+get_tier() {
+  local workflow_name="$1"
+  python3 - "${SCRIPT_DIR}/../config/workflow-priority-tiers.yml" "${workflow_name}" << 'PYEOF'
+import yaml, sys
+config_path, wf_name = sys.argv[1], sys.argv[2]
+try:
+    config = yaml.safe_load(open(config_path))
+    tiers = config.get("tiers", {})
+    for tier_num, tier_data in tiers.items():
+        workflows = tier_data.get("workflows", [])
+        if any(wf_name == w.get("name", w) if isinstance(w, dict) else wf_name == w for w in workflows):
+            print(tier_num)
+            sys.exit(0)
+    print(3)  # default MEDIUM
+except Exception:
+    print(3)
+PYEOF
+}
+
+# ── Queue clear ───────────────────────────────────────────────────────────────
+do_queue_clear() {
+  info "Clearing queued runs to free runner slots for flush pipeline..."
+  info "  Aggressive clear: ${AGGRESSIVE_CLEAR}"
+
+  local queued_runs
+  queued_runs=$(gh_get "${GH_API}/repos/${REPO}/actions/runs?status=queued&per_page=100" \
+    | python3 -c "import json,sys; d=json.load(sys.stdin); [print(r['id'], r['name']) for r in d.get('workflow_runs',[])]" 2>/dev/null || echo "")
+
+  if [[ -z "${queued_runs}" ]]; then
+    info "No queued runs found — queue is clear"
+    return 0
+  fi
+
+  local cancelled=0 skipped=0
+  while IFS=' ' read -r run_id run_name; do
+    [[ -z "${run_id}" ]] && continue
+
+    local tier
+    tier=$(get_tier "${run_name}")
+
+    # Never cancel tier 1 (CRITICAL)
+    if [[ "${tier}" == "1" ]]; then
+      info "  SKIP (tier 1 CRITICAL): ${run_name} [${run_id}]"
+      ((skipped++)) || true
+      continue
+    fi
+
+    # Skip tier 2 (HIGH) unless aggressive clear
+    if [[ "${tier}" == "2" ]] && [[ "${AGGRESSIVE_CLEAR}" != "true" ]]; then
+      info "  SKIP (tier 2 HIGH, not aggressive): ${run_name} [${run_id}]"
+      ((skipped++)) || true
+      continue
+    fi
+
+    if [[ "${DRY_RUN}" == "true" ]]; then
+      dry "  Would cancel tier ${tier}: ${run_name} [${run_id}]"
+      ((cancelled++)) || true
+      continue
+    fi
+
+    if gh_api "POST" "${GH_API}/repos/${REPO}/actions/runs/${run_id}/cancel" > /dev/null 2>&1; then
+      info "  Cancelled tier ${tier}: ${run_name} [${run_id}]"
+      ((cancelled++)) || true
+    else
+      warn "  Failed to cancel: ${run_name} [${run_id}]"
+    fi
+  done <<< "${queued_runs}"
+
+  info "Queue clear complete: ${cancelled} cancelled, ${skipped} skipped"
+  echo "sentinel_cleared=${cancelled}" >> "${GITHUB_OUTPUT:-/dev/null}"
+}
+
+# ── Keepalive ─────────────────────────────────────────────────────────────────
+do_keepalive() {
+  local max_seconds=$(( SENTINEL_MAX_MINUTES * 60 ))
+  local elapsed=0
+
+  info "Keepalive started — holding runner slot for up to ${SENTINEL_MAX_MINUTES} min"
+  [[ -n "${FLUSH_RUN_ID}" ]] && info "  Watching flush run: ${FLUSH_RUN_ID}"
+
+  while [[ ${elapsed} -lt ${max_seconds} ]]; do
+    sleep "${SENTINEL_POLL_SECONDS}"
+    elapsed=$(( elapsed + SENTINEL_POLL_SECONDS ))
+
+    # Check if the watched flush run has completed
+    if [[ -n "${FLUSH_RUN_ID}" ]]; then
+      local run_status
+      run_status=$(gh_get "${GH_API}/repos/${REPO}/actions/runs/${FLUSH_RUN_ID}" \
+        | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('status','unknown'))" 2>/dev/null || echo "unknown")
+
+      if [[ "${run_status}" == "completed" ]]; then
+        info "Flush run ${FLUSH_RUN_ID} completed — releasing runner slot"
+        echo "sentinel_exit=flush_completed" >> "${GITHUB_OUTPUT:-/dev/null}"
+        return 0
+      fi
+
+      info "  [${elapsed}s/${max_seconds}s] Flush run status: ${run_status} — holding slot"
+    else
+      info "  [${elapsed}s/${max_seconds}s] Holding runner slot (no run ID to watch)"
+    fi
+  done
+
+  warn "Sentinel max time (${SENTINEL_MAX_MINUTES} min) reached — releasing slot"
+  echo "sentinel_exit=timeout" >> "${GITHUB_OUTPUT:-/dev/null}"
+}
+
+# ── Dispatch ──────────────────────────────────────────────────────────────────
+case "${MODE}" in
+  clear)     do_queue_clear ;;
+  keepalive) do_keepalive ;;
+  *)
+    echo "Usage: $0 {clear|keepalive}" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/inject-badges.sh
+++ b/scripts/inject-badges.sh
@@ -192,25 +192,28 @@ make_ona_badge() {
   echo "[![Built with Ona](${BADGE_SVG})](${BADGE_BASE}${url})"
 }
 
-# make_eco_ci_badge owner repo
+# make_eco_ci_badge full_repo_path
 # Returns the metrics.green-coding.io energy badge for the repo's eco-audit run.
-# The badge URL is constructed from the repo slug and workflow filename.
+# full_repo_path must be the complete path as it appears in the SCM
+# (e.g. "owner/repo" for GitHub, "group/subgroup/repo" for GitLab subgroups).
 make_eco_ci_badge() {
-  local owner="$1" repo="$2"
+  local full_path="$1"
   local encoded_repo
-  encoded_repo=$(python3 -c "import urllib.parse; print(urllib.parse.quote('${owner}/${repo}', safe=''))" 2>/dev/null || echo "${owner}%2F${repo}")
+  encoded_repo=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "${full_path}" 2>/dev/null || python3 -c "import urllib.parse; print(urllib.parse.quote('${full_path}', safe=''))" 2>/dev/null || echo "${full_path//\//%2F}")
   echo "[![Energy](https://api.green-coding.io/v1/ci/badge/get?repo=${encoded_repo}&branch=main&workflow=${ECO_CI_WORKFLOW})](https://metrics.green-coding.io/ci-index.html)"
 }
 
-# make_badge_line owner repo platform_url
+# make_badge_line owner repo platform_url [full_scm_path]
 # Returns the full badge line: Ona + KDE Eco + Blue Angel + eco-ci (if ECO_BADGES=true)
+# full_scm_path defaults to owner/repo but should be the complete subgroup path
+# for GitLab repos (e.g. "openos-project/systems/fork-sync-all").
 make_badge_line() {
-  local owner="$1" repo="$2" platform_url="$3"
+  local owner="$1" repo="$2" platform_url="$3" full_scm_path="${4:-${1}/${2}}"
   local ona_badge
   ona_badge=$(make_ona_badge "${platform_url}")
   if [[ "${ECO_BADGES}" == "true" ]]; then
     local eco_ci_badge
-    eco_ci_badge=$(make_eco_ci_badge "${owner}" "${repo}")
+    eco_ci_badge=$(make_eco_ci_badge "${full_scm_path}")
     echo "${ona_badge} ${KDE_ECO_BADGE} ${BLUE_ANGEL_BADGE} ${eco_ci_badge}"
   else
     echo "${ona_badge}"
@@ -339,7 +342,8 @@ process_gl_project() {
   local badge target_url
   local target_url="https://gitlab.com/${project_path}"
 
-  # Derive owner/repo from project_path (namespace/repo) for eco-ci badge URL
+  # gl_owner/gl_repo used for display only; full project_path passed to
+  # make_badge_line so the eco-ci badge URL encodes the complete subgroup path.
   local gl_owner gl_repo
   gl_owner=$(echo "$project_path" | cut -d/ -f1)
   gl_repo=$(echo "$project_path" | rev | cut -d/ -f1 | rev)
@@ -359,7 +363,8 @@ process_gl_project() {
   fi
 
   local badge_line new_content
-  badge_line=$(make_badge_line "$gl_owner" "$gl_repo" "$target_url")
+  # Pass project_path as full_scm_path so eco-ci badge URL is correct for subgroups
+  badge_line=$(make_badge_line "$gl_owner" "$gl_repo" "$target_url" "$project_path")
 
   local stripped_content
   stripped_content=$(echo "$content" | grep -v "ona\.com/build-with-ona\|eco\.kde\.org\|blauer-engel\.de\|green-coding\.io" || true)

--- a/scripts/queue-manager.sh
+++ b/scripts/queue-manager.sh
@@ -37,6 +37,10 @@ STALE_QUEUE_MIN="${STALE_QUEUE_MIN:-25}"
 DRY_RUN="${DRY_RUN:-false}"
 MIN_QUOTA="${MIN_QUOTA:-500}"
 THIS_RUN_ID="${THIS_RUN_ID:-0}"
+# FLUSH_ACTIVE — set by flush-lifecycle.yml while the flush pipeline is running.
+# When true, queue-manager skips eviction of tier 2 (HIGH) runs so flush stages
+# are not cancelled mid-pipeline. Tier 1 (CRITICAL) is always protected.
+FLUSH_ACTIVE="${FLUSH_ACTIVE:-${VARS_FLUSH_ACTIVE:-false}}"
 
 info() { echo "[queue-manager] $*" >&2; }
 dry()  { echo "[queue-manager][dry-run] $*" >&2; }
@@ -109,6 +113,9 @@ fi
 # Pass 2: Evict — cancel runs queued longer than STALE_QUEUE_MIN
 # Both passes respect the protected list and THIS_RUN_ID.
 
+if [[ "${FLUSH_ACTIVE}" == "true" ]]; then
+  info "FLUSH_ACTIVE=true — tier 2 (HIGH) runs are protected from eviction"
+fi
 info "Running dedup + evict passes (stale threshold: ${STALE_QUEUE_MIN} min)..."
 
 # Write queued_json to a tempfile — avoids env var size limits and shell
@@ -121,6 +128,7 @@ cancel_ids=$(THIS_RUN_ID="$THIS_RUN_ID" \
              STALE_QUEUE_MIN="$STALE_QUEUE_MIN" \
              QJSON_FILE="$_qjson_tmp" \
              TIERS_FILE="$TIERS_FILE" \
+             FLUSH_ACTIVE="$FLUSH_ACTIVE" \
              python3 - <<'PYEOF'
 import json, os, yaml
 from datetime import datetime, timezone, timedelta
@@ -129,10 +137,31 @@ from collections import defaultdict
 with open(os.environ["QJSON_FILE"]) as f:
     runs = json.load(f)
 
-# Load tier map — tier 1 = protected
+# Load tier map — tier 1 = protected, tier 2 = protected during flush
 with open(os.environ["TIERS_FILE"]) as f:
     tiers_cfg = yaml.safe_load(f)
-protected = {e["name"] for e in tiers_cfg.get("tiers", []) if e.get("tier") == 1}
+
+flush_active = os.environ.get("FLUSH_ACTIVE", "false").lower() == "true"
+
+# Build name→tier map
+tier_map = {}
+for entry in tiers_cfg.get("tiers", []):
+    tier_num = entry.get("tier", 3)
+    for wf in entry.get("workflows", []):
+        name = wf.get("name", wf) if isinstance(wf, dict) else wf
+        tier_map[name] = tier_num
+
+def get_tier(name):
+    return tier_map.get(name, 3)
+
+# Protected: tier 1 always; tier 2 also protected when flush is active
+def is_protected(name):
+    t = get_tier(name)
+    if t == 1:
+        return True
+    if flush_active and t == 2:
+        return True
+    return False
 
 this_run     = int(os.environ.get("THIS_RUN_ID", "0"))
 stale_min    = int(os.environ.get("STALE_QUEUE_MIN", "25"))
@@ -146,7 +175,7 @@ for run in runs:
 to_cancel = {}  # id -> reason
 
 for wf_name, wf_runs in by_workflow.items():
-    if wf_name in protected:
+    if is_protected(wf_name):
         continue
     # Sort newest first
     wf_runs.sort(key=lambda r: r["created_at"], reverse=True)

--- a/scripts/quota-reserve.sh
+++ b/scripts/quota-reserve.sh
@@ -43,6 +43,10 @@ GRACE_MIN="${GRACE_MIN:-5}"
 DRY_RUN="${DRY_RUN:-false}"
 THIS_RUN_ID="${THIS_RUN_ID:-0}"
 API="https://api.github.com"
+# FLUSH_ACTIVE — set by flush-lifecycle.yml while the flush pipeline is running.
+# When true, quota-reserve raises the effective tier floor to 2 so flush stages
+# (tier 2 HIGH) are never cancelled to recover quota headroom.
+FLUSH_ACTIVE="${FLUSH_ACTIVE:-${VARS_FLUSH_ACTIVE:-false}}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TIERS_FILE="${SCRIPT_DIR}/../config/workflow-priority-tiers.yml"
@@ -86,6 +90,9 @@ fi
 
 deficit=$(( RESERVE_FLOOR - remaining ))
 info "Quota below reserve floor by ${deficit} calls — scanning queued runs..."
+if [[ "${FLUSH_ACTIVE}" == "true" ]]; then
+  info "FLUSH_ACTIVE=true — tier 2 (HIGH) runs are protected from cancellation"
+fi
 
 # ── Priority tiers ────────────────────────────────────────────────────────────
 # Workflows are cancelled lowest-priority-first.
@@ -213,7 +220,7 @@ while IFS='|' read -r run_id name tier age; do
   fi
 done < <(THIS_RUN_ID="$THIS_RUN_ID" GRACE_MIN="$GRACE_MIN" \
   QJSON_FILE="$_qjson_tmp" TIERS_FILE="$TIERS_FILE" COSTS_FILE="$COSTS_FILE" \
-  REMAINING="$remaining" RESERVE_FLOOR="$RESERVE_FLOOR" \
+  REMAINING="$remaining" RESERVE_FLOOR="$RESERVE_FLOOR" FLUSH_ACTIVE="$FLUSH_ACTIVE" \
   python3 - <<'PYEOF'
 import json, os, sys, yaml
 from datetime import datetime, timezone, timedelta
@@ -241,6 +248,7 @@ remaining     = int(os.environ.get("REMAINING", "0"))
 reserve_floor = int(os.environ.get("RESERVE_FLOOR", "1000"))
 this_run      = int(os.environ.get("THIS_RUN_ID", "0"))
 grace_min     = int(os.environ.get("GRACE_MIN", "5"))
+flush_active  = os.environ.get("FLUSH_ACTIVE", "false").lower() == "true"
 now           = datetime.now(timezone.utc)
 grace_cut     = now - timedelta(minutes=grace_min)
 
@@ -251,7 +259,13 @@ for run in runs:
     created = datetime.fromisoformat(run["created_at"].replace("Z", "+00:00"))
     tier    = tier_map.get(name, default_tier)
 
+    # Tier 1 (CRITICAL) is always protected.
+    # Tier 2 (HIGH) is also protected while flush pipeline is active —
+    # cancelling a flush stage mid-pipeline would leave the system in a
+    # partially-flushed state that is harder to recover than waiting for quota.
     if rid == this_run or tier == 1 or created > grace_cut:
+        continue
+    if flush_active and tier == 2:
         continue
 
     # Cost-aware cancellation: also cancel if remaining < this workflow's min_quota

--- a/scripts/update-readmes.sh
+++ b/scripts/update-readmes.sh
@@ -587,16 +587,16 @@ ECO_BADGES="${ECO_BADGES:-true}"
 ECO_CI_WORKFLOW="${ECO_CI_WORKFLOW:-eco-audit.yml}"
 
 badge_line_for() {
-  local owner="$1" repo="$2" platform="${3:-github}"
+  local owner="$1" repo="$2" platform="${3:-github}" full_scm_path="${4:-${1}/${2}}"
   local target_url
   case "$platform" in
-    gitlab) target_url="https://gitlab.com/${owner}/${repo}" ;;
+    gitlab) target_url="https://gitlab.com/${full_scm_path}" ;;
     *)      target_url="https://github.com/${owner}/${repo}" ;;
   esac
   local ona_badge="[![Built with Ona](${BADGE_SVG})](${BADGE_BASE_URL}${target_url})"
   if [[ "${ECO_BADGES}" == "true" ]]; then
     local encoded_repo
-    encoded_repo=$(python3 -c "import urllib.parse; print(urllib.parse.quote('${owner}/${repo}', safe=''))" 2>/dev/null || echo "${owner}%2F${repo}")
+    encoded_repo=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "${full_scm_path}" 2>/dev/null || echo "${full_scm_path//\//%2F}")
     local eco_ci_badge="[![Energy](https://api.green-coding.io/v1/ci/badge/get?repo=${encoded_repo}&branch=main&workflow=${ECO_CI_WORKFLOW})](https://metrics.green-coding.io/ci-index.html)"
     echo "${ona_badge} ${_KDE_ECO_BADGE} ${_BLUE_ANGEL_BADGE} ${eco_ci_badge}"
   else


### PR DESCRIPTION
$## Summary\n\nThree independent improvements.\n\n### 1. Flush Lifecycle Manager\n\nNew `flush-lifecycle.yml` workflow + `flush-sentinel.sh` script that coordinates the `pre-flush-prep → full-chain-flush → post-flush-prep` pipeline with quota reservation, runner slot holding, and pause/resume at quota reset.\n\n**How it works:**\n1. Checks quota ≥1500 before starting — hard-aborts if insufficient\n2. Sets `FLUSH_ACTIVE=true` as a repo Actions variable\n3. Clears non-CRITICAL queued runs via `flush-sentinel.sh clear` to free runner slots\n4. Starts a parallel **sentinel job** that holds a runner slot by polling the lifecycle job status every 60s\n5. Dispatches `pre-flush-prep`, waits, checks quota\n6. If quota < 600 between stages: sleeps until reset (polls every 2 min, max 65 min), then continues\n7. Dispatches `full-chain-flush`, waits, checks quota again\n8. Dispatches `post-flush-prep`\n9. Clears `FLUSH_ACTIVE=false` in an `always()` step\n\n**queue-manager + quota-reserve awareness:**\n- Both scripts now read `FLUSH_ACTIVE` from env (passed as `vars.FLUSH_ACTIVE` in their workflows)\n- When `FLUSH_ACTIVE=true`: tier 2 (HIGH) runs are excluded from eviction/cancellation\n- Tier 1 (CRITICAL) is always protected regardless\n\n**Config:**\n- `workflow-priority-tiers.yml` — Flush Lifecycle Manager at tier 1\n- `workflow-quota-costs.yml` — min_quota: 1500\n- `workflow-sync.yml` — registered under github_only\n\n### 2. NotebookLM variant + date-stamped subdirectories\n\nExpands `docs/notebooklm/` to match all customization options in NotebookLM Studio (from screenshots):\n\n| Type | Variants |\n|---|---|\n| audio-overview | short / medium / long |\n| video-overview | explainer / brief |\n| slide-deck | detailed / presenter |\n| flashcards | fewer/standard/more × easy/medium/hard |\n| quiz | fewer/standard/more × easy/medium/hard |\n| infographic | landscape / portrait / square |\n| reports | briefing-doc / study-guide / blog-post |\n\nEach variant dir has a `README.md` (settings, formats, naming, upload command) and a `2026-06-17/` date-stamped session subdir.\n\n### 3. GitLab eco-ci badge subgroup path fix\n\n`make_eco_ci_badge()` now takes a `full_path` argument. `make_badge_line()` accepts an optional `full_scm_path` (defaults to `owner/repo`). The GitLab processor passes `project_path` as `full_scm_path` so repos in subgroups (e.g. `openos-project/systems/fork-sync-all`) get a correctly URL-encoded eco-ci badge. Same fix applied to `update-readmes.sh`.