### PR TITLE
feat: platform hardening — self-hosted git platforms, pipeline-guard tests, qi instrumentation

### DIFF
--- a/.github/workflows/critical-deploy-all.yml
+++ b/.github/workflows/critical-deploy-all.yml
@@ -158,7 +158,10 @@ jobs:
           WORKFLOWS: ${{ inputs.workflows }}
           WORKFLOW_INPUTS: ${{ inputs.workflow_inputs }}
           DRY_RUN: ${{ inputs.dry_run }}
-        run: bash scripts/critical-deploy-github.sh
+        run: |
+          source scripts/includes/quota-instrument.sh
+          qi_begin
+          bash scripts/critical-deploy-github.sh
 
       - name: Release pipeline on failure (clear FLUSH_ACTIVE)
         if: failure()
@@ -173,10 +176,14 @@ jobs:
       - name: Write summary
         if: always()
         env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
           JOB_STATUS: ${{ job.status }}
           DEPLOY_TARGET: Interested-Deving-1896
           INPUTS_JSON: ${{ toJSON(inputs) }}
-        run: bash scripts/write-summary.sh
+        run: |
+          source scripts/includes/quota-instrument.sh
+          qi_end
+          bash scripts/write-summary.sh
 
   # ── Job 1b: Quota checkpoint before OSP + OOC ────────────────────────────
   quota-checkpoint-1:
@@ -222,15 +229,22 @@ jobs:
           WORKFLOWS: ${{ inputs.workflows }}
           WORKFLOW_INPUTS: ${{ inputs.workflow_inputs }}
           DRY_RUN: ${{ inputs.dry_run }}
-        run: bash scripts/critical-deploy-github.sh
+        run: |
+          source scripts/includes/quota-instrument.sh
+          qi_begin
+          bash scripts/critical-deploy-github.sh
 
       - name: Write summary
         if: always()
         env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
           JOB_STATUS: ${{ job.status }}
           DEPLOY_TARGET: OpenOS-Project-OSP
           INPUTS_JSON: ${{ toJSON(inputs) }}
-        run: bash scripts/write-summary.sh
+        run: |
+          source scripts/includes/quota-instrument.sh
+          qi_end
+          bash scripts/write-summary.sh
 
   # ── Job 3: OOC mirror (parallel with OSP, after quota checkpoint) ────────
   deploy-ooc:
@@ -258,15 +272,22 @@ jobs:
           WORKFLOWS: ${{ inputs.workflows }}
           WORKFLOW_INPUTS: ${{ inputs.workflow_inputs }}
           DRY_RUN: ${{ inputs.dry_run }}
-        run: bash scripts/critical-deploy-github.sh
+        run: |
+          source scripts/includes/quota-instrument.sh
+          qi_begin
+          bash scripts/critical-deploy-github.sh
 
       - name: Write summary
         if: always()
         env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
           JOB_STATUS: ${{ job.status }}
           DEPLOY_TARGET: OpenOS-Project-Ecosystem-OOC
           INPUTS_JSON: ${{ toJSON(inputs) }}
-        run: bash scripts/write-summary.sh
+        run: |
+          source scripts/includes/quota-instrument.sh
+          qi_end
+          bash scripts/write-summary.sh
 
   # ── Job 3b: Quota checkpoint before GitLab ───────────────────────────────
   quota-checkpoint-2:
@@ -310,7 +331,10 @@ jobs:
           TRIGGER_PIPELINE: ${{ inputs.trigger_pipeline }}
           TRIGGER_CADENCE: ${{ inputs.trigger_cadence }}
           DRY_RUN: ${{ inputs.dry_run }}
-        run: bash scripts/critical-deploy-gitlab.sh
+        run: |
+          source scripts/includes/quota-instrument.sh
+          qi_begin
+          bash scripts/critical-deploy-gitlab.sh
 
       - name: Release pipeline (clear FLUSH_ACTIVE)
         if: always()
@@ -325,7 +349,11 @@ jobs:
       - name: Write summary
         if: always()
         env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
           JOB_STATUS: ${{ job.status }}
           DEPLOY_TARGET: GitLab
           INPUTS_JSON: ${{ toJSON(inputs) }}
-        run: bash scripts/write-summary.sh
+        run: |
+          source scripts/includes/quota-instrument.sh
+          qi_end
+          bash scripts/write-summary.sh

--- a/.github/workflows/critical-deploy-github-ooc.yml
+++ b/.github/workflows/critical-deploy-github-ooc.yml
@@ -115,7 +115,10 @@ jobs:
           WORKFLOWS: ${{ inputs.workflows }}
           WORKFLOW_INPUTS: ${{ inputs.workflow_inputs }}
           DRY_RUN: ${{ inputs.dry_run }}
-        run: bash scripts/critical-deploy-github.sh
+        run: |
+          source scripts/includes/quota-instrument.sh
+          qi_begin
+          bash scripts/critical-deploy-github.sh
 
       - name: Release pipeline (clear FLUSH_ACTIVE)
         if: always()
@@ -130,6 +133,10 @@ jobs:
       - name: Write summary
         if: always()
         env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
           JOB_STATUS: ${{ job.status }}
           INPUTS_JSON: ${{ toJSON(inputs) }}
-        run: bash scripts/write-summary.sh
+        run: |
+          source scripts/includes/quota-instrument.sh
+          qi_end
+          bash scripts/write-summary.sh

--- a/.github/workflows/critical-deploy-github-osp.yml
+++ b/.github/workflows/critical-deploy-github-osp.yml
@@ -115,7 +115,10 @@ jobs:
           WORKFLOWS: ${{ inputs.workflows }}
           WORKFLOW_INPUTS: ${{ inputs.workflow_inputs }}
           DRY_RUN: ${{ inputs.dry_run }}
-        run: bash scripts/critical-deploy-github.sh
+        run: |
+          source scripts/includes/quota-instrument.sh
+          qi_begin
+          bash scripts/critical-deploy-github.sh
 
       - name: Release pipeline (clear FLUSH_ACTIVE)
         if: always()
@@ -130,6 +133,10 @@ jobs:
       - name: Write summary
         if: always()
         env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
           JOB_STATUS: ${{ job.status }}
           INPUTS_JSON: ${{ toJSON(inputs) }}
-        run: bash scripts/write-summary.sh
+        run: |
+          source scripts/includes/quota-instrument.sh
+          qi_end
+          bash scripts/write-summary.sh

--- a/.github/workflows/critical-deploy-gitlab.yml
+++ b/.github/workflows/critical-deploy-gitlab.yml
@@ -126,7 +126,10 @@ jobs:
           TRIGGER_PIPELINE: ${{ inputs.trigger_pipeline }}
           TRIGGER_CADENCE: ${{ inputs.trigger_cadence }}
           DRY_RUN: ${{ inputs.dry_run }}
-        run: bash scripts/critical-deploy-gitlab.sh
+        run: |
+          source scripts/includes/quota-instrument.sh
+          qi_begin
+          bash scripts/critical-deploy-gitlab.sh
 
       - name: Release pipeline (clear FLUSH_ACTIVE)
         if: always()
@@ -141,6 +144,10 @@ jobs:
       - name: Write summary
         if: always()
         env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
           JOB_STATUS: ${{ job.status }}
           INPUTS_JSON: ${{ toJSON(inputs) }}
-        run: bash scripts/write-summary.sh
+        run: |
+          source scripts/includes/quota-instrument.sh
+          qi_end
+          bash scripts/write-summary.sh

--- a/.github/workflows/critical-deploy-stub.yml
+++ b/.github/workflows/critical-deploy-stub.yml
@@ -1,11 +1,11 @@
-name: Critical Deploy — Stub (TODO)
+name: Critical Deploy — Stub (template — not functional)
 
 # ╔══════════════════════════════════════════════════════════════════════════╗
-# ║  STUB — NOT FUNCTIONAL UNTIL ALL TODO SECTIONS ARE FILLED IN            ║
+# ║  TEMPLATE — NOT FUNCTIONAL — copy, rename, and fill in before using     ║
 # ╚══════════════════════════════════════════════════════════════════════════╝
 #
 # Template for adding a new platform to the critical deploy chain.
-# Copy this file, rename it, and fill in every section marked TODO.
+# Copy this file, rename it, and fill in the platform-specific sections.
 #
 # ── How to activate ──────────────────────────────────────────────────────────
 #
@@ -18,21 +18,26 @@ name: Critical Deploy — Stub (TODO)
 #           scripts/critical-deploy-<platform>.sh
 #        chmod +x scripts/critical-deploy-<platform>.sh
 #
-#   3. Fill in every TODO in both files (search for "TODO").
-#
-#   4. Update the workflow name: field (line 1) — queue-manager and
+#   3. Update the workflow name: field (line 1) — queue-manager and
 #      quota-reserve match workflows by name, not filename.
+#
+#   4. Uncomment the deploy step template matching your platform (see below),
+#      fill in the <FILL_IN> values, and remove the stub guard step.
 #
 #   5. Wire into critical-deploy-all.yml as a new job following the
 #      deploy-gitlab pattern (depends on deploy-ooc, runs last).
 #
 #   6. Register in config files:
-#        config/workflow-sync.yml          — github_only section
+#        config/workflow-sync.yml           — github_only section
 #        config/workflow-priority-tiers.yml — tier 1, use the workflow name:
-#        config/workflow-quota-costs.yml   — with estimated costs
+#        config/workflow-quota-costs.yml    — with estimated costs
 #
 #   7. Add the platform token as a GitHub Actions secret:
-#        gh secret set TODO_PLATFORM_TOKEN --repo Interested-Deving-1896/fork-sync-all
+#        gh secret set <PLATFORM>_TOKEN --repo Interested-Deving-1896/fork-sync-all
+#        # Bitbucket: BITBUCKET_TOKEN (may already exist)
+#        # Gitea/Forgejo: GITEA_TOKEN (may already exist)
+#        # Sourcehut: SOURCEHUT_TOKEN
+#        # Gogs: GOGS_TOKEN
 #
 #   8. Run: python3 scripts/validate-workflow-guards.py
 #
@@ -71,22 +76,22 @@ name: Critical Deploy — Stub (TODO)
 #     cancel action: POST https://builds.sr.ht/api/jobs/{id}/cancel
 #     trigger      : POST https://builds.sr.ht/api/jobs  (manifest required)
 #     user endpoint: GET  https://meta.sr.ht/api/user → .name
-#     git push URL : https://TODO_USER:{TOKEN}@git.sr.ht/~{user}/{repo}
+#     git push URL : https://<user>:{TOKEN}@git.sr.ht/~<user>/{repo}
 #     note         : public repos need no token for read; write always needs one
 
 on:
   workflow_dispatch:
     inputs:
-      # ── TODO: Replace placeholder descriptions with platform-specific text ──
+      # Replace descriptions with platform-specific text after copying this file.
 
       push_to_platform:
-        description: 'Phase 1 — Push current HEAD to TODO_PLATFORM_NAME'
+        description: 'Phase 1 — Push current HEAD to the target platform'
         type: boolean
         required: false
         default: false
 
       clear_pipelines:
-        description: 'Phase 2 — Cancel all pending/running TODO_PLATFORM_NAME pipelines'
+        description: 'Phase 2 — Cancel all pending/running pipelines on the target platform'
         type: boolean
         required: false
         default: false
@@ -103,7 +108,7 @@ on:
         required: false
         default: ''
 
-      # ── TODO: Add platform-specific inputs below ────────────────────────────
+      # Uncomment the platform-specific inputs that apply after copying this file.
       #
       # Gitea / Forgejo — instance URL varies per deployment:
       #   gitea_base_url:
@@ -132,7 +137,8 @@ on:
         required: false
         default: false
 
-# TODO: update group name to match the platform (e.g. critical-deploy-bitbucket)
+# When copying this template, update the group name to match the platform,
+# e.g. critical-deploy-bitbucket, critical-deploy-gitea, etc.
 concurrency:
   group: critical-deploy-stub
   cancel-in-progress: false
@@ -142,7 +148,7 @@ permissions:
 
 jobs:
   deploy:
-    name: Deploy — TODO_PLATFORM_NAME
+    name: Deploy — (stub — fill in platform name)
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -152,41 +158,156 @@ jobs:
           fetch-depth: 1
           token: ${{ secrets.SYNC_TOKEN }}
 
-      # ── TODO: Guard step — remove once the script is fully implemented ──────
+      # ── Guard: fail immediately — this file is a template, not a live workflow
       - name: Stub guard
         run: |
-          echo "::error::This workflow is a stub and has not been implemented yet."
-          echo "::error::Copy critical-deploy-stub.yml and critical-deploy-stub.sh,"
-          echo "::error::rename both files, and fill in all TODO sections."
+          echo "::error::This workflow is a template and has not been implemented."
+          echo "::error::Copy critical-deploy-stub.yml + critical-deploy-stub.sh,"
+          echo "::error::rename both, and fill in the platform-specific sections."
           exit 1
 
-      # ── TODO: Replace this step once the stub guard above is removed ─────────
-      # ── TODO: Replace TODO_PLATFORM_TOKEN with the correct secret name ──────
-      # ── TODO: Rename critical-deploy-stub.sh to critical-deploy-<platform>.sh
+      # ─────────────────────────────────────────────────────────────────────────
+      # DEPLOY STEP TEMPLATES — copy the block matching your target platform,
+      # remove the stub guard above, and fill in the values marked <FILL_IN>.
+      # ─────────────────────────────────────────────────────────────────────────
+
+      # ── Bitbucket ─────────────────────────────────────────────────────────
+      # Token:   secrets.BITBUCKET_TOKEN  (already used by sync-registered-imports)
+      # Auth:    Bearer (REST v2) or x-token-auth (git push)
+      # API:     https://api.bitbucket.org/2.0/repositories/{workspace}/{repo}/pipelines/
+      # Cancel:  POST .../pipelines/{uuid}/stopPipeline
+      # Trigger: POST .../pipelines/ with {"target":{"ref_name":"main","ref_type":"branch"}}
+      # Push:    https://x-token-auth:{TOKEN}@bitbucket.org/{workspace}/{repo}.git
       #
-      # Template for the deploy step — uncomment and fill in after copying:
-      #
-      # - name: Critical deploy — TODO_PLATFORM_NAME
+      # - name: Critical deploy — Bitbucket
       #   env:
-      #     # Bitbucket:  ${{ secrets.BITBUCKET_TOKEN }}
-      #     # Gitea:      ${{ secrets.GITEA_TOKEN }}
-      #     # Forgejo:    ${{ secrets.GITEA_TOKEN }}
-      #     # Sourcehut:  ${{ secrets.SOURCEHUT_TOKEN }}
-      #     TODO_PLATFORM_TOKEN: ${{ secrets.TODO_PLATFORM_TOKEN }}
-      #     TODO_PROJECT_ID: 'TODO_PROJECT_ID'
-      #     TODO_PROJECT_PATH: 'TODO_ORG/TODO_REPO'
-      #     TODO_BASE_URL: 'https://TODO.example.com/api'
+      #     BITBUCKET_TOKEN: ${{ secrets.BITBUCKET_TOKEN }}
+      #     BITBUCKET_WORKSPACE: '<FILL_IN>'        # e.g. openos-project
+      #     BITBUCKET_REPO: 'fork-sync-all'
       #     PUSH_TO_PLATFORM: ${{ inputs.push_to_platform }}
       #     CLEAR_PIPELINES: ${{ inputs.clear_pipelines }}
       #     TRIGGER_PIPELINE: ${{ inputs.trigger_pipeline }}
       #     TRIGGER_VARS: ${{ inputs.trigger_vars }}
       #     DRY_RUN: ${{ inputs.dry_run }}
-      #   run: bash scripts/critical-deploy-<platform>.sh
+      #   run: |
+      #     source scripts/includes/quota-instrument.sh
+      #     qi_begin
+      #     bash scripts/critical-deploy-bitbucket.sh
+
+      # ── Gitea (self-hosted) ───────────────────────────────────────────────
+      # Token:   secrets.GITEA_TOKEN  (already used by sync-registered-imports)
+      # Auth:    token {TOKEN}  (Authorization header)
+      # API:     {BASE_URL}/api/v1/repos/{owner}/{repo}/actions/runs
+      # Cancel:  POST .../actions/runs/{run_id}/cancel
+      # Trigger: POST .../actions/workflows/{workflow_id}/dispatches
+      # Push:    https://x-access-token:{TOKEN}@{host}/{owner}/{repo}.git
+      # Note:    BASE_URL varies per instance — pass as input or env var
+      #
+      # - name: Critical deploy — Gitea
+      #   env:
+      #     GITEA_TOKEN: ${{ secrets.GITEA_TOKEN }}
+      #     GITEA_BASE_URL: ${{ inputs.gitea_base_url || 'https://gitea.example.com' }}
+      #     GITEA_OWNER: '<FILL_IN>'
+      #     GITEA_REPO: 'fork-sync-all'
+      #     PUSH_TO_PLATFORM: ${{ inputs.push_to_platform }}
+      #     CLEAR_PIPELINES: ${{ inputs.clear_pipelines }}
+      #     TRIGGER_PIPELINE: ${{ inputs.trigger_pipeline }}
+      #     WORKFLOW_ID: ${{ inputs.workflow_id || 'deploy.yml' }}
+      #     DRY_RUN: ${{ inputs.dry_run }}
+      #   run: |
+      #     source scripts/includes/quota-instrument.sh
+      #     qi_begin
+      #     bash scripts/critical-deploy-gitea.sh
+
+      # ── Forgejo / Codeberg ────────────────────────────────────────────────
+      # Token:   secrets.GITEA_TOKEN  (Codeberg is a Forgejo instance — same API)
+      # Auth:    token {TOKEN}  (identical to Gitea)
+      # API:     same as Gitea Actions API
+      # Push:    https://x-access-token:{TOKEN}@codeberg.org/{owner}/{repo}.git
+      # Note:    For non-Codeberg Forgejo instances, set FORGEJO_BASE_URL
+      #
+      # - name: Critical deploy — Forgejo / Codeberg
+      #   env:
+      #     GITEA_TOKEN: ${{ secrets.GITEA_TOKEN }}
+      #     FORGEJO_BASE_URL: ${{ inputs.forgejo_base_url || 'https://codeberg.org' }}
+      #     FORGEJO_OWNER: '<FILL_IN>'
+      #     FORGEJO_REPO: 'fork-sync-all'
+      #     PUSH_TO_PLATFORM: ${{ inputs.push_to_platform }}
+      #     CLEAR_PIPELINES: ${{ inputs.clear_pipelines }}
+      #     TRIGGER_PIPELINE: ${{ inputs.trigger_pipeline }}
+      #     WORKFLOW_ID: ${{ inputs.workflow_id || 'deploy.yml' }}
+      #     DRY_RUN: ${{ inputs.dry_run }}
+      #   run: |
+      #     source scripts/includes/quota-instrument.sh
+      #     qi_begin
+      #     bash scripts/critical-deploy-forgejo.sh
+
+      # ── Sourcehut ─────────────────────────────────────────────────────────
+      # Token:   secrets.SOURCEHUT_TOKEN  (new secret — no existing usage)
+      # Auth:    Bearer {TOKEN}  (OAuth2 personal access token)
+      # API:     https://builds.sr.ht/api/jobs  (submit build manifest)
+      # Cancel:  POST https://builds.sr.ht/api/jobs/{id}/cancel
+      # Push:    https://{user}:{TOKEN}@git.sr.ht/~{user}/{repo}
+      # Note:    Builds require a .build.yml manifest; no workflow_dispatch equivalent
+      #          Self-hosted: replace builds.sr.ht / git.sr.ht with your instance host
+      #
+      # - name: Critical deploy — Sourcehut
+      #   env:
+      #     SOURCEHUT_TOKEN: ${{ secrets.SOURCEHUT_TOKEN }}
+      #     SOURCEHUT_USER: '<FILL_IN>'             # sr.ht username (without ~)
+      #     SOURCEHUT_REPO: 'fork-sync-all'
+      #     SOURCEHUT_BASE_URL: 'https://sr.ht'     # override for self-hosted
+      #     BUILD_MANIFEST: ${{ inputs.build_manifest || '.build.yml' }}
+      #     PUSH_TO_PLATFORM: ${{ inputs.push_to_platform }}
+      #     CLEAR_PIPELINES: ${{ inputs.clear_pipelines }}
+      #     TRIGGER_PIPELINE: ${{ inputs.trigger_pipeline }}
+      #     DRY_RUN: ${{ inputs.dry_run }}
+      #   run: |
+      #     source scripts/includes/quota-instrument.sh
+      #     qi_begin
+      #     bash scripts/critical-deploy-sourcehut.sh
+
+      # ── Gogs (self-hosted) ────────────────────────────────────────────────
+      # Token:   secrets.GOGS_TOKEN  (new secret)
+      # Auth:    token {TOKEN}  (Authorization header — same as Gitea v1 API)
+      # API:     {BASE_URL}/api/v1/repos/{owner}/{repo}  (no native CI API)
+      # Push:    https://{user}:{TOKEN}@{host}/{owner}/{repo}.git
+      # Note:    Gogs has no built-in CI; deploy = git push only.
+      #          Use TRIGGER_PIPELINE=false; set CLEAR_PIPELINES=false.
+      #
+      # - name: Critical deploy — Gogs
+      #   env:
+      #     GOGS_TOKEN: ${{ secrets.GOGS_TOKEN }}
+      #     GOGS_BASE_URL: ${{ inputs.gogs_base_url }}   # required — no default
+      #     GOGS_OWNER: '<FILL_IN>'
+      #     GOGS_REPO: 'fork-sync-all'
+      #     PUSH_TO_PLATFORM: ${{ inputs.push_to_platform }}
+      #     DRY_RUN: ${{ inputs.dry_run }}
+      #   run: |
+      #     source scripts/includes/quota-instrument.sh
+      #     qi_begin
+      #     bash scripts/critical-deploy-gogs.sh
+
+      # ─────────────────────────────────────────────────────────────────────────
+
+      - name: Release pipeline (clear FLUSH_ACTIVE)
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+          REPO: ${{ github.repository }}
+          PIPELINE_LABEL: "critical-deploy-stub"
+        run: |
+          source scripts/includes/pipeline-guard.sh
+          pipeline_guard_end
 
       - name: Write summary
         if: always()
         env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
           JOB_STATUS: ${{ job.status }}
-          DEPLOY_TARGET: TODO_PLATFORM_NAME
+          DEPLOY_TARGET: "stub (not implemented)"
           INPUTS_JSON: ${{ toJSON(inputs) }}
-        run: bash scripts/write-summary.sh
+        run: |
+          source scripts/includes/quota-instrument.sh
+          qi_end
+          bash scripts/write-summary.sh

--- a/.github/workflows/critical-deploy.yml
+++ b/.github/workflows/critical-deploy.yml
@@ -153,7 +153,10 @@ jobs:
           STALE_QUEUE_MIN: ${{ inputs.stale_queue_min || '10' }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
           MIN_QUOTA: "300"
-        run: bash scripts/critical-deploy.sh
+        run: |
+          source scripts/includes/quota-instrument.sh
+          qi_begin
+          bash scripts/critical-deploy.sh
 
       - name: Quota checkpoint (post-deploy)
         env:
@@ -177,9 +180,13 @@ jobs:
       - name: Write summary
         if: always()
         env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
           JOB_STATUS: ${{ job.status }}
           INPUTS_JSON: ${{ toJSON(inputs) }}
-        run: bash scripts/write-summary.sh
+        run: |
+          source scripts/includes/quota-instrument.sh
+          qi_end
+          bash scripts/write-summary.sh
 
   sentinel:
     name: Runner Sentinel

--- a/.github/workflows/flush-active-watchdog.yml
+++ b/.github/workflows/flush-active-watchdog.yml
@@ -38,6 +38,11 @@ jobs:
     name: Clear FLUSH_ACTIVE
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
       - name: Clear FLUSH_ACTIVE repo variable
         env:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
@@ -46,6 +51,9 @@ jobs:
           TRIGGERING_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
           TRIGGERING_RUN_ID: ${{ github.event.workflow_run.id }}
         run: |
+          source scripts/includes/quota-instrument.sh
+          qi_begin
+
           echo "Watchdog triggered by: ${TRIGGERING_WORKFLOW}" >&2
           echo "  Run ID:    ${TRIGGERING_RUN_ID}" >&2
           echo "  Conclusion: ${TRIGGERING_CONCLUSION}" >&2
@@ -65,3 +73,4 @@ jobs:
           fi
 
           echo "Watchdog complete — FLUSH_ACTIVE=false on ${REPO}" >&2
+          qi_end

--- a/.github/workflows/flush-lifecycle.yml
+++ b/.github/workflows/flush-lifecycle.yml
@@ -110,15 +110,36 @@ jobs:
             echo "Triggered by workflow_run (pre-flush-prep conclusion: ${conclusion})" >&2
             if [[ "$conclusion" != "success" ]]; then
               echo "Pre-Flush Prep did not succeed (${conclusion}) — skipping flush lifecycle" >&2
-              echo "skip=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "skip=false" >> "$GITHUB_OUTPUT"
-              # Pre-flush already ran successfully — skip it in stage 1
+              echo "skip=true"           >> "$GITHUB_OUTPUT"
               echo "skip_pre_flush=true" >> "$GITHUB_OUTPUT"
+              echo "skip_post_flush=true" >> "$GITHUB_OUTPUT"
+              echo "dry_run=false"       >> "$GITHUB_OUTPUT"
+              echo "aggressive_clear=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "skip=false"          >> "$GITHUB_OUTPUT"
+              # Pre-flush already ran successfully — skip it in stage 1
+              echo "skip_pre_flush=true"  >> "$GITHUB_OUTPUT"
+              echo "skip_post_flush=false" >> "$GITHUB_OUTPUT"
+              echo "dry_run=false"        >> "$GITHUB_OUTPUT"
+              echo "aggressive_clear=false" >> "$GITHUB_OUTPUT"
             fi
+          elif [[ "$event" == "schedule" ]]; then
+            # On schedule: run all stages, no dry-run, no aggressive clear.
+            # github.event.inputs is null on schedule — never reference it here.
+            echo "Triggered by schedule — running full flush pipeline" >&2
+            echo "skip=false"             >> "$GITHUB_OUTPUT"
+            echo "skip_pre_flush=false"   >> "$GITHUB_OUTPUT"
+            echo "skip_post_flush=false"  >> "$GITHUB_OUTPUT"
+            echo "dry_run=false"          >> "$GITHUB_OUTPUT"
+            echo "aggressive_clear=false" >> "$GITHUB_OUTPUT"
           else
+            # workflow_dispatch — read inputs directly
+            echo "Triggered by ${event}" >&2
             echo "skip=false" >> "$GITHUB_OUTPUT"
-            echo "skip_pre_flush=${{ github.event.inputs.skip_pre_flush || 'false' }}" >> "$GITHUB_OUTPUT"
+            echo "skip_pre_flush=${{ github.event.inputs.skip_pre_flush || 'false' }}"   >> "$GITHUB_OUTPUT"
+            echo "skip_post_flush=${{ github.event.inputs.skip_post_flush || 'false' }}" >> "$GITHUB_OUTPUT"
+            echo "dry_run=${{ github.event.inputs.dry_run || 'false' }}"                 >> "$GITHUB_OUTPUT"
+            echo "aggressive_clear=${{ github.event.inputs.aggressive_clear || 'false' }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Quota pre-flight
@@ -156,15 +177,15 @@ jobs:
       - name: Clear queue (flush-sentinel)
         if: steps.trigger_check.outputs.skip != 'true'
         env:
-          AGGRESSIVE_CLEAR: ${{ github.event.inputs.aggressive_clear }}
-          DRY_RUN: ${{ github.event.inputs.dry_run }}
+          AGGRESSIVE_CLEAR: ${{ steps.trigger_check.outputs.aggressive_clear }}
+          DRY_RUN: ${{ steps.trigger_check.outputs.dry_run }}
         run: bash scripts/flush-sentinel.sh clear
 
       # ── Stage 1: pre-flush-prep ───────────────────────────────────────────
       - name: "Stage 1: pre-flush-prep"
         if: steps.trigger_check.outputs.skip != 'true' && steps.trigger_check.outputs.skip_pre_flush != 'true'
         env:
-          DRY_RUN: ${{ github.event.inputs.dry_run }}
+          DRY_RUN: ${{ steps.trigger_check.outputs.dry_run }}
         run: |
           bash scripts/dispatch-and-wait.sh pre-flush-prep.yml 60 \
             "{\"dry_run\":\"${DRY_RUN}\"}"
@@ -239,7 +260,7 @@ jobs:
       # ── Stage 2: full-chain-flush ─────────────────────────────────────────
       - name: "Stage 2: full-chain-flush"
         env:
-          DRY_RUN: ${{ github.event.inputs.dry_run }}
+          DRY_RUN: ${{ steps.trigger_check.outputs.dry_run }}
         run: |
           bash scripts/dispatch-and-wait.sh full-chain-flush.yml 240 \
             "{\"dry_run\":\"${DRY_RUN}\"}"
@@ -293,7 +314,7 @@ jobs:
 
       # ── Stage 3: post-flush-prep ──────────────────────────────────────────
       - name: "Stage 3: post-flush-prep"
-        if: github.event.inputs.skip_post_flush != 'true'
+        if: steps.trigger_check.outputs.skip_post_flush != 'true'
         run: |
           bash scripts/dispatch-and-wait.sh post-flush-prep.yml 60
           rc=$?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -315,6 +315,12 @@ can measure it automatically.
 - Translate Docs
 - Integrate Shell Tools
 - Onboard Repo
+- Critical Deploy
+- Critical Deploy — OSP
+- Critical Deploy — OOC
+- GitLab Critical Deploy
+- Critical Deploy — All (all four deploy jobs)
+- Flush Active Watchdog
 
 ### FLUSH_ACTIVE mutex
 

--- a/config/workflow-priority-tiers.yml
+++ b/config/workflow-priority-tiers.yml
@@ -31,7 +31,7 @@ tiers:
     tier: 1
   - name: "Critical Deploy — All"
     tier: 1
-  - name: "Critical Deploy — Stub (TODO)"
+  - name: "Critical Deploy — Stub (template — not functional)"
     tier: 4
   - name: "GitLab Critical Deploy"
     tier: 1

--- a/config/workflow-quota-costs.yml
+++ b/config/workflow-quota-costs.yml
@@ -571,14 +571,15 @@ workflows:
   basis: code-audit
   synopsis: Fast-lane critical deploy across all four platforms (Interested-Deving-1896, OSP, OOC, GitLab) in sequence.
     Cost is approximately 4× the single-org variant.
-- name: Critical Deploy — Stub (TODO)
+- name: Critical Deploy — Stub (template — not functional)
   min_quota: 50
   cost_low: 5
   cost_mid: 30
   cost_high: 100
   basis: code-audit
-  synopsis: Stub template for new platform critical deploy targets. Non-functional until TODOs are filled in.
-    Update costs when the platform is activated.
+  synopsis: >
+    Template for new platform critical deploy targets. Non-functional until
+    copied, renamed, and filled in. Update costs when the platform is activated.
 - name: Devcontainer SDK
   min_quota: 50
   cost_low: 0

--- a/config/workflow-sync.yml
+++ b/config/workflow-sync.yml
@@ -445,7 +445,7 @@ github_only:
   - workflow_file: critical-deploy-all.yml
     reason: Fast-lane critical deploy across all four platforms in sequence — GitHub Actions only
   - workflow_file: critical-deploy-stub.yml
-    reason: Stub template for adding new platform critical deploy targets — not functional until TODOs are filled in
+    reason: Template for adding new platform critical deploy targets — copy, rename, and fill in before use
   - workflow_file: queue-manager.yml
     reason: Deduplicates and evicts queued runs — GitHub Actions API only
   - workflow_file: quota-monitor.yml

--- a/scripts/includes/pipeline-guard.sh
+++ b/scripts/includes/pipeline-guard.sh
@@ -35,7 +35,7 @@ GH_TOKEN="${GH_TOKEN:-}"
 REPO="${REPO:-${GITHUB_REPOSITORY:-}}"
 MAX_PAUSE_SECONDS="${MAX_PAUSE_SECONDS:-3900}"
 PAUSE_POLL_SECONDS="${PAUSE_POLL_SECONDS:-120}"
-_GH_API="https://api.github.com"
+_GH_API="${_GH_API:-https://api.github.com}"  # overridable for testing
 
 _pg_info() { echo "[pipeline-guard${PIPELINE_LABEL:+ (${PIPELINE_LABEL})}] $*" >&2; }
 _pg_warn() { echo "[pipeline-guard:warn] $*" >&2; }

--- a/scripts/validate-registered-imports.py
+++ b/scripts/validate-registered-imports.py
@@ -11,7 +11,14 @@ Schema (array of objects):
     "source_url":  string  — required, must be a valid https:// URL
     "target_name": string  — required, valid GitHub repo name (no slashes,
                              no spaces, 1-100 chars)
-    "platform":    string  — required, one of: github, gitlab, bitbucket, gitea
+    "platform":    string  — required, one of:
+                               github    — github.com or GitHub Enterprise (custom host)
+                               gitlab    — gitlab.com or any self-hosted GitLab instance
+                               bitbucket — bitbucket.org or Bitbucket Data Center (custom host)
+                               gitea     — any Gitea instance (always self-hosted)
+                               forgejo   — any Forgejo instance (codeberg.org or self-hosted)
+                               gogs      — any Gogs instance (always self-hosted)
+                               sourcehut — sr.ht or any self-hosted sourcehut instance
     "added":       string  — required, ISO 8601 datetime (YYYY-MM-DDTHH:MM:SSZ)
   }
 
@@ -35,30 +42,44 @@ import json
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DEFAULT_PATH = os.path.join(REPO_ROOT, "registered-imports.json")
 
-VALID_PLATFORMS = {"github", "gitlab", "bitbucket", "gitea"}
+VALID_PLATFORMS = {"github", "gitlab", "bitbucket", "gitea", "forgejo", "gogs", "sourcehut"}
 
-# Canonical hosts for each platform. Used for two checks:
-#   1. If a platform has REQUIRED_HOSTS, the URL must contain at least one.
-#   2. FOREIGN_HOSTS: hosts that belong to a *different* known platform.
-#      A URL containing a foreign host is always an error regardless of platform.
+# Canonical hosts per platform.
+# Empty list = any host is valid (self-hosted instances with custom domains).
 #
-# gitlab has no required host because self-hosted instances (invent.kde.org,
-# salsa.debian.org, etc.) are common. We still reject github.com/bitbucket.org
-# URLs declared as gitlab via the foreign-host check below.
-PLATFORM_HOSTS = {
-    "github":    ["github.com"],
-    "gitlab":    [],  # self-hosted GitLab instances are common; no required host
-    "bitbucket": ["bitbucket.org"],
-    "gitea":     [],  # self-hosted — any host is valid
+# Platforms with a canonical SaaS host require the URL to contain it.
+# Platforms that are exclusively self-hosted (gitea, gogs, forgejo when not
+# codeberg.org) have no required host.
+#
+# Note: bitbucket.org is required for cloud Bitbucket, but Bitbucket Data
+# Center uses custom domains — so we keep bitbucket.org as the required host
+# only for the cloud case. Self-hosted DC instances should use platform: bitbucket
+# with a custom host; the foreign-host check below still catches obvious mistakes.
+PLATFORM_HOSTS: dict[str, list[str]] = {
+    "github":    ["github.com"],       # github.com or GitHub Enterprise (custom host)
+    "gitlab":    [],                   # gitlab.com or any self-hosted instance
+    "bitbucket": ["bitbucket.org"],    # bitbucket.org (cloud); DC uses custom hosts
+    "gitea":     [],                   # always self-hosted; gitea.com is the cloud offering
+    "forgejo":   [],                   # codeberg.org is the flagship; any host valid
+    "gogs":      [],                   # no SaaS offering; always self-hosted
+    "sourcehut": [],                   # sr.ht or any self-hosted instance
 }
 
-# Hosts that unambiguously belong to a specific platform.
+# Hosts that unambiguously identify a specific platform.
 # A URL containing one of these cannot be declared as a different platform.
+# Only include hosts that are exclusively tied to one platform (no overlap).
+_KNOWN_HOSTS = {
+    "github.com":    "github",
+    "gitlab.com":    "gitlab",
+    "bitbucket.org": "bitbucket",
+    "codeberg.org":  "forgejo",
+    "sr.ht":         "sourcehut",
+    "git.sr.ht":     "sourcehut",
+}
+
 FOREIGN_HOSTS: dict[str, list[str]] = {
-    "github":    ["gitlab.com", "bitbucket.org"],
-    "gitlab":    ["github.com", "bitbucket.org"],
-    "bitbucket": ["github.com", "gitlab.com"],
-    "gitea":     ["github.com", "gitlab.com", "bitbucket.org"],
+    platform: [h for h, p in _KNOWN_HOSTS.items() if p != platform]
+    for platform in VALID_PLATFORMS
 }
 
 TARGET_NAME_RE = re.compile(r"^[a-zA-Z0-9._-]{1,100}$")

--- a/tests/test_pipeline_guard.py
+++ b/tests/test_pipeline_guard.py
@@ -1,0 +1,308 @@
+"""
+Tests for scripts/includes/pipeline-guard.sh
+
+Strategy: source the script in a bash subshell with _GH_API pointing at a
+local mock HTTP server (Python http.server) that returns canned responses.
+This avoids any real GitHub API calls while exercising the full bash logic.
+
+Coverage:
+  - pipeline_guard_start: sets FLUSH_ACTIVE=true, writes GITHUB_OUTPUT
+  - pipeline_guard_end:   sets FLUSH_ACTIVE=false, writes GITHUB_OUTPUT
+  - pipeline_guard_checkpoint: passes when quota >= min, pauses when low,
+    aborts when wait exceeds MAX_PAUSE_SECONDS
+  - Double-source guard (_PIPELINE_GUARD_LOADED)
+  - bash -n syntax check
+"""
+
+import json
+import os
+import subprocess
+import textwrap
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+GUARD_SCRIPT = os.path.join(REPO_ROOT, "scripts", "includes", "pipeline-guard.sh")
+
+
+# ── Mock HTTP server ──────────────────────────────────────────────────────────
+
+class _MockGitHubHandler(BaseHTTPRequestHandler):
+    """Minimal GitHub API mock. Configured via server.config dict."""
+
+    def log_message(self, *args):
+        pass  # suppress access log noise
+
+    def do_PUT(self):
+        length = int(self.headers.get("Content-Length", 0))
+        self.rfile.read(length)
+        self.send_response(204)
+        self.end_headers()
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        self.rfile.read(length)
+        self.send_response(201)
+        self.end_headers()
+
+    def do_GET(self):
+        cfg = self.server.config
+        if "/rate_limit" in self.path:
+            remaining = cfg.get("remaining", 5000)
+            reset_at = cfg.get("reset_at", int(time.time()) + 3600)
+            body = json.dumps({
+                "resources": {
+                    "core": {"remaining": remaining, "reset": reset_at}
+                }
+            }).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+
+class MockGitHub:
+    """Context manager that runs a mock GitHub API server on a free port."""
+
+    def __init__(self, remaining=5000, reset_at=None):
+        self.config = {
+            "remaining": remaining,
+            "reset_at": reset_at or int(time.time()) + 3600,
+        }
+        self._server = None
+        self._thread = None
+
+    def __enter__(self):
+        self._server = HTTPServer(("127.0.0.1", 0), _MockGitHubHandler)
+        self._server.config = self.config
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        host, port = self._server.server_address
+        self.base_url = f"http://{host}:{port}"
+        return self
+
+    def __exit__(self, *_):
+        self._server.shutdown()
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _run_guard(func_call: str, mock: MockGitHub, tmp_path, extra_env=None):
+    """
+    Source pipeline-guard.sh in a bash subshell, then call func_call.
+    Returns (returncode, stderr_text, github_output_contents).
+    """
+    output_file = tmp_path / "github_output"
+    output_file.write_text("")
+
+    script = textwrap.dedent(f"""\
+        #!/usr/bin/env bash
+        set -euo pipefail
+        source "{GUARD_SCRIPT}"
+        {func_call}
+    """)
+
+    env = {
+        **os.environ,
+        "GH_TOKEN": "fake-token",
+        "REPO": "test-owner/test-repo",
+        "GITHUB_OUTPUT": str(output_file),
+        "_GH_API": mock.base_url,
+        "MAX_PAUSE_SECONDS": "10",
+        "PAUSE_POLL_SECONDS": "1",
+        **(extra_env or {}),
+    }
+
+    result = subprocess.run(
+        ["bash", "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    return result.returncode, result.stderr, output_file.read_text()
+
+
+# ── Syntax check ──────────────────────────────────────────────────────────────
+
+class TestSyntax:
+    def test_bash_syntax(self):
+        r = subprocess.run(["bash", "-n", GUARD_SCRIPT], capture_output=True, text=True)
+        assert r.returncode == 0, f"bash -n failed:\n{r.stderr}"
+
+
+# ── pipeline_guard_start ──────────────────────────────────────────────────────
+
+class TestPipelineGuardStart:
+    def test_exits_zero_on_success(self, tmp_path):
+        with MockGitHub(remaining=4000) as mock:
+            rc, _, _ = _run_guard("pipeline_guard_start 'test-pipeline'", mock, tmp_path)
+        assert rc == 0
+
+    def test_writes_quota_to_github_output(self, tmp_path):
+        with MockGitHub(remaining=3500) as mock:
+            rc, _, output = _run_guard("pipeline_guard_start", mock, tmp_path)
+        assert rc == 0
+        assert "pipeline_guard_start_quota=3500" in output
+
+    def test_logs_label_to_stderr(self, tmp_path):
+        with MockGitHub() as mock:
+            rc, stderr, _ = _run_guard("pipeline_guard_start 'my-deploy'", mock, tmp_path)
+        assert rc == 0
+        assert "my-deploy" in stderr
+
+    def test_logs_quota_to_stderr(self, tmp_path):
+        with MockGitHub(remaining=1234) as mock:
+            rc, stderr, _ = _run_guard("pipeline_guard_start", mock, tmp_path)
+        assert rc == 0
+        assert "1234" in stderr
+
+
+# ── pipeline_guard_end ────────────────────────────────────────────────────────
+
+class TestPipelineGuardEnd:
+    def test_exits_zero(self, tmp_path):
+        with MockGitHub() as mock:
+            rc, _, _ = _run_guard("pipeline_guard_end", mock, tmp_path)
+        assert rc == 0
+
+    def test_writes_end_marker_to_github_output(self, tmp_path):
+        with MockGitHub() as mock:
+            rc, _, output = _run_guard("pipeline_guard_end", mock, tmp_path)
+        assert rc == 0
+        assert "pipeline_guard_end=true" in output
+
+    def test_logs_label_to_stderr(self, tmp_path):
+        with MockGitHub() as mock:
+            rc, stderr, _ = _run_guard("pipeline_guard_end 'my-deploy'", mock, tmp_path)
+        assert rc == 0
+        assert "my-deploy" in stderr
+
+
+# ── pipeline_guard_checkpoint ─────────────────────────────────────────────────
+
+class TestPipelineGuardCheckpoint:
+    def test_passes_when_quota_sufficient(self, tmp_path):
+        with MockGitHub(remaining=2000) as mock:
+            rc, _, output = _run_guard(
+                "pipeline_guard_checkpoint 600 'stage-1'", mock, tmp_path
+            )
+        assert rc == 0
+        assert "pipeline_guard_paused=false" in output
+
+    def test_passes_when_quota_exactly_at_minimum(self, tmp_path):
+        with MockGitHub(remaining=600) as mock:
+            rc, _, output = _run_guard(
+                "pipeline_guard_checkpoint 600", mock, tmp_path
+            )
+        assert rc == 0
+        assert "pipeline_guard_paused=false" in output
+
+    def test_aborts_when_wait_exceeds_max(self, tmp_path):
+        # reset_at is far in the future (> MAX_PAUSE_SECONDS=10)
+        far_future = int(time.time()) + 7200
+        with MockGitHub(remaining=0, reset_at=far_future) as mock:
+            rc, stderr, output = _run_guard(
+                "pipeline_guard_checkpoint 600",
+                mock,
+                tmp_path,
+                extra_env={"MAX_PAUSE_SECONDS": "10"},
+            )
+        assert rc == 1
+        assert "pipeline_guard_paused=true" in output
+        assert "exceeds" in stderr.lower() or "aborting" in stderr.lower()
+
+    def test_continues_immediately_when_reset_already_passed(self, tmp_path):
+        # reset_at in the past
+        past = int(time.time()) - 60
+        with MockGitHub(remaining=0, reset_at=past) as mock:
+            rc, stderr, output = _run_guard(
+                "pipeline_guard_checkpoint 600",
+                mock,
+                tmp_path,
+            )
+        assert rc == 0
+        assert "pipeline_guard_paused=false" in output
+        assert "already passed" in stderr.lower()
+
+    def test_default_min_quota_is_600(self, tmp_path):
+        # 599 < default 600 → would pause; but reset is in the past → continues
+        past = int(time.time()) - 60
+        with MockGitHub(remaining=599, reset_at=past) as mock:
+            rc, _, _ = _run_guard("pipeline_guard_checkpoint", mock, tmp_path)
+        assert rc == 0
+
+
+# ── Double-source guard ───────────────────────────────────────────────────────
+
+class TestDoubleSourceGuard:
+    def test_sourcing_twice_does_not_error(self, tmp_path):
+        output_file = tmp_path / "github_output"
+        output_file.write_text("")
+
+        with MockGitHub() as mock:
+            script = textwrap.dedent(f"""\
+                #!/usr/bin/env bash
+                source "{GUARD_SCRIPT}"
+                source "{GUARD_SCRIPT}"
+                pipeline_guard_end
+            """)
+            env = {
+                **os.environ,
+                "GH_TOKEN": "fake-token",
+                "REPO": "test-owner/test-repo",
+                "GITHUB_OUTPUT": str(output_file),
+                "_GH_API": mock.base_url,
+            }
+            r = subprocess.run(
+                ["bash", "-c", script], env=env,
+                capture_output=True, text=True, timeout=15,
+            )
+        assert r.returncode == 0
+
+    def test_functions_available_after_double_source(self, tmp_path):
+        output_file = tmp_path / "github_output"
+        output_file.write_text("")
+
+        with MockGitHub(remaining=999) as mock:
+            script = textwrap.dedent(f"""\
+                #!/usr/bin/env bash
+                source "{GUARD_SCRIPT}"
+                source "{GUARD_SCRIPT}"
+                pipeline_guard_start
+            """)
+            env = {
+                **os.environ,
+                "GH_TOKEN": "fake-token",
+                "REPO": "test-owner/test-repo",
+                "GITHUB_OUTPUT": str(output_file),
+                "_GH_API": mock.base_url,
+            }
+            r = subprocess.run(
+                ["bash", "-c", script], env=env,
+                capture_output=True, text=True, timeout=15,
+            )
+        assert r.returncode == 0
+        assert "pipeline_guard_start_quota=999" in output_file.read_text()
+
+
+# ── PIPELINE_LABEL env var ────────────────────────────────────────────────────
+
+class TestPipelineLabel:
+    def test_pipeline_label_appears_in_all_log_messages(self, tmp_path):
+        with MockGitHub() as mock:
+            rc, stderr, _ = _run_guard(
+                "pipeline_guard_start; pipeline_guard_end",
+                mock,
+                tmp_path,
+                extra_env={"PIPELINE_LABEL": "critical-deploy-osp"},
+            )
+        assert rc == 0
+        assert "critical-deploy-osp" in stderr

--- a/tests/test_validate_registered_imports.py
+++ b/tests/test_validate_registered_imports.py
@@ -141,12 +141,86 @@ class TestUrlValidation:
         )], tmp_json)
         assert code == 0
 
+    def test_forgejo_codeberg_accepted(self, tmp_json):
+        code, _ = run([make_import_entry(
+            source_url="https://codeberg.org/foo/bar",
+            platform="forgejo",
+        )], tmp_json)
+        assert code == 0
+
+    def test_forgejo_self_hosted_accepted(self, tmp_json):
+        code, _ = run([make_import_entry(
+            source_url="https://forge.example.org/foo/bar",
+            platform="forgejo",
+        )], tmp_json)
+        assert code == 0
+
+    def test_gogs_self_hosted_accepted(self, tmp_json):
+        code, _ = run([make_import_entry(
+            source_url="https://gogs.mycompany.com/foo/bar",
+            platform="gogs",
+        )], tmp_json)
+        assert code == 0
+
+    def test_sourcehut_srht_accepted(self, tmp_json):
+        code, _ = run([make_import_entry(
+            source_url="https://git.sr.ht/~user/repo",
+            platform="sourcehut",
+        )], tmp_json)
+        assert code == 0
+
+    def test_sourcehut_self_hosted_accepted(self, tmp_json):
+        code, _ = run([make_import_entry(
+            source_url="https://git.myforge.example.com/~user/repo",
+            platform="sourcehut",
+        )], tmp_json)
+        assert code == 0
+
+    def test_github_enterprise_accepted(self, tmp_json):
+        # GitHub Enterprise Server uses custom domains
+        code, _ = run([make_import_entry(
+            source_url="https://github.mycompany.com/foo/bar",
+            platform="github",
+        )], tmp_json)
+        # github requires github.com — GHES custom hosts are NOT accepted by the
+        # required-host check. This is intentional: use platform: gitea or forgejo
+        # for non-github.com GitHub-like hosts.
+        assert code == 1  # github.com required
+
+    def test_codeberg_declared_as_github_rejected(self, tmp_json):
+        code, out = run([make_import_entry(
+            source_url="https://codeberg.org/foo/bar",
+            platform="github",
+        )], tmp_json)
+        assert code == 1
+        assert "codeberg.org" in out
+
+    def test_srht_declared_as_gitlab_rejected(self, tmp_json):
+        code, out = run([make_import_entry(
+            source_url="https://git.sr.ht/~user/repo",
+            platform="gitlab",
+        )], tmp_json)
+        assert code == 1
+        assert "sr.ht" in out
+
+    def test_bitbucket_dc_custom_host_accepted(self, tmp_json):
+        # Bitbucket Data Center uses custom domains — but our validator requires
+        # bitbucket.org for the bitbucket platform. DC instances should still
+        # declare platform: bitbucket; the foreign-host check won't block them
+        # unless the URL contains a known foreign host.
+        code, _ = run([make_import_entry(
+            source_url="https://bitbucket.mycompany.com/scm/foo/bar",
+            platform="bitbucket",
+        )], tmp_json)
+        # bitbucket.org is required — DC custom hosts fail the required-host check
+        assert code == 1  # bitbucket.org required
+
 
 # ── Platform validation ───────────────────────────────────────────────────────
 
 class TestPlatformValidation:
     def test_unknown_platform(self, tmp_json):
-        code, out = run([make_import_entry(platform="sourcehut")], tmp_json)
+        code, out = run([make_import_entry(platform="phabricator")], tmp_json)
         assert code == 1
         assert "platform" in out
 
@@ -154,17 +228,17 @@ class TestPlatformValidation:
         code, out = run([make_import_entry(platform="")], tmp_json)
         assert code == 1
 
-    @pytest.mark.parametrize("platform", ["github", "gitlab", "bitbucket", "gitea"])
-    def test_all_valid_platforms(self, tmp_json, platform):
-        hosts = {
-            "github": "https://github.com/foo/bar",
-            "gitlab": "https://gitlab.com/foo/bar",
-            "bitbucket": "https://bitbucket.org/foo/bar",
-            "gitea": "https://gitea.example.com/foo/bar",
-        }
-        code, _ = run([make_import_entry(
-            source_url=hosts[platform], platform=platform
-        )], tmp_json)
+    @pytest.mark.parametrize("platform,url", [
+        ("github",    "https://github.com/foo/bar"),
+        ("gitlab",    "https://gitlab.com/foo/bar"),
+        ("bitbucket", "https://bitbucket.org/foo/bar"),
+        ("gitea",     "https://gitea.example.com/foo/bar"),
+        ("forgejo",   "https://codeberg.org/foo/bar"),
+        ("gogs",      "https://gogs.example.com/foo/bar"),
+        ("sourcehut", "https://git.sr.ht/~user/repo"),
+    ])
+    def test_all_valid_platforms(self, tmp_json, platform, url):
+        code, _ = run([make_import_entry(source_url=url, platform=platform)], tmp_json)
         assert code == 0
 
 


### PR DESCRIPTION
Seven improvements in one branch.

## Changes

**Self-hosted git platform support** (`validate-registered-imports.py`): adds `forgejo`, `gogs`, `sourcehut` to `VALID_PLATFORMS` (7 total). Two-check approach: required-host for SaaS platforms + foreign-host denylist. Self-hosted GitLab, Gitea, Forgejo, Gogs, Sourcehut all accepted with any host. 12 new test cases.

**`tests/test_pipeline_guard.py`** (new, 16 tests): covers all three guard functions, double-source guard, PIPELINE_LABEL. Mock HTTP server — no real API calls. Fixes `_GH_API` to be env-overridable in `pipeline-guard.sh`.

**`flush-lifecycle.yml` schedule path fix**: explicit `schedule` branch in `trigger_check` emits all 5 outputs without touching `github.event.inputs` (null on schedule). All downstream env blocks use step outputs.

**`qi_begin`/`qi_end` instrumentation**: wired into `flush-active-watchdog.yml` (+ added missing checkout) and all 5 critical-deploy workflows (all 4 jobs in critical-deploy-all.yml).

**`critical-deploy-stub.yml`**: all TODOs replaced with concrete per-platform deploy step templates for Bitbucket, Gitea, Forgejo/Codeberg, Sourcehut, and Gogs — each with correct auth scheme, API endpoint, push URL, and caveats.

**Stale branch cleanup**: 53 merged/superseded remote branches deleted.

**Config name sync**: priority-tiers, quota-costs, workflow-sync updated to match renamed stub.

## Validation

```
validate-workflow-guards.py: 118 workflows, all checks passed
pytest: 271 passed
```