### PR TITLE
feat: OTA reconcile — hybrid A/B/C fallback layer for mirror-chain consumers

### DIFF
--- a/.github/workflows/ota-reconcile.yml
+++ b/.github/workflows/ota-reconcile.yml
@@ -1,0 +1,92 @@
+name: OTA Reconcile
+
+# Hybrid fallback and drift-detection layer for mirror-chain consumer repos.
+# Runs weekly and autonomously selects the best recovery path per repo:
+#
+#   Path A — Version stamp only (repo is current)
+#   Path B — Drift reconcile PR (files differ from template)
+#   Path C — Quota-recovery PR (sync-template.sh left this repo incomplete)
+#
+# See DOCS/ota-reconcile.md for full architecture documentation.
+
+on:
+  schedule:
+    - cron: '17 3 * * 3'   # Weekly on Wednesdays at 03:17 UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Report changes without writing stamps or opening PRs'
+        required: false
+        default: false
+        type: boolean
+      repo_filter:
+        description: 'Process only repos whose name contains this substring'
+        required: false
+        default: ''
+        type: string
+      force_path:
+        description: 'Override runtime path selection (A | B | C | leave blank for auto)'
+        required: false
+        default: ''
+        type: string
+      profile_filter:
+        description: 'Limit to repos with this template profile (full | mirror | infra-core | standalone)'
+        required: false
+        default: ''
+        type: string
+
+concurrency:
+  group: ota-reconcile
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  reconcile:
+    name: OTA Reconcile
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Quota pre-flight
+        id: quota
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+          MIN_QUOTA: "1500"
+        run: |
+          source scripts/includes/quota-snapshot.sh
+          quota_snapshot
+
+      - name: Resolve FSA SHA
+        id: sha
+        if: steps.quota.outputs.skip == 'false'
+        run: echo "fsa_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Run OTA Reconcile
+        if: steps.quota.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+          GITHUB_OWNER: Interested-Deving-1896
+          FSA_SHA: ${{ steps.sha.outputs.fsa_sha }}
+          CONSUMERS_FILE: config/template-consumers.yml
+          BLOCKLIST_FILE: config/ota-blocklist.yml
+          MANIFEST_FILE: config/template-manifest.yml
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          REPO_FILTER: ${{ inputs.repo_filter || '' }}
+          FORCE_PATH: ${{ inputs.force_path || '' }}
+          PROFILE_FILTER: ${{ inputs.profile_filter || '' }}
+          OTA_VERSION: ${{ github.ref_name || 'reconcile' }}
+          BUDGET_MINUTES: "50"
+        run: bash scripts/ota-reconcile.sh
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/sync-agent-prices.yml
+++ b/.github/workflows/sync-agent-prices.yml
@@ -1,0 +1,192 @@
+name: Sync Agent Prices
+
+# Hybrid A+B+C automated price refresh for config/agent-cost-profiles.yml.
+#
+# Option A — Anthropic API: queries /v1/models directly (requires ANTHROPIC_API_KEY).
+#            Currently the Anthropic API does not return pricing in model metadata,
+#            so this falls back to LiteLLM. When Anthropic adds pricing to the API
+#            response, scripts/sync-agent-prices.py will use it automatically.
+#
+# Option B — LiteLLM: fetches the latest commit of
+#            model_prices_and_context_window.json from BerriAI/litellm on GitHub.
+#            Covers Anthropic, OpenAI, and Google models. Updates the pinned SHA
+#            in config/agent-cost-profiles.yml.
+#
+# Option C — Staleness check: flags agents with price_source: manual or free
+#            whose prices_last_verified date is >90 days old. Does not modify
+#            them — opens an issue comment or step summary warning instead.
+#
+# On price change: opens a PR for human review. Never auto-merges.
+# On no change:    updates prices_last_verified silently (direct commit, [skip ci]).
+# On error:        fails the workflow; does not open a PR or commit.
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'   # Monday 09:00 UTC (after weekend LiteLLM releases)
+
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Compute diff without writing changes or opening a PR'
+        type: boolean
+        required: false
+        default: false
+      stale_days:
+        description: 'Days before a manual price entry is considered stale (default: 90)'
+        type: string
+        required: false
+        default: '90'
+      force_pr:
+        description: 'Open a PR even if no prices changed (useful for testing)'
+        type: boolean
+        required: false
+        default: false
+
+concurrency:
+  group: sync-agent-prices
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    name: Sync agent prices
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          token: ${{ secrets.SYNC_TOKEN }}
+
+      - name: Quota pre-flight
+        id: quota
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+        run: |
+          source scripts/includes/budget.sh
+          remaining=$(workflow_min_quota "Sync Agent Prices" 2>/dev/null || echo 50)
+          actual=$(gh api /rate_limit --jq '.resources.core.remaining' 2>/dev/null || echo 9999)
+          if [[ "$actual" -lt "$remaining" ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Quota too low ($actual < $remaining) — skipping" >&2
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run price sync
+        id: sync
+        if: steps.quota.outputs.skip == 'false'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_STEP_SUMMARY: ${{ env.GITHUB_STEP_SUMMARY }}
+        run: |
+          DRY_RUN_FLAG=""
+          if [[ "${{ inputs.dry_run }}" == "true" ]]; then
+            DRY_RUN_FLAG="--dry-run"
+          fi
+
+          STALE_DAYS="${{ inputs.stale_days || '90' }}"
+
+          set +e
+          python3 scripts/sync-agent-prices.py \
+            --stale-days "$STALE_DAYS" \
+            $DRY_RUN_FLAG
+          EXIT_CODE=$?
+          set -e
+
+          # Exit codes: 0=no change, 1=error, 2=prices changed
+          if [[ $EXIT_CODE -eq 0 ]]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "error=false"   >> "$GITHUB_OUTPUT"
+          elif [[ $EXIT_CODE -eq 2 ]]; then
+            echo "changed=true"  >> "$GITHUB_OUTPUT"
+            echo "error=false"   >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "error=true"    >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+          # force_pr override
+          if [[ "${{ inputs.force_pr }}" == "true" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # ── Path A: prices changed → open PR for review ───────────────────────
+      - name: Create price-update branch
+        if: steps.sync.outputs.changed == 'true' && inputs.dry_run != 'true'
+        id: branch
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+        run: |
+          BRANCH="chore/sync-agent-prices-$(date -u '+%Y-%m-%d')"
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add config/agent-cost-profiles.yml
+          git diff --cached --stat >&2
+          git commit -m "chore(costs): sync agent prices from LiteLLM $(date -u '+%Y-%m-%d')"
+          git push origin "$BRANCH"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Open PR for price changes
+        if: steps.sync.outputs.changed == 'true' && inputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+        run: |
+          BRANCH="${{ steps.branch.outputs.branch }}"
+
+          # Build PR body from step summary content
+          BODY=$(cat << 'PREOF'
+          ## Automated agent price sync
+
+          This PR was opened automatically by `sync-agent-prices.yml`.
+
+          **Sources used:**
+          - Option B: LiteLLM `model_prices_and_context_window.json` (pinned SHA updated)
+          - Option A: Anthropic API `/v1/models` (pricing not yet in API response — fell back to LiteLLM)
+
+          **Review checklist:**
+          - [ ] Verify changed prices against provider pricing pages
+            - Anthropic: https://anthropic.com/pricing
+            - OpenAI: https://openai.com/pricing
+            - Google: https://ai.google.dev/pricing
+          - [ ] Check that `prices_last_verified` dates are updated
+          - [ ] Confirm `litellm_pin.sha` points to a recent commit
+          - [ ] Update `DOCS/ai-agent-costs.md` tables if prices changed significantly
+
+          **Do not merge without reviewing the price changes above.**
+          PREOF
+          )
+
+          gh pr create \
+            --title "chore(costs): sync agent prices $(date -u '+%Y-%m-%d')" \
+            --head "$BRANCH" \
+            --base main \
+            --body "$BODY" \
+            --label "automated,costs" 2>/dev/null || \
+          gh pr create \
+            --title "chore(costs): sync agent prices $(date -u '+%Y-%m-%d')" \
+            --head "$BRANCH" \
+            --base main \
+            --body "$BODY"
+
+      # ── Path B: no price changes → update verified dates silently ─────────
+      - name: Commit verified-date update (no price changes)
+        if: steps.sync.outputs.changed == 'false' && steps.sync.outputs.error == 'false' && inputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add config/agent-cost-profiles.yml
+          if git diff --cached --quiet; then
+            echo "No changes to commit (prices and pin already current)" >&2
+          else
+            git commit -m "chore(costs): update agent price verification dates [skip ci]"
+            git push
+          fi

--- a/.github/workflows/track-agent-costs.yml
+++ b/.github/workflows/track-agent-costs.yml
@@ -295,6 +295,49 @@ jobs:
               print(f"WARNING: {profile_warning}", file=sys.stderr)
           PYEOF
 
+      - name: Staleness check (Option C)
+        if: always()
+        env:
+          STALE_DAYS: "90"
+        run: |
+          python3 - << 'PYEOF'
+          import yaml, sys
+          from datetime import datetime, timezone, timedelta
+          from pathlib import Path
+
+          stale_days = int(__import__('os').environ.get('STALE_DAYS', '90'))
+          config = yaml.safe_load(open('config/agent-cost-profiles.yml'))
+          agents = config.get('agents', {})
+          today  = datetime.now(timezone.utc)
+          stale  = []
+
+          for name, ap in agents.items():
+              source   = ap.get('price_source', 'manual')
+              verified = ap.get('prices_last_verified')
+              if source in ('manual',) and verified:
+                  try:
+                      dt = datetime.fromisoformat(str(verified)).replace(tzinfo=timezone.utc)
+                      age = (today - dt).days
+                      if age > stale_days:
+                          stale.append((name, ap.get('display_name', name), age, source))
+                  except ValueError:
+                      stale.append((name, ap.get('display_name', name), '?', source))
+
+          if stale:
+              summary = __import__('os').environ.get('GITHUB_STEP_SUMMARY', '')
+              msg = f'\n### ⚠️ Stale manual price entries ({len(stale)})\n\n'
+              msg += '| Agent | Last verified | Age | Action |\n|---|---|---|---|\n'
+              for name, disp, age, src in stale:
+                  msg += f'| {disp} | {agents[name].get("prices_last_verified", "unknown")} | {age} days | Verify at provider and update `config/agent-cost-profiles.yml` |\n'
+              msg += '\nRun `sync-agent-prices.yml` to refresh auto-updatable entries.\n'
+              print(msg, file=sys.stderr)
+              if summary:
+                  with open(summary, 'a') as f:
+                      f.write(msg)
+          else:
+              print('[staleness] All manual price entries are current.', file=sys.stderr)
+          PYEOF
+
       - name: Commit log update
         env:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}

--- a/DOCS/ota-reconcile.md
+++ b/DOCS/ota-reconcile.md
@@ -1,0 +1,204 @@
+# OTA Reconcile
+
+OTA Reconcile is a hybrid fallback and drift-detection layer that sits between
+the push-based template sync system and the pull-based OTA delivery system.
+
+It runs on a weekly schedule (and on demand) and autonomously selects the
+appropriate recovery path for each repo at runtime based on observed state.
+
+---
+
+## Problem statement
+
+Template sync (`sync-template.sh`) is push-based and continuous, but has three
+failure modes that leave repos silently out of date:
+
+1. **Quota exhaustion** — propagation stops early; repos processed after the
+   cutoff never receive the update. The checkpoint resumes on the next push, but
+   if no push occurs the gap persists indefinitely.
+
+2. **Silent drift** — a file in a consumer repo was manually edited, a sync
+   failed with a non-fatal error, or a new file was added to the template after
+   the last push that touched that consumer's path filter. The repo is behind
+   but no alarm fires.
+
+3. **No version record** — mirror-chain repos have no machine-readable record of
+   which fork-sync-all commit they last received. There is no way to answer
+   "is this repo current?" without diffing every file.
+
+OTA Reconcile addresses all three without replacing or duplicating template sync.
+
+---
+
+## Architecture
+
+### Three paths, one runtime selector
+
+`ota-reconcile.sh` evaluates each consumer repo and selects one of three paths:
+
+| Path | Name | When selected | What it does |
+|------|------|---------------|--------------|
+| A | **Version stamp** | Repo is current (no drift detected) | Writes/updates `.ota/version` with the current FSA commit SHA and timestamp. Zero file changes, no PR. |
+| B | **Drift reconcile** | Drift detected, template sync healthy | Runs `ota-payload-build.sh --full` scoped to template-manifest-owned files, opens a PR with the delta. |
+| C | **Quota fallback** | Template sync failed/incomplete for this repo | Same as B, but triggered by detecting the repo's `.ota/version` SHA is behind the last successful FSA push and no in-flight sync PR exists. |
+
+The selector runs all detection checks upfront and picks the lowest-cost path
+that addresses the observed state. A repo that is current takes path A (one API
+call to write the version stamp). A repo with drift takes path B or C depending
+on whether the drift is due to a quota failure.
+
+### Detection checks (run per repo, in order)
+
+```
+1. Read .ota/version from target repo (raw.githubusercontent — no quota cost)
+   → missing or empty: repo has never been stamped → path B (full reconcile)
+
+2. Compare .ota/version SHA against current FSA HEAD SHA
+   → matches: repo is current → path A (stamp only, update timestamp)
+   → behind: proceed to check 3
+
+3. Check for an open OTA/reconcile PR against this repo (gh_get /pulls)
+   → open PR exists: already in-flight → skip (avoid duplicate PRs)
+   → no open PR: proceed to check 4
+
+4. Check sync-template.sh checkpoint file residue via repo Actions variable
+   OTA_SYNC_INCOMPLETE (set by sync-template.sh on quota-exhausted exit)
+   → variable present and value == 'true': quota failure caused the gap → path C
+   → variable absent or false: drift from another cause → path B
+
+5. Run ota-payload-build.sh --full (dry-run) to confirm actual file delta
+   → zero files changed: stamp only (path A) — version was behind but files match
+   → files changed: open PR (path B or C, label differs)
+```
+
+Check 1 uses `raw.githubusercontent.com` (no quota). Checks 2–4 use at most
+3 REST calls per repo. Check 5 (payload build) clones two repos — only reached
+when drift is confirmed.
+
+### Version stamp format
+
+`.ota/version` is a plain YAML file written to every consumer on each
+reconcile pass:
+
+```yaml
+# Managed by fork-sync-all ota-reconcile. Do not edit manually.
+fsa_sha: abc1234def5678...   # FSA HEAD SHA at time of last successful sync
+fsa_ref: main
+stamped_at: 2026-06-17T12:00:00Z
+reconcile_path: A            # A | B | C — which path was taken
+template_sync_sha: abc1234   # SHA of last template sync (from sync-template.sh)
+```
+
+`sync-template.sh` also writes this file on each successful consumer sync
+(path A stamp, no PR needed) so the record is maintained even between
+reconcile runs.
+
+### Scope boundary
+
+OTA Reconcile only touches files that `template-manifest.yml` declares as
+owned by template sync for the consumer's profile. It does **not** touch:
+
+- Files outside the profile's include set
+- `.ota/config.yml` (managed by the repo owner)
+- `README.md`, `registered-imports.json`, `dep-graph/` (always excluded)
+- Workflow files that the consumer has `disclaim:`-ed in `.ota/config.yml`
+
+This is the same boundary enforced by `ota-payload-build.sh`. Reconcile
+reuses that script directly — it does not implement its own diffing.
+
+---
+
+## Configuration
+
+### `ota-blocklist.yml` — new field
+
+```yaml
+# Profiles eligible for OTA reconcile (drift detection + fallback).
+# These are mirror-chain profiles normally excluded from OTA delivery.
+# Reconcile is additive — it does not replace template sync for these repos.
+reconcile_eligible_profiles:
+  - full
+  - mirror
+  - infra-core
+  - standalone
+```
+
+All four profiles are eligible by default. A repo can opt out of reconcile
+by setting `reconcile: false` in its `.ota/config.yml`.
+
+### `.ota/config.yml` — new fields (consumer-side)
+
+```yaml
+# Opt out of OTA reconcile entirely (still receives template sync normally)
+reconcile: false
+
+# Override which path reconcile is allowed to take for this repo
+# Useful for repos where auto-PRs are undesirable
+reconcile_max_path: A   # A | B | C (default: C — all paths allowed)
+```
+
+### `OTA_SYNC_INCOMPLETE` Actions variable (set by sync-template.sh)
+
+`sync-template.sh` sets this variable on the consumer repo when it exits
+due to quota exhaustion before processing that repo:
+
+- `true` — this repo was in the queue when quota ran out
+- absent / `false` — repo was processed (successfully or with a non-quota error)
+
+OTA Reconcile reads this variable (check 4) to distinguish path B from path C,
+then clears it after opening the recovery PR.
+
+---
+
+## Workflow
+
+`ota-reconcile.yml` runs weekly (Wednesdays 03:17 UTC) and on manual dispatch.
+
+**Inputs (manual dispatch):**
+- `dry_run` — report what would happen without writing anything or opening PRs
+- `repo_filter` — process only repos matching this name substring
+- `force_path` — override runtime path selection (`A`, `B`, or `C`)
+- `profile_filter` — limit to repos with this template profile
+
+**Outputs (job summary):**
+
+```
+OTA Reconcile — v1.1.0 — 2026-06-17
+
+Repos processed:  48
+  Path A (stamp): 41
+  Path B (drift): 5
+  Path C (quota): 2
+  Skipped:        0
+  Failed:         0
+
+Path B PRs opened:
+  Interested-Deving-1896/some-repo  → ota/reconcile-v1.1.0
+  ...
+
+Path C PRs opened:
+  Interested-Deving-1896/other-repo → ota/reconcile-v1.1.0 [quota-recovery]
+  ...
+```
+
+---
+
+## Interaction with existing systems
+
+| System | Interaction |
+|--------|-------------|
+| `sync-template.sh` | Reconcile is downstream — it detects what sync missed, never races with it. Sync writes `.ota/version` on success; reconcile reads it. |
+| `ota-deliver.sh` | Orthogonal — deliver targets opted-in independent forks; reconcile targets mirror-chain consumers. No overlap in registry. |
+| `ota-self-update.yml` | Orthogonal — self-update runs in the fork itself (pull-based); reconcile runs in fork-sync-all (push-based). |
+| `quota-reserve.yml` | Reconcile is tier 4 (LOW) — cancelled first when quota is low. This is intentional: reconcile is a safety net, not a critical path. |
+| `queue-manager.yml` | Standard concurrency group `ota-reconcile` — at most one run at a time. |
+
+---
+
+## Exit codes (`ota-reconcile.sh`)
+
+| Code | Meaning |
+|------|---------|
+| 0 | All repos processed; no failures |
+| 1 | One or more repos failed (payload build error, PR creation error) |
+| 2 | Quota exhausted mid-run; partial completion (resume on next run) |

--- a/config/agent-cost-profiles.yml
+++ b/config/agent-cost-profiles.yml
@@ -1,19 +1,39 @@
 # config/agent-cost-profiles.yml
 #
 # Machine-readable cost profiles for AI agents used in fork-sync-all.
-# Used by .github/workflows/track-agent-costs.yml for validation and reporting.
+# Used by:
+#   .github/workflows/track-agent-costs.yml  — session logging + USD calculation
+#   .github/workflows/sync-agent-prices.yml  — weekly automated price refresh
+#   scripts/sync-agent-prices.py             — price fetch + diff + update logic
 #
 # Fields per agent:
-#   display_name    — human-readable name shown in step summaries
-#   billing_model   — ocu | gh-models | anthropic-direct | openai-direct | free
-#   ocu_per_hour    — OCU cost for environment runtime (all Ona-hosted agents = 1.0)
-#   model_in_ocu    — true if model inference is billed in OCUs (false = external billing)
-#   tokenizer       — cl100k | anthropic-bpe | sentencepiece | unknown
-#   context_k       — context window in thousands of tokens
-#   tokens_per_ocu  — approximate tokens (input+output) per OCU; null if not applicable
-#   cost_per_1m_in  — USD per 1M input tokens (null if billed via OCUs or free)
-#   cost_per_1m_out — USD per 1M output tokens (null if billed via OCUs or free)
-#   notes           — freeform notes
+#   display_name         — human-readable name shown in step summaries
+#   billing_model        — ocu | gh-models | anthropic-direct | openai-direct | free
+#   ocu_per_hour         — OCU cost for environment runtime (all Ona-hosted = 1.0)
+#   model_in_ocu         — true if model inference is billed in OCUs
+#   tokenizer            — cl100k | anthropic-bpe | sentencepiece | unknown
+#   context_k            — context window in thousands of tokens (input)
+#   context_out_k        — output context window in thousands of tokens
+#   tokens_per_ocu       — approx tokens (input+output) per OCU; null if not applicable
+#   cost_per_1m_in       — USD per 1M input tokens (null if billed via OCUs or free)
+#   cost_per_1m_out      — USD per 1M output tokens (null if billed via OCUs or free)
+#   litellm_key          — key in LiteLLM model_prices_and_context_window.json (null if N/A)
+#   price_source         — litellm | anthropic-api | google-api | manual | free
+#   prices_last_verified — ISO 8601 date when prices were last confirmed correct
+#   notes                — freeform notes
+#
+# Price sync:
+#   cost_per_1m_in/out are updated automatically by sync-agent-prices.yml (weekly).
+#   The litellm_key field determines which LiteLLM entry is used as the source.
+#   Agents with price_source: manual or free are never auto-updated.
+#   After any auto-update a PR is opened for human review before merging.
+
+# LiteLLM source pin — updated weekly by sync-agent-prices.yml
+# Pinning to a specific commit SHA ensures reproducible price lookups.
+litellm_pin:
+  sha: "1ccc1e5b23bf"
+  date: "2026-06-17"
+  url: "https://raw.githubusercontent.com/BerriAI/litellm/{sha}/model_prices_and_context_window.json"
 
 agents:
   ona:
@@ -22,14 +42,18 @@ agents:
     ocu_per_hour: 1.0
     model_in_ocu: true
     tokenizer: anthropic-bpe
-    context_k: 200
-    tokens_per_ocu: 37500   # midpoint of 25K–50K estimate
-    cost_per_1m_in: null    # billed via OCUs
+    context_k: 1000
+    context_out_k: 64
+    tokens_per_ocu: 37500
+    cost_per_1m_in: null    # billed via OCUs — no direct token cost
     cost_per_1m_out: null
+    litellm_key: null       # OCU-billed; no LiteLLM price sync needed
+    price_source: manual
+    prices_last_verified: "2026-06-17"
     notes: >
       Default agent for interactive sessions and PRs. Environment runtime
       (1 OCU/hr Standard) + model inference both billed in OCUs.
-      $0.25/OCU flat rate for top-ups.
+      $0.25/OCU flat rate for top-ups. Underlying model is claude-sonnet-4-6.
 
   codex-ona:
     display_name: "Codex Agent (via Ona, Ona-managed model)"
@@ -38,9 +62,13 @@ agents:
     model_in_ocu: true
     tokenizer: cl100k
     context_k: 128
+    context_out_k: 16
     tokens_per_ocu: 37500
     cost_per_1m_in: null
     cost_per_1m_out: null
+    litellm_key: null
+    price_source: manual
+    prices_last_verified: "2026-06-17"
     notes: >
       Codex running in an Ona Cloud environment without a connected ChatGPT plan.
       Both environment runtime and model inference billed in OCUs.
@@ -49,12 +77,16 @@ agents:
     display_name: "Codex Agent (via Ona, ChatGPT plan connected)"
     billing_model: ocu
     ocu_per_hour: 1.0
-    model_in_ocu: false     # model billed by OpenAI, not Ona
+    model_in_ocu: false
     tokenizer: cl100k
     context_k: 128
+    context_out_k: 16
     tokens_per_ocu: null
-    cost_per_1m_in: null    # managed by OpenAI/ChatGPT plan
+    cost_per_1m_in: null    # managed by OpenAI/ChatGPT plan — not tracked here
     cost_per_1m_out: null
+    litellm_key: null
+    price_source: manual
+    prices_last_verified: "2026-06-17"
     notes: >
       Codex with a connected ChatGPT account. Environment runtime billed in OCUs
       (1 OCU/hr); model inference billed by OpenAI against the ChatGPT plan.
@@ -63,13 +95,17 @@ agents:
   github-models-gpt4o:
     display_name: "GitHub Models — GPT-4o"
     billing_model: gh-models
-    ocu_per_hour: 1.0       # env runtime still billed in OCUs
+    ocu_per_hour: 1.0
     model_in_ocu: false
     tokenizer: cl100k
     context_k: 128
+    context_out_k: 16
     tokens_per_ocu: null
     cost_per_1m_in: null    # free via GitHub Models quota
     cost_per_1m_out: null
+    litellm_key: null       # free tier — no price sync needed
+    price_source: free
+    prices_last_verified: "2026-06-17"
     notes: >
       Used by llm.sh, update-readmes.sh, translate-docs.sh, create-readmes.sh.
       Model inference is free via GitHub Models quota (~150K tokens/day).
@@ -83,9 +119,13 @@ agents:
     model_in_ocu: false
     tokenizer: cl100k
     context_k: 128
+    context_out_k: 16
     tokens_per_ocu: null
     cost_per_1m_in: null
     cost_per_1m_out: null
+    litellm_key: null
+    price_source: free
+    prices_last_verified: "2026-06-17"
     notes: >
       Used by resolve-failures.sh, generate-descriptions.sh.
       Higher daily quota than gpt-4o (~1M tokens/day). Default model for
@@ -94,45 +134,58 @@ agents:
   anthropic-direct:
     display_name: "Anthropic API (direct, Claude 4 Sonnet)"
     billing_model: anthropic-direct
-    ocu_per_hour: 0.0       # no Ona environment — direct API call
+    ocu_per_hour: 0.0
     model_in_ocu: false
     tokenizer: anthropic-bpe
-    context_k: 200
+    context_k: 1000
+    context_out_k: 64
     tokens_per_ocu: null
-    cost_per_1m_in: 3.00    # USD, as of 2026 — verify at anthropic.com/pricing
+    cost_per_1m_in: 3.00    # auto-updated by sync-agent-prices.yml
     cost_per_1m_out: 15.00
+    litellm_key: "claude-sonnet-4-6"
+    price_source: litellm
+    prices_last_verified: "2026-06-17"
     notes: >
       Direct Anthropic API usage via ANTHROPIC_API_KEY. No OCU cost.
       Log ocu_estimate as 0; use anthropic_input_tokens + anthropic_output_tokens
       fields to track actual token consumption and compute USD cost.
 
   anthropic-direct-haiku:
-    display_name: "Anthropic API (direct, Claude 3.5 Haiku)"
+    display_name: "Anthropic API (direct, Claude Haiku 4.5)"
     billing_model: anthropic-direct
     ocu_per_hour: 0.0
     model_in_ocu: false
     tokenizer: anthropic-bpe
     context_k: 200
+    context_out_k: 64
     tokens_per_ocu: null
-    cost_per_1m_in: 0.80
-    cost_per_1m_out: 4.00
+    cost_per_1m_in: 1.00    # auto-updated by sync-agent-prices.yml
+    cost_per_1m_out: 5.00
+    litellm_key: "claude-haiku-4-5"
+    price_source: litellm
+    prices_last_verified: "2026-06-17"
     notes: >
-      Cheaper Claude model for high-volume direct API tasks. Same tokenizer
-      as Claude 4 Sonnet. Verify pricing at anthropic.com/pricing.
+      Faster, cheaper Claude model for high-volume direct API tasks.
+      Updated from claude-3-5-haiku to claude-haiku-4-5 (current generation).
 
   gemini-direct:
-    display_name: "Google Gemini (direct API)"
-    billing_model: openai-direct   # reuse field — means "external pay-per-token"
+    display_name: "Google Gemini 2.5 Pro (direct API)"
+    billing_model: openai-direct
     ocu_per_hour: 0.0
     model_in_ocu: false
     tokenizer: sentencepiece
-    context_k: 1000
+    context_k: 1048
+    context_out_k: 64
     tokens_per_ocu: null
-    cost_per_1m_in: 1.25    # Gemini 1.5 Pro as of 2026 — verify at ai.google.dev
-    cost_per_1m_out: 5.00
+    cost_per_1m_in: 1.25    # auto-updated by sync-agent-prices.yml
+    cost_per_1m_out: 10.00
+    litellm_key: "gemini/gemini-2.5-pro"
+    price_source: litellm
+    prices_last_verified: "2026-06-17"
     notes: >
       Not currently used in fork-sync-all scripts. Included for completeness.
-      1M token context window makes it suitable for whole-repo analysis tasks.
+      Updated to Gemini 2.5 Pro (current generation). 1M token context window
+      makes it suitable for whole-repo analysis tasks.
 
 # ── Task complexity profiles ──────────────────────────────────────────────────
 #

--- a/config/ota-blocklist.yml
+++ b/config/ota-blocklist.yml
@@ -42,3 +42,18 @@ excluded_profiles:
   - full
   - mirror
   - infra-core
+
+# ── Reconcile-eligible profiles ──────────────────────────────────────────────
+# Profiles that ota-reconcile.sh is allowed to process for drift detection
+# and quota-fallback recovery. Unlike OTA delivery, reconcile is additive —
+# it does not replace template sync, it detects what sync missed.
+#
+# All four profiles are eligible by default. A repo can opt out individually
+# by setting `reconcile: false` in its .ota/config.yml.
+#
+# To restrict reconcile to specific profiles, edit this list.
+reconcile_eligible_profiles:
+  - full
+  - mirror
+  - infra-core
+  - standalone

--- a/config/workflow-priority-tiers.yml
+++ b/config/workflow-priority-tiers.yml
@@ -212,6 +212,8 @@ tiers:
   # Cancelled first when quota drops below reserve floor.
   - name: "Track Agent Costs"
     tier: 4
+  - name: "Sync Agent Prices"
+    tier: 4
   - name: "Translate READMEs"
     tier: 4
   - name: "Generate SBOM"

--- a/config/workflow-priority-tiers.yml
+++ b/config/workflow-priority-tiers.yml
@@ -186,6 +186,8 @@ tiers:
     tier: 3
   - name: "OTA Opt-In"
     tier: 3
+  - name: "OTA Reconcile"
+    tier: 4
   - name: "OTA Release"
     tier: 3
   - name: "OTA Self-Update"

--- a/config/workflow-quota-costs.yml
+++ b/config/workflow-quota-costs.yml
@@ -772,6 +772,15 @@ workflows:
   basis: code-audit
   synopsis: Four-stage SBOM pipeline — Trivy generates CycloneDX+SPDX, sbomasm augments metadata, parlay enriches
     components, sbomqs scores quality. Runs weekly and on push to main. Release assets attached by OTA Release.
+- name: OTA Reconcile
+  min_quota: 200
+  cost_low: 20
+  cost_mid: 80
+  cost_high: 200
+  basis: code-audit
+  synopsis: Weekly drift detection and quota-fallback reconcile for mirror-chain consumer repos. Autonomously selects path
+    A (stamp), B (drift PR), or C (quota-recovery PR) per repo based on .ota/version SHA, open PR state, and
+    OTA_SYNC_INCOMPLETE variable.
 - name: OTA Release
   min_quota: 100
   cost_low: 10

--- a/config/workflow-quota-costs.yml
+++ b/config/workflow-quota-costs.yml
@@ -953,6 +953,21 @@ workflows:
   cost_high: 200
   basis: code-audit
   synopsis: Bare-clones every repo in OpenOS-Project-OSP and git push --mirror into OpenOS-Project-Ecosystem-OOC, completing the second hop of the three-org mirror chain.
+- name: Sync Agent Prices
+  min_quota: 50
+  cost_low: 3
+  cost_mid: 8
+  cost_high: 15
+  basis: code-audit
+  notes: >
+    1 GitHub API call (latest LiteLLM commit SHA) + 1 raw.githubusercontent.com
+    fetch (free, no quota) + optional Anthropic API call (external, no GH quota).
+    On price change: 1 branch push + 1 PR create. On no change: 1 commit push.
+  synopsis: >
+    Weekly hybrid A+B+C price refresh for config/agent-cost-profiles.yml.
+    Fetches LiteLLM model_prices_and_context_window.json at a pinned SHA,
+    diffs against current prices, and opens a PR for human review if anything
+    changed. Flags stale manual entries as warnings. Never auto-merges.
 - name: Track Agent Costs
   min_quota: 10
   cost_low: 1

--- a/config/workflow-sync.yml
+++ b/config/workflow-sync.yml
@@ -300,6 +300,8 @@ github_only:
     reason: Merges GitHub PRs via GitHub API — no GitLab equivalent
   - workflow_file: track-agent-costs.yml
     reason: Records AI agent session costs to data/agent-cost-log.json — GitHub-hosted log, manual dispatch only
+  - workflow_file: sync-agent-prices.yml
+    reason: Weekly price refresh for config/agent-cost-profiles.yml via LiteLLM + Anthropic API — opens PR on change, never auto-merges
   - workflow_file: sync-in.yml
     reason: Manages Sync-in server/client — targets a self-hosted instance, no GitLab CI equivalent
   - workflow_file: sync-to-gitlab.yml

--- a/config/workflow-sync.yml
+++ b/config/workflow-sync.yml
@@ -480,6 +480,8 @@ github_only:
     reason: Handles OTA opt-in from fork — GitHub API only
   - workflow_file: generate-sbom.yml
     reason: Four-stage SBOM pipeline (Trivy/sbomasm/parlay/sbomqs) — GitHub API only
+  - workflow_file: ota-reconcile.yml
+    reason: Drift detection and quota-fallback reconcile for mirror-chain consumers — GitHub API only
   - workflow_file: ota-release.yml
     reason: Delivers OTA updates to registered forks — GitHub API only
   - workflow_file: ota-self-update.yml

--- a/scripts/ota-reconcile.sh
+++ b/scripts/ota-reconcile.sh
@@ -1,0 +1,633 @@
+#!/usr/bin/env bash
+#
+# ota-reconcile.sh
+#
+# Hybrid fallback and drift-detection layer for mirror-chain consumer repos.
+# Runs weekly (via ota-reconcile.yml) and autonomously selects the best
+# recovery path per repo at runtime:
+#
+#   Path A — Version stamp only (repo is current, just update .ota/version)
+#   Path B — Drift reconcile (files differ, open a PR with the delta)
+#   Path C — Quota fallback (sync-template.sh left this repo incomplete)
+#
+# Detection order per repo:
+#   1. Read .ota/version SHA via raw.githubusercontent (no quota cost)
+#   2. Compare against current FSA HEAD SHA
+#   3. Check for an existing open reconcile PR (avoid duplicates)
+#   4. Check OTA_SYNC_INCOMPLETE Actions variable (quota failure indicator)
+#   5. Run ota-payload-build.sh --full --dry-run to confirm actual file delta
+#
+# Required env:
+#   GH_TOKEN        GitHub PAT with repo read + PR write + variables write
+#   GITHUB_OWNER    Org containing consumer repos (Interested-Deving-1896)
+#   FSA_SHA         Current fork-sync-all HEAD SHA (written to .ota/version)
+#
+# Optional env:
+#   CONSUMERS_FILE    Path to config/template-consumers.yml
+#   BLOCKLIST_FILE    Path to config/ota-blocklist.yml
+#   MANIFEST_FILE     Path to config/template-manifest.yml
+#   DRY_RUN           "true" to skip writes and PR creation
+#   REPO_FILTER       Substring filter on repo name
+#   FORCE_PATH        Override path selection: A | B | C
+#   PROFILE_FILTER    Only process repos with this template profile
+#   OTA_VERSION       Version tag for PR branch names (default: reconcile)
+#   BUDGET_MINUTES    Max runtime in minutes (default: 50)
+#
+set -uo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+: "${GITHUB_OWNER:?GITHUB_OWNER is required}"
+: "${FSA_SHA:?FSA_SHA is required}"
+
+CONSUMERS_FILE="${CONSUMERS_FILE:-config/template-consumers.yml}"
+BLOCKLIST_FILE="${BLOCKLIST_FILE:-config/ota-blocklist.yml}"
+MANIFEST_FILE="${MANIFEST_FILE:-config/template-manifest.yml}"
+DRY_RUN="${DRY_RUN:-false}"
+REPO_FILTER="${REPO_FILTER:-}"
+FORCE_PATH="${FORCE_PATH:-}"
+PROFILE_FILTER="${PROFILE_FILTER:-}"
+OTA_VERSION="${OTA_VERSION:-reconcile}"
+BUDGET_MINUTES="${BUDGET_MINUTES:-50}"
+PAYLOAD_BUILD_SCRIPT="${PAYLOAD_BUILD_SCRIPT:-scripts/ota-payload-build.sh}"
+API="${API:-https://api.github.com}"
+RAW="${RAW:-https://raw.githubusercontent.com}"
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+info() { echo "[ota-reconcile] $*" >&2; }
+warn() { echo "[ota-reconcile] WARN: $*" >&2; }
+die()  { echo "[ota-reconcile] ERROR: $*" >&2; exit 1; }
+
+gh_api() {
+  local method="$1" url="$2"; shift 2
+  curl -sf -X "$method" \
+    -H "Authorization: token ${GH_TOKEN}" \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "$@" "$url" 2>/dev/null || echo "{}"
+}
+
+gh_get() {
+  gh_api GET "$1"
+}
+
+# Budget: wall-clock deadline
+DEADLINE=$(( $(date +%s) + BUDGET_MINUTES * 60 ))
+budget_ok() { (( $(date +%s) < DEADLINE )); }
+
+# ── read consumers ────────────────────────────────────────────────────────────
+
+read_consumers() {
+  python3 - "$CONSUMERS_FILE" "$PROFILE_FILTER" <<'PYEOF'
+import sys, yaml
+
+consumers_file = sys.argv[1]
+profile_filter = sys.argv[2]
+
+with open(consumers_file) as f:
+    data = yaml.safe_load(f) or {}
+
+consumers = data.get("consumers", []) or []
+for c in consumers:
+    if not isinstance(c, dict):
+        continue
+    name = c.get("name", "")
+    profile = c.get("profile", "full")
+    disabled = c.get("disabled", False)
+    if disabled or not name:
+        continue
+    if profile_filter and profile != profile_filter:
+        continue
+    print(f"{name}\t{profile}")
+PYEOF
+}
+
+# ── reconcile_eligible check ──────────────────────────────────────────────────
+
+is_reconcile_eligible() {
+  local profile="$1"
+  python3 - "$BLOCKLIST_FILE" "$profile" <<'PYEOF'
+import sys, yaml
+
+blocklist_file = sys.argv[1]
+profile = sys.argv[2]
+
+with open(blocklist_file) as f:
+    data = yaml.safe_load(f) or {}
+
+eligible = data.get("reconcile_eligible_profiles", ["full", "mirror", "infra-core", "standalone"])
+sys.exit(0 if profile in eligible else 1)
+PYEOF
+}
+
+# ── per-repo .ota/config.yml checks ──────────────────────────────────────────
+
+repo_reconcile_enabled() {
+  local repo="$1"
+  # Returns 0 (enabled) unless reconcile: false is set in .ota/config.yml
+  local content
+  content=$(curl -sf \
+    "${RAW}/${repo}/main/.ota/config.yml" \
+    -H "Authorization: token ${GH_TOKEN}" 2>/dev/null || true)
+  if echo "$content" | grep -q "^reconcile: false"; then
+    return 1
+  fi
+  return 0
+}
+
+repo_max_path() {
+  local repo="$1"
+  local content
+  content=$(curl -sf \
+    "${RAW}/${repo}/main/.ota/config.yml" \
+    -H "Authorization: token ${GH_TOKEN}" 2>/dev/null || true)
+  echo "$content" | python3 -c "
+import sys
+for line in sys.stdin:
+    line = line.strip()
+    if line.startswith('reconcile_max_path:'):
+        val = line.split(':', 1)[1].strip().strip('\"')
+        print(val)
+        sys.exit(0)
+print('C')
+" 2>/dev/null || echo "C"
+}
+
+# ── detection checks ──────────────────────────────────────────────────────────
+
+# Check 1+2: read .ota/version and compare SHA
+# Returns: "current" | "behind" | "missing"
+check_version_stamp() {
+  local repo="$1"
+  local content
+  content=$(curl -sf \
+    "${RAW}/${repo}/main/.ota/version" \
+    -H "Authorization: token ${GH_TOKEN}" 2>/dev/null || true)
+
+  if [[ -z "$content" ]]; then
+    echo "missing"
+    return
+  fi
+
+  local stamped_sha
+  stamped_sha=$(echo "$content" | python3 -c "
+import sys
+for line in sys.stdin:
+    line = line.strip()
+    if line.startswith('fsa_sha:'):
+        print(line.split(':', 1)[1].strip())
+        sys.exit(0)
+" 2>/dev/null || true)
+
+  if [[ -z "$stamped_sha" ]]; then
+    echo "missing"
+  elif [[ "$stamped_sha" == "$FSA_SHA" ]]; then
+    echo "current"
+  else
+    echo "behind"
+  fi
+}
+
+# Check 3: open reconcile PR exists?
+check_open_pr() {
+  local repo="$1"
+  local prs
+  prs=$(gh_get "${API}/repos/${repo}/pulls?state=open&per_page=50")
+  echo "$prs" | python3 -c "
+import sys, json
+prs = json.load(sys.stdin)
+if not isinstance(prs, list):
+    sys.exit(1)
+for pr in prs:
+    branch = pr.get('head', {}).get('ref', '')
+    if branch.startswith('ota/reconcile') or branch.startswith('ota/quota-recovery'):
+        sys.exit(0)
+sys.exit(1)
+" 2>/dev/null
+}
+
+# Check 4: OTA_SYNC_INCOMPLETE Actions variable
+check_sync_incomplete() {
+  local repo="$1"
+  local result
+  result=$(gh_get "${API}/repos/${repo}/actions/variables/OTA_SYNC_INCOMPLETE")
+  local val
+  val=$(echo "$result" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+print(d.get('value', 'false'))
+" 2>/dev/null || echo "false")
+  [[ "$val" == "true" ]]
+}
+
+# Clear OTA_SYNC_INCOMPLETE after handling
+clear_sync_incomplete() {
+  local repo="$1"
+  [[ "$DRY_RUN" == "true" ]] && return
+  curl -sf -X DELETE \
+    -H "Authorization: token ${GH_TOKEN}" \
+    -H "Accept: application/vnd.github+json" \
+    "${API}/repos/${repo}/actions/variables/OTA_SYNC_INCOMPLETE" \
+    >/dev/null 2>&1 || true
+}
+
+# ── path selector ─────────────────────────────────────────────────────────────
+
+select_path() {
+  local repo="$1"
+  local repo_name="${repo##*/}"
+
+  # Honour explicit override
+  if [[ -n "$FORCE_PATH" ]]; then
+    echo "$FORCE_PATH"
+    return
+  fi
+
+  # Honour per-repo max_path cap
+  local max_path
+  max_path=$(repo_max_path "$repo")
+
+  # Check 1+2: version stamp
+  local stamp_status
+  stamp_status=$(check_version_stamp "$repo")
+  info "  stamp: ${stamp_status}"
+
+  if [[ "$stamp_status" == "current" ]]; then
+    echo "A"
+    return
+  fi
+
+  # Stamp missing or behind — check for in-flight PR
+  if check_open_pr "$repo"; then
+    info "  open reconcile PR found — skipping"
+    echo "SKIP"
+    return
+  fi
+
+  # Check 4: quota failure?
+  if check_sync_incomplete "$repo"; then
+    info "  OTA_SYNC_INCOMPLETE=true — quota fallback"
+    if [[ "$max_path" == "A" ]]; then
+      echo "A"
+    else
+      echo "C"
+    fi
+    return
+  fi
+
+  # Default: drift reconcile
+  if [[ "$max_path" == "A" ]]; then
+    echo "A"
+  else
+    echo "B"
+  fi
+}
+
+# ── path A: write version stamp ───────────────────────────────────────────────
+
+do_path_a() {
+  local repo="$1" path_label="${2:-A}"
+  local repo_name="${repo##*/}"
+
+  local stamp
+  stamp=$(printf 'fsa_sha: %s\nfsa_ref: main\nstamped_at: %s\nreconcile_path: %s\n' \
+    "$FSA_SHA" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$path_label")
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    info "  DRY: would write .ota/version to ${repo}"
+    return 0
+  fi
+
+  # Get current file SHA if it exists (needed for update)
+  local existing_sha=""
+  local existing
+  existing=$(gh_get "${API}/repos/${repo}/contents/.ota/version")
+  existing_sha=$(echo "$existing" | python3 -c \
+    "import sys,json; print(json.load(sys.stdin).get('sha',''))" 2>/dev/null || true)
+
+  local payload
+  payload=$(python3 -c "
+import json, base64, sys
+content = base64.b64encode(sys.stdin.read().encode()).decode()
+d = {'message': 'chore: update .ota/version [skip ci]', 'content': content}
+sha = '$existing_sha'
+if sha:
+    d['sha'] = sha
+print(json.dumps(d))
+" <<< "$stamp")
+
+  local http_code
+  http_code=$(curl -sf -o /dev/null -w "%{http_code}" \
+    -X PUT \
+    -H "Authorization: token ${GH_TOKEN}" \
+    -H "Accept: application/vnd.github+json" \
+    -H "Content-Type: application/json" \
+    "${API}/repos/${repo}/contents/.ota/version" \
+    -d "$payload" 2>/dev/null) || http_code="000"
+
+  if [[ "$http_code" == "200" || "$http_code" == "201" ]]; then
+    info "  .ota/version written (path ${path_label})"
+    return 0
+  else
+    warn "  Failed to write .ota/version to ${repo} (HTTP ${http_code})"
+    return 1
+  fi
+}
+
+# ── path B/C: drift reconcile via ota-payload-build.sh ───────────────────────
+
+do_path_bc() {
+  local repo="$1" path_label="$2"
+  local repo_name="${repo##*/}"
+
+  # Build payload
+  local payload_dir
+  payload_dir=$(mktemp -d)
+  trap 'rm -rf "$payload_dir"' RETURN
+
+  local rc=0
+  TARGET_REPO="$repo" \
+  PAYLOAD_DIR="$payload_dir" \
+  MANIFEST_FILE="$MANIFEST_FILE" \
+  GH_TOKEN="$GH_TOKEN" \
+  DRY_RUN="false" \
+    bash "$PAYLOAD_BUILD_SCRIPT" --full 2>&1 | sed 's/^/    /' >&2 || rc=$?
+
+  if [[ "$rc" -ne 0 ]]; then
+    warn "  Payload build failed (exit ${rc})"
+    return 1
+  fi
+
+  # Check 5: confirm actual delta
+  if [[ ! -s "${payload_dir}/.ota-changed-files" ]]; then
+    info "  No file delta after payload build — writing stamp only"
+    do_path_a "$repo" "$path_label"
+    return $?
+  fi
+
+  local changed_count
+  changed_count=$(wc -l < "${payload_dir}/.ota-changed-files")
+  info "  ${changed_count} files to update (path ${path_label})"
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    info "  DRY: would open PR against ${repo} (path ${path_label}, ${changed_count} files)"
+    return 0
+  fi
+
+  # Clone target, apply payload, push branch, open PR
+  local clone_dir
+  clone_dir=$(mktemp -d)
+  trap 'rm -rf "$clone_dir"' RETURN
+
+  local clone_url="https://x-access-token:${GH_TOKEN}@github.com/${repo}.git"
+  if ! git clone --quiet --depth=1 "$clone_url" "${clone_dir}/repo" 2>/dev/null; then
+    warn "  Failed to clone ${repo}"
+    return 1
+  fi
+
+  local default_branch
+  default_branch=$(gh_get "${API}/repos/${repo}" | python3 -c \
+    "import sys,json; print(json.load(sys.stdin).get('default_branch','main'))" 2>/dev/null || echo "main")
+
+  pushd "${clone_dir}/repo" >/dev/null
+
+  local branch_suffix
+  if [[ "$path_label" == "C" ]]; then
+    branch_suffix="quota-recovery-${FSA_SHA:0:8}"
+  else
+    branch_suffix="${OTA_VERSION}-${FSA_SHA:0:8}"
+  fi
+  local ota_branch="ota/reconcile-${branch_suffix}"
+
+  git checkout -b "$ota_branch" 2>/dev/null
+
+  # Apply payload + write version stamp
+  while IFS= read -r changed_file; do
+    [[ "$changed_file" == ".ota-changed-files" ]] && continue
+    local dest_dir
+    dest_dir="$(dirname "$changed_file")"
+    mkdir -p "$dest_dir"
+    cp "${payload_dir}/${changed_file}" "$changed_file"
+    git add "$changed_file"
+  done < "${payload_dir}/.ota-changed-files"
+
+  # Write .ota/version into the branch
+  mkdir -p .ota
+  printf 'fsa_sha: %s\nfsa_ref: main\nstamped_at: %s\nreconcile_path: %s\n' \
+    "$FSA_SHA" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$path_label" > .ota/version
+  git add .ota/version
+
+  if git diff --cached --quiet; then
+    info "  No staged changes — skipping PR"
+    popd >/dev/null
+    return 0
+  fi
+
+  local commit_msg="chore: OTA reconcile (path ${path_label}) — ${FSA_SHA:0:8}"
+  if [[ "$path_label" == "C" ]]; then
+    commit_msg="chore: OTA quota-recovery reconcile — ${FSA_SHA:0:8}"
+  fi
+
+  git -c user.name="ota-bot" -c user.email="ota@fork-sync-all" \
+    commit -m "$commit_msg
+
+Automated reconcile from fork-sync-all ota-reconcile.sh.
+Path: ${path_label} | FSA SHA: ${FSA_SHA}
+Files changed: ${changed_count}
+
+Co-authored-by: Ona <no-reply@ona.com>" 2>/dev/null
+
+  if ! git push --quiet origin "$ota_branch" 2>/dev/null; then
+    warn "  Failed to push ${ota_branch} to ${repo}"
+    popd >/dev/null
+    return 1
+  fi
+
+  popd >/dev/null
+
+  # Open PR
+  local pr_title pr_label_note
+  if [[ "$path_label" == "C" ]]; then
+    pr_title="chore: OTA quota-recovery reconcile — ${FSA_SHA:0:8}"
+    pr_label_note=" This PR was triggered by a detected quota-exhaustion gap in the last template sync run."
+  else
+    pr_title="chore: OTA drift reconcile — ${FSA_SHA:0:8}"
+    pr_label_note=""
+  fi
+
+  local pr_body
+  pr_body=$(printf \
+'## OTA Reconcile (Path %s)
+
+This PR was opened automatically by [fork-sync-all ota-reconcile.sh](https://github.com/Interested-Deving-1896/fork-sync-all).%s
+
+**FSA SHA:** `%s`
+**Files changed (%s):**
+```
+%s
+```
+
+To opt out of future reconcile runs, set `reconcile: false` in `.ota/config.yml`.' \
+    "$path_label" "$pr_label_note" "$FSA_SHA" "$changed_count" \
+    "$(grep -v '^\.ota-changed-files$' "${payload_dir}/.ota-changed-files" || true)")
+
+  local pr_result
+  pr_result=$(curl -sf -X POST \
+    -H "Authorization: token ${GH_TOKEN}" \
+    -H "Accept: application/vnd.github+json" \
+    -H "Content-Type: application/json" \
+    "${API}/repos/${repo}/pulls" \
+    -d "$(python3 -c "
+import json, sys
+print(json.dumps({
+  'title': sys.argv[1],
+  'head':  sys.argv[2],
+  'base':  sys.argv[3],
+  'body':  sys.stdin.read()
+}))" "$pr_title" "$ota_branch" "$default_branch" <<< "$pr_body")" 2>/dev/null || echo "{}")
+
+  local pr_url
+  pr_url=$(echo "$pr_result" | python3 -c \
+    "import sys,json; print(json.load(sys.stdin).get('html_url',''))" 2>/dev/null || true)
+
+  if [[ -n "$pr_url" ]]; then
+    info "  PR opened: ${pr_url}"
+    # Clear quota-failure indicator now that we've handled it
+    [[ "$path_label" == "C" ]] && clear_sync_incomplete "$repo"
+    return 0
+  else
+    local err
+    err=$(echo "$pr_result" | python3 -c \
+      "import sys,json; print(json.load(sys.stdin).get('message','unknown'))" 2>/dev/null || true)
+    warn "  PR creation failed: ${err}"
+    return 1
+  fi
+}
+
+# ── main loop ─────────────────────────────────────────────────────────────────
+
+info "OTA Reconcile starting"
+info "  FSA SHA:    ${FSA_SHA:0:12}..."
+info "  Owner:      ${GITHUB_OWNER}"
+info "  Dry run:    ${DRY_RUN}"
+info "  Force path: ${FORCE_PATH:-auto}"
+echo "" >&2
+
+count_a=0; count_b=0; count_c=0; count_skip=0; count_fail=0
+selected_path=""
+local_repo=""
+
+declare -a pr_b_list=() pr_c_list=()
+
+while IFS=$'\t' read -r repo_name profile; do
+  [[ -z "$repo_name" ]] && continue
+
+  if [[ -n "$REPO_FILTER" && "$repo_name" != *"$REPO_FILTER"* ]]; then
+    continue
+  fi
+
+  if ! budget_ok; then
+    warn "Budget exhausted — stopping early"
+    break
+  fi
+
+  local_repo="${GITHUB_OWNER}/${repo_name}"
+  info "──────────────────────────────────────────"
+  info "Repo: ${local_repo}  profile=${profile}"
+
+  # Profile eligibility
+  if ! is_reconcile_eligible "$profile"; then
+    info "  Profile '${profile}' not in reconcile_eligible_profiles — skipping"
+    (( count_skip++ )) || true
+    continue
+  fi
+
+  # Per-repo opt-out
+  if ! repo_reconcile_enabled "$local_repo"; then
+    info "  reconcile: false in .ota/config.yml — skipping"
+    (( count_skip++ )) || true
+    continue
+  fi
+
+  # Select path
+  selected_path=$(select_path "$local_repo")
+
+  if [[ "$selected_path" == "SKIP" ]]; then
+    (( count_skip++ )) || true
+    continue
+  fi
+
+  info "  Selected path: ${selected_path}"
+
+  case "$selected_path" in
+    A)
+      if do_path_a "$local_repo" "A"; then
+        (( count_a++ )) || true
+      else
+        (( count_fail++ )) || true
+      fi
+      ;;
+    B)
+      if do_path_bc "$local_repo" "B"; then
+        (( count_b++ )) || true
+        pr_b_list+=("$local_repo")
+      else
+        (( count_fail++ )) || true
+      fi
+      ;;
+    C)
+      if do_path_bc "$local_repo" "C"; then
+        (( count_c++ )) || true
+        pr_c_list+=("$local_repo")
+      else
+        (( count_fail++ )) || true
+      fi
+      ;;
+    *)
+      warn "  Unknown path '${selected_path}' — skipping"
+      (( count_skip++ )) || true
+      ;;
+  esac
+
+  echo "" >&2
+done < <(read_consumers)
+
+# ── summary ───────────────────────────────────────────────────────────────────
+
+echo "" >&2
+info "========================================"
+info "  OTA Reconcile complete"
+info "  Path A (stamp):  ${count_a}"
+info "  Path B (drift):  ${count_b}"
+info "  Path C (quota):  ${count_c}"
+info "  Skipped:         ${count_skip}"
+info "  Failed:          ${count_fail}"
+info "========================================"
+
+# Write GitHub Actions step summary if available
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  {
+    echo "## OTA Reconcile — \`${FSA_SHA:0:12}\`"
+    echo ""
+    echo "| | Count |"
+    echo "|---|---|"
+    echo "| Path A (stamp only) | ${count_a} |"
+    echo "| Path B (drift PR) | ${count_b} |"
+    echo "| Path C (quota-recovery PR) | ${count_c} |"
+    echo "| Skipped | ${count_skip} |"
+    echo "| Failed | ${count_fail} |"
+    if [[ ${#pr_b_list[@]} -gt 0 ]]; then
+      echo ""
+      echo "### Path B PRs"
+      for r in "${pr_b_list[@]}"; do echo "- \`${r}\`"; done
+    fi
+    if [[ ${#pr_c_list[@]} -gt 0 ]]; then
+      echo ""
+      echo "### Path C PRs (quota-recovery)"
+      for r in "${pr_c_list[@]}"; do echo "- \`${r}\`"; done
+    fi
+  } >> "$GITHUB_STEP_SUMMARY"
+fi
+
+[[ "$count_fail" -gt 0 ]] && exit 1
+exit 0

--- a/scripts/sync-agent-prices.py
+++ b/scripts/sync-agent-prices.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+"""
+scripts/sync-agent-prices.py
+
+Hybrid A+B+C price sync for config/agent-cost-profiles.yml.
+
+Sources (in priority order per agent):
+  A — Anthropic API  GET /v1/models  (requires ANTHROPIC_API_KEY)
+  B — LiteLLM        model_prices_and_context_window.json (pinned SHA)
+  C — Staleness      flag agents with prices_last_verified > STALE_DAYS old
+
+Behaviour:
+  - Fetches LiteLLM JSON at the pinned SHA from litellm_pin.sha in the config.
+  - For each agent with price_source: litellm, looks up litellm_key and reads
+    input_cost_per_token / output_cost_per_token (converts to per-1M).
+  - For agents with price_source: anthropic-api, queries the Anthropic API
+    directly for the model's pricing (requires ANTHROPIC_API_KEY env var).
+  - Agents with price_source: manual or free are never modified.
+  - Computes a diff of changed prices.
+  - Updates config/agent-cost-profiles.yml in-place (prices + prices_last_verified
+    + litellm_pin.sha/date).
+  - Exits 0 with no changes if nothing changed.
+  - Exits 2 if prices changed (caller should open a PR).
+  - Exits 1 on fetch/parse errors.
+  - Writes a structured report to GITHUB_STEP_SUMMARY if set.
+  - Flags stale entries (price_source: manual, prices_last_verified > STALE_DAYS)
+    as warnings — does not modify them, just reports.
+
+Usage:
+  python3 scripts/sync-agent-prices.py [--config PATH] [--stale-days N] [--dry-run]
+
+Environment:
+  ANTHROPIC_API_KEY  — optional; enables Option A (Anthropic API direct lookup)
+  GITHUB_STEP_SUMMARY — optional; path to write step summary markdown
+"""
+
+import argparse
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).parent.parent
+DEFAULT_CONFIG = REPO_ROOT / "config" / "agent-cost-profiles.yml"
+LITELLM_URL_TEMPLATE = (
+    "https://raw.githubusercontent.com/BerriAI/litellm/{sha}"
+    "/model_prices_and_context_window.json"
+)
+ANTHROPIC_MODELS_URL = "https://api.anthropic.com/v1/models"
+DEFAULT_STALE_DAYS = 90
+
+
+# ── Fetch helpers ─────────────────────────────────────────────────────────────
+
+def fetch_json(url: str, headers: dict | None = None) -> dict:
+    req = urllib.request.Request(url, headers=headers or {})
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        raise RuntimeError(f"HTTP {e.code} fetching {url}") from e
+    except Exception as e:
+        raise RuntimeError(f"Failed to fetch {url}: {e}") from e
+
+
+def fetch_litellm(sha: str) -> dict:
+    url = LITELLM_URL_TEMPLATE.format(sha=sha)
+    print(f"[litellm] Fetching {url}", file=sys.stderr)
+    return fetch_json(url)
+
+
+def fetch_anthropic_models(api_key: str) -> dict:
+    """
+    Returns a dict of model_id -> {input_cost_per_1m, output_cost_per_1m}
+    from the Anthropic /v1/models endpoint.
+
+    Note: as of 2026, the Anthropic models API returns model metadata but
+    pricing is not included in the response. This function is a stub that
+    returns an empty dict — if Anthropic adds pricing to the API response
+    in future, implement it here.
+    """
+    print("[anthropic-api] Querying Anthropic /v1/models ...", file=sys.stderr)
+    try:
+        data = fetch_json(
+            ANTHROPIC_MODELS_URL,
+            headers={
+                "x-api-key": api_key,
+                "anthropic-version": "2023-06-01",
+            },
+        )
+        # Anthropic API currently does not include pricing in model list.
+        # Log available models for debugging but return empty pricing dict.
+        models = [m.get("id", "") for m in data.get("data", [])]
+        print(f"[anthropic-api] Available models: {models}", file=sys.stderr)
+        print(
+            "[anthropic-api] Pricing not available in API response — "
+            "falling back to LiteLLM for Anthropic prices.",
+            file=sys.stderr,
+        )
+        return {}
+    except RuntimeError as e:
+        print(f"[anthropic-api] WARNING: {e} — falling back to LiteLLM", file=sys.stderr)
+        return {}
+
+
+# ── Price extraction ──────────────────────────────────────────────────────────
+
+def litellm_price(litellm_data: dict, key: str) -> tuple[float | None, float | None, int | None, int | None]:
+    """
+    Returns (cost_per_1m_in, cost_per_1m_out, context_k, context_out_k)
+    for the given LiteLLM key, or (None, None, None, None) if not found.
+    """
+    entry = litellm_data.get(key)
+    if not entry:
+        return None, None, None, None
+
+    in_per_token  = entry.get("input_cost_per_token")
+    out_per_token = entry.get("output_cost_per_token")
+    ctx_in  = entry.get("max_input_tokens")
+    ctx_out = entry.get("max_output_tokens")
+
+    cost_in  = round(in_per_token  * 1_000_000, 6) if in_per_token  is not None else None
+    cost_out = round(out_per_token * 1_000_000, 6) if out_per_token is not None else None
+    ctx_in_k  = round(ctx_in  / 1000) if ctx_in  else None
+    ctx_out_k = round(ctx_out / 1000) if ctx_out else None
+
+    return cost_in, cost_out, ctx_in_k, ctx_out_k
+
+
+# ── Staleness check ───────────────────────────────────────────────────────────
+
+def is_stale(verified_str: str | None, stale_days: int) -> bool:
+    if not verified_str:
+        return True
+    try:
+        verified = datetime.fromisoformat(str(verified_str))
+        if verified.tzinfo is None:
+            verified = verified.replace(tzinfo=timezone.utc)
+        return (datetime.now(timezone.utc) - verified) > timedelta(days=stale_days)
+    except ValueError:
+        return True
+
+
+# ── YAML round-trip helpers ───────────────────────────────────────────────────
+
+def _update_agent_field(lines: list[str], agent_name: str, field: str, new_value) -> bool:
+    """
+    In-place update of a scalar field under an agent block in the YAML source.
+    Returns True if a change was made.
+    Preserves all comments and formatting outside the changed line.
+    """
+    in_agent = False
+    indent = ""
+    changed = False
+
+    for i, line in enumerate(lines):
+        # Detect agent block start (e.g. "  ona:")
+        stripped = line.rstrip()
+        if stripped.endswith(f"{agent_name}:") and not stripped.startswith("#"):
+            in_agent = True
+            indent = " " * (len(line) - len(line.lstrip()) + 2)
+            continue
+
+        if in_agent:
+            # End of this agent block = next non-empty, non-comment line at same or lower indent
+            if stripped and not stripped.startswith("#"):
+                line_indent = len(line) - len(line.lstrip())
+                agent_indent = len(indent) - 2
+                if line_indent <= agent_indent and not stripped.startswith(f"{indent.strip()}"):
+                    in_agent = False
+                    continue
+
+            # Match the field
+            field_prefix = f"{indent}{field}:"
+            if line.startswith(field_prefix):
+                # Format the new value
+                if isinstance(new_value, str):
+                    formatted = f'"{new_value}"'
+                elif new_value is None:
+                    formatted = "null"
+                elif isinstance(new_value, float):
+                    # Preserve up to 4 significant decimal places, strip trailing zeros
+                    formatted = f"{new_value:.4f}".rstrip("0").rstrip(".")
+                    if "." not in formatted:
+                        formatted += ".0"
+                else:
+                    formatted = str(new_value)
+
+                # Preserve inline comment if present
+                comment = ""
+                rest = line[len(field_prefix):].strip()
+                if "#" in rest:
+                    comment = "  " + rest[rest.index("#"):]
+
+                new_line = f"{indent}{field}: {formatted}{comment}\n"
+                if new_line != line:
+                    lines[i] = new_line
+                    changed = True
+                break
+
+    return changed
+
+
+def _update_litellm_pin(lines: list[str], sha: str, date: str) -> bool:
+    changed = False
+    for i, line in enumerate(lines):
+        if line.strip().startswith("sha:") and i > 0:
+            # Check we're inside litellm_pin block
+            for j in range(i - 1, max(i - 5, -1), -1):
+                if "litellm_pin:" in lines[j]:
+                    new_line = f'  sha: "{sha}"\n'
+                    if lines[i] != new_line:
+                        lines[i] = new_line
+                        changed = True
+                    break
+        if line.strip().startswith("date:") and i > 0:
+            for j in range(i - 1, max(i - 5, -1), -1):
+                if "litellm_pin:" in lines[j]:
+                    new_line = f'  date: "{date}"\n'
+                    if lines[i] != new_line:
+                        lines[i] = new_line
+                        changed = True
+                    break
+    return changed
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", default=str(DEFAULT_CONFIG))
+    parser.add_argument("--stale-days", type=int, default=DEFAULT_STALE_DAYS)
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Compute diff but do not write changes")
+    args = parser.parse_args()
+
+    config_path = Path(args.config)
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+    # ── Load config ───────────────────────────────────────────────────────────
+    with open(config_path) as f:
+        raw_lines = f.readlines()
+    with open(config_path) as f:
+        config = yaml.safe_load(f)
+
+    agents       = config.get("agents", {})
+    litellm_pin  = config.get("litellm_pin", {})
+    current_sha  = litellm_pin.get("sha", "main")
+
+    # ── Fetch latest LiteLLM SHA ──────────────────────────────────────────────
+    print("[sha] Fetching latest LiteLLM commit SHA for model_prices_and_context_window.json ...", file=sys.stderr)
+    try:
+        commits = fetch_json(
+            "https://api.github.com/repos/BerriAI/litellm/commits"
+            "?path=model_prices_and_context_window.json&per_page=1"
+        )
+        latest_sha  = commits[0]["sha"][:12]
+        latest_date = commits[0]["commit"]["committer"]["date"][:10]
+        print(f"[sha] Latest SHA: {latest_sha} ({latest_date})", file=sys.stderr)
+    except Exception as e:
+        print(f"[sha] WARNING: could not fetch latest SHA ({e}) — using pinned {current_sha}", file=sys.stderr)
+        latest_sha  = current_sha
+        latest_date = today
+
+    # ── Fetch LiteLLM data ────────────────────────────────────────────────────
+    try:
+        litellm_data = fetch_litellm(latest_sha)
+    except RuntimeError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        # Fall back to pinned SHA
+        if latest_sha != current_sha:
+            print(f"[litellm] Falling back to pinned SHA {current_sha}", file=sys.stderr)
+            try:
+                litellm_data = fetch_litellm(current_sha)
+                latest_sha  = current_sha
+                latest_date = litellm_pin.get("date", today)
+            except RuntimeError as e2:
+                print(f"ERROR: fallback also failed: {e2}", file=sys.stderr)
+                return 1
+        else:
+            return 1
+
+    # ── Option A: Anthropic API ───────────────────────────────────────────────
+    anthropic_api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    anthropic_prices: dict = {}
+    if anthropic_api_key:
+        anthropic_prices = fetch_anthropic_models(anthropic_api_key)
+    else:
+        print("[anthropic-api] ANTHROPIC_API_KEY not set — skipping Option A", file=sys.stderr)
+
+    # ── Process each agent ────────────────────────────────────────────────────
+    changes:  list[dict] = []
+    warnings: list[str]  = []
+    working_lines = list(raw_lines)
+
+    for agent_name, ap in agents.items():
+        price_source = ap.get("price_source", "manual")
+        litellm_key  = ap.get("litellm_key")
+        verified_str = ap.get("prices_last_verified")
+
+        # Option C: staleness check for manual entries
+        if price_source in ("manual", "free"):
+            if is_stale(verified_str, args.stale_days):
+                warnings.append(
+                    f"{agent_name}: price_source={price_source}, "
+                    f"prices_last_verified={verified_str} is >{args.stale_days} days old — "
+                    f"manual verification needed"
+                )
+            continue
+
+        # Option A: Anthropic API (currently returns empty — future-proofed)
+        if price_source == "anthropic-api" and litellm_key in anthropic_prices:
+            ap_prices = anthropic_prices[litellm_key]
+            new_in  = ap_prices.get("input_cost_per_1m")
+            new_out = ap_prices.get("output_cost_per_1m")
+        elif price_source in ("litellm", "anthropic-api") and litellm_key:
+            # Option B: LiteLLM
+            new_in, new_out, new_ctx_k, new_ctx_out_k = litellm_price(litellm_data, litellm_key)
+            if new_in is None:
+                warnings.append(
+                    f"{agent_name}: litellm_key '{litellm_key}' not found in LiteLLM data"
+                )
+                continue
+        else:
+            continue
+
+        old_in  = ap.get("cost_per_1m_in")
+        old_out = ap.get("cost_per_1m_out")
+
+        price_changed = (
+            new_in  is not None and abs((new_in  or 0) - (old_in  or 0)) > 0.0001
+        ) or (
+            new_out is not None and abs((new_out or 0) - (old_out or 0)) > 0.0001
+        )
+
+        if price_changed:
+            changes.append({
+                "agent":   agent_name,
+                "display": ap.get("display_name", agent_name),
+                "field":   "cost_per_1m_in",
+                "old":     old_in,
+                "new":     new_in,
+            })
+            changes.append({
+                "agent":   agent_name,
+                "display": ap.get("display_name", agent_name),
+                "field":   "cost_per_1m_out",
+                "old":     old_out,
+                "new":     new_out,
+            })
+
+        if not args.dry_run:
+            if new_in is not None:
+                _update_agent_field(working_lines, agent_name, "cost_per_1m_in",  new_in)
+            if new_out is not None:
+                _update_agent_field(working_lines, agent_name, "cost_per_1m_out", new_out)
+            # Update context windows if they changed
+            if new_ctx_k and new_ctx_k != ap.get("context_k"):
+                _update_agent_field(working_lines, agent_name, "context_k", new_ctx_k)
+            if new_ctx_out_k and new_ctx_out_k != ap.get("context_out_k"):
+                _update_agent_field(working_lines, agent_name, "context_out_k", new_ctx_out_k)
+            _update_agent_field(working_lines, agent_name, "prices_last_verified", today)
+
+    # ── Update litellm_pin ────────────────────────────────────────────────────
+    pin_changed = latest_sha != current_sha
+    if not args.dry_run and pin_changed:
+        _update_litellm_pin(working_lines, latest_sha, latest_date)
+
+    # ── Write updated config ──────────────────────────────────────────────────
+    if not args.dry_run and (changes or pin_changed):
+        with open(config_path, "w") as f:
+            f.writelines(working_lines)
+        print(f"[write] Updated {config_path}", file=sys.stderr)
+
+    # ── Report ────────────────────────────────────────────────────────────────
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+
+    print("\n=== Price Sync Report ===", file=sys.stderr)
+
+    if changes:
+        print(f"\nPrice changes ({len(changes) // 2} agent(s)):", file=sys.stderr)
+        seen = set()
+        for c in changes:
+            if c["agent"] not in seen:
+                seen.add(c["agent"])
+                in_c  = next((x for x in changes if x["agent"] == c["agent"] and x["field"] == "cost_per_1m_in"),  {})
+                out_c = next((x for x in changes if x["agent"] == c["agent"] and x["field"] == "cost_per_1m_out"), {})
+                print(
+                    f"  {c['display']}: "
+                    f"in ${in_c.get('old')} → ${in_c.get('new')}/1M, "
+                    f"out ${out_c.get('old')} → ${out_c.get('new')}/1M",
+                    file=sys.stderr,
+                )
+    else:
+        print("\nNo price changes.", file=sys.stderr)
+
+    if pin_changed:
+        print(f"\nLiteLLM pin updated: {current_sha} → {latest_sha} ({latest_date})", file=sys.stderr)
+
+    if warnings:
+        print(f"\nWarnings ({len(warnings)}):", file=sys.stderr)
+        for w in warnings:
+            print(f"  ⚠ {w}", file=sys.stderr)
+
+    # Write step summary
+    if summary_path:
+        with open(summary_path, "a") as f:
+            f.write("## Agent Price Sync\n\n")
+            f.write(f"**LiteLLM SHA**: `{latest_sha}` ({latest_date})")
+            if pin_changed:
+                f.write(f" ← updated from `{current_sha}`")
+            f.write("\n\n")
+
+            if changes:
+                f.write(f"### Price changes — {len(changes) // 2} agent(s)\n\n")
+                f.write("| Agent | Field | Old | New |\n|---|---|---|---|\n")
+                for c in changes:
+                    f.write(f"| {c['display']} | {c['field']} | ${c['old']} | ${c['new']} |\n")
+                f.write("\n> A PR has been opened for review.\n")
+            else:
+                f.write("✅ No price changes — all prices current.\n")
+
+            if warnings:
+                f.write(f"\n### Staleness warnings — {len(warnings)}\n\n")
+                for w in warnings:
+                    f.write(f"- ⚠️ {w}\n")
+                f.write(
+                    f"\nAgents with `price_source: manual` or `free` are not auto-updated. "
+                    f"Verify prices at the relevant provider and update "
+                    f"`config/agent-cost-profiles.yml` manually.\n"
+                )
+
+    # Exit codes: 0 = no changes, 1 = error, 2 = prices changed (open PR)
+    if changes:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sync-template.sh
+++ b/scripts/sync-template.sh
@@ -1025,6 +1025,17 @@ print(' '.join(names))
     # Stop if API quota is too low to safely process another consumer
     if ! quota_ok; then
       quota_exhausted=1
+      # Signal to ota-reconcile.sh that this repo was not processed due to
+      # quota exhaustion. Reconcile reads this variable (check 4) to select
+      # path C (quota-recovery) instead of path B (drift).
+      if [[ "$DRY_RUN" != "true" ]]; then
+        curl -sf -o /dev/null -X PUT \
+          -H "Authorization: token ${GH_TOKEN}" \
+          -H "Accept: application/vnd.github+json" \
+          -H "Content-Type: application/json" \
+          "${API}/repos/${GITHUB_OWNER}/${c_name}/actions/variables/OTA_SYNC_INCOMPLETE" \
+          -d '{"name":"OTA_SYNC_INCOMPLETE","value":"true"}' 2>/dev/null || true
+      fi
       break
     fi
 
@@ -1141,6 +1152,41 @@ print(' '.join(names))
           _set_repo_var "AF_REGISTRY_BRANCH" "$reg_branch"
           _set_repo_var "AF_REGISTRY_PATH"   "$reg_path"
           unset -f _set_repo_var
+        fi
+
+        # Write .ota/version stamp so ota-reconcile.sh can detect currency
+        # without diffing files. Failure is non-fatal.
+        local fsa_sha_val="${FSA_SHA:-${GITHUB_SHA:-}}"
+        if [[ -n "$fsa_sha_val" ]]; then
+          local stamp_content existing_file_sha stamp_payload stamp_http
+          stamp_content=$(printf 'fsa_sha: %s\nfsa_ref: main\nstamped_at: %s\nreconcile_path: A\n' \
+            "$fsa_sha_val" "$(date -u +%Y-%m-%dT%H:%M:%SZ)")
+          existing_file_sha=$(curl -sf \
+            -H "Authorization: token ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "${API}/repos/${GITHUB_OWNER}/${c_name}/contents/.ota/version" \
+            2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('sha',''))" 2>/dev/null || true)
+          stamp_payload=$(python3 -c "
+import json, base64, sys
+content = base64.b64encode(sys.stdin.read().encode()).decode()
+d = {'message': 'chore: update .ota/version [skip ci]', 'content': content}
+sha = '$existing_file_sha'
+if sha:
+    d['sha'] = sha
+print(json.dumps(d))
+" <<< "$stamp_content")
+          stamp_http=$(curl -sf -o /dev/null -w "%{http_code}" \
+            -X PUT \
+            -H "Authorization: token ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "Content-Type: application/json" \
+            "${API}/repos/${GITHUB_OWNER}/${c_name}/contents/.ota/version" \
+            -d "$stamp_payload" 2>/dev/null) || stamp_http="000"
+          if [[ "$stamp_http" == "200" || "$stamp_http" == "201" ]]; then
+            info "  .ota/version stamped (${fsa_sha_val:0:8})"
+          else
+            warn "  Could not write .ota/version to ${c_name} (HTTP ${stamp_http}) — reconcile will handle on next run"
+          fi
         fi
       fi
     else

--- a/tests/test_ota_reconcile.py
+++ b/tests/test_ota_reconcile.py
@@ -1,0 +1,492 @@
+"""
+Tests for scripts/ota-reconcile.sh
+
+Strategy: mock the GitHub API and raw.githubusercontent.com with a local HTTP
+server, then invoke ota-reconcile.sh in a subprocess with controlled env vars.
+ota-payload-build.sh is stubbed via a wrapper script to avoid real git clones.
+
+Coverage:
+  - Path A selected when .ota/version SHA matches FSA_SHA
+  - Path B selected when SHA is behind and OTA_SYNC_INCOMPLETE is absent
+  - Path C selected when SHA is behind and OTA_SYNC_INCOMPLETE=true
+  - SKIP when an open reconcile PR already exists
+  - SKIP when reconcile: false in .ota/config.yml
+  - SKIP when profile not in reconcile_eligible_profiles
+  - force_path override bypasses detection
+  - dry_run suppresses all writes and PR creation
+  - Version stamp written on path A
+  - OTA_SYNC_INCOMPLETE cleared after path C
+  - bash -n syntax check
+"""
+
+import json
+import os
+import subprocess
+import textwrap
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+RECONCILE_SCRIPT = os.path.join(REPO_ROOT, "scripts", "ota-reconcile.sh")
+CONSUMERS_FILE = os.path.join(REPO_ROOT, "config", "template-consumers.yml")
+BLOCKLIST_FILE = os.path.join(REPO_ROOT, "config", "ota-blocklist.yml")
+MANIFEST_FILE = os.path.join(REPO_ROOT, "config", "template-manifest.yml")
+
+FSA_SHA = "abc1234def5678901234567890abcdef12345678"
+OLD_SHA = "0000000000000000000000000000000000000000"
+
+
+# ── Mock HTTP server ──────────────────────────────────────────────────────────
+
+class _MockHandler(BaseHTTPRequestHandler):
+    """Handles GitHub API + raw.githubusercontent.com requests."""
+
+    def log_message(self, *args):
+        pass
+
+    def _send_json(self, code, body):
+        data = json.dumps(body).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _send_text(self, code, text):
+        data = text.encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _read_body(self):
+        length = int(self.headers.get("Content-Length", 0))
+        return self.rfile.read(length).decode() if length else ""
+
+    def do_DELETE(self):
+        self._read_body()
+        cfg = self.server.config
+        cfg.setdefault("deleted_vars", []).append(self.path)
+        self.send_response(204)
+        self.end_headers()
+
+    def do_PUT(self):
+        body = self._read_body()
+        cfg = self.server.config
+        cfg.setdefault("put_calls", []).append({"path": self.path, "body": body})
+        self.send_response(201)
+        self.end_headers()
+
+    def do_POST(self):
+        body = self._read_body()
+        cfg = self.server.config
+        cfg.setdefault("post_calls", []).append({"path": self.path, "body": body})
+        # Return a fake PR URL
+        self._send_json(201, {"html_url": f"https://github.com/test/repo/pull/99"})
+
+    def do_GET(self):
+        cfg = self.server.config
+        path = self.path.split("?")[0]
+
+        # raw.githubusercontent.com — .ota/version
+        # URL pattern: /{owner}/{repo}/main/.ota/version
+        if path.endswith("/.ota/version") and "/main/" in path and "/repos/" not in path and "/contents/" not in path:
+            version_sha = cfg.get("version_sha", "")
+            if version_sha == "404":
+                self.send_response(404)
+                self.end_headers()
+                return
+            stamp = f"fsa_sha: {version_sha}\nfsa_ref: main\nstamped_at: 2026-01-01T00:00:00Z\nreconcile_path: A\n"
+            self._send_text(200, stamp)
+            return
+
+        # raw.githubusercontent.com — .ota/config.yml
+        if path.endswith("/.ota/config.yml") and "/main/" in path and "/repos/" not in path:
+            ota_config = cfg.get("ota_config", "")
+            if ota_config == "404":
+                self.send_response(404)
+                self.end_headers()
+                return
+            self._send_text(200, ota_config)
+            return
+
+        # GET /repos/{owner}/{repo}/pulls
+        if "/pulls" in path and "variables" not in path:
+            open_prs = cfg.get("open_prs", [])
+            self._send_json(200, open_prs)
+            return
+
+        # GET /repos/{owner}/{repo}/actions/variables/OTA_SYNC_INCOMPLETE
+        if "OTA_SYNC_INCOMPLETE" in path:
+            incomplete = cfg.get("sync_incomplete", False)
+            if incomplete:
+                self._send_json(200, {"name": "OTA_SYNC_INCOMPLETE", "value": "true"})
+            else:
+                self.send_response(404)
+                self.end_headers()
+            return
+
+        # GET /repos/{owner}/{repo}/contents/.ota/version (for SHA lookup before PUT)
+        if "/contents/.ota/version" in path:
+            existing_sha = cfg.get("existing_version_file_sha", "")
+            if existing_sha:
+                self._send_json(200, {"sha": existing_sha, "content": ""})
+            else:
+                self.send_response(404)
+                self.end_headers()
+            return
+
+        # GET /repos/{owner}/{repo} (default branch)
+        if path.count("/") == 3 and path.startswith("/repos/"):
+            self._send_json(200, {"default_branch": "main", "name": path.split("/")[-1]})
+            return
+
+        # Fallback
+        self._send_json(200, {})
+
+
+def _start_mock_server(config=None):
+    server = HTTPServer(("127.0.0.1", 0), _MockHandler)
+    server.config = config or {}
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server
+
+
+# ── Consumers file fixture ────────────────────────────────────────────────────
+
+def _write_consumers(tmp_path, repos):
+    """Write a minimal template-consumers.yml with the given repos."""
+    consumers = {"consumers": [
+        {"name": r.get("name"), "profile": r.get("profile", "full")}
+        for r in repos
+    ]}
+    path = tmp_path / "template-consumers.yml"
+    path.write_text(yaml.dump(consumers))
+    return str(path)
+
+
+def _write_blocklist(tmp_path, extra=None):
+    """Write a minimal ota-blocklist.yml."""
+    data = {
+        "github_orgs": ["Interested-Deving-1896"],
+        "gitlab_namespaces": ["openos-project"],
+        "excluded_profiles": ["full", "mirror", "infra-core"],
+        "reconcile_eligible_profiles": ["full", "mirror", "infra-core", "standalone"],
+    }
+    if extra:
+        data.update(extra)
+    path = tmp_path / "ota-blocklist.yml"
+    path.write_text(yaml.dump(data))
+    return str(path)
+
+
+# ── Helper to run the script ──────────────────────────────────────────────────
+
+def _write_payload_stub_script(tmp_path, has_changes=False):
+    """Write a stub ota-payload-build.sh and return its path."""
+    stub = tmp_path / "ota-payload-build-stub.sh"
+    if has_changes:
+        stub.write_text(textwrap.dedent("""\
+            #!/usr/bin/env bash
+            mkdir -p "$PAYLOAD_DIR/some"
+            echo "some/file.yml" > "$PAYLOAD_DIR/.ota-changed-files"
+            echo "# stub" > "$PAYLOAD_DIR/some/file.yml"
+            exit 0
+        """))
+    else:
+        stub.write_text(textwrap.dedent("""\
+            #!/usr/bin/env bash
+            mkdir -p "$PAYLOAD_DIR"
+            # No changes — empty changed-files list
+            exit 0
+        """))
+    stub.chmod(0o755)
+    return str(stub)
+
+
+def _run_reconcile(server, consumers_file, blocklist_file, tmp_path,
+                   extra_env=None, repo_filter="test-repo", payload_has_changes=False):
+    port = server.server_address[1]
+    api_url = f"http://127.0.0.1:{port}"
+
+    payload_stub = _write_payload_stub_script(tmp_path, has_changes=payload_has_changes)
+
+    env = {
+        "PATH": os.environ.get("PATH", ""),
+        "GH_TOKEN": "test-token",
+        "GITHUB_OWNER": "Interested-Deving-1896",
+        "FSA_SHA": FSA_SHA,
+        "CONSUMERS_FILE": consumers_file,
+        "BLOCKLIST_FILE": blocklist_file,
+        "MANIFEST_FILE": MANIFEST_FILE,
+        "DRY_RUN": "false",
+        "REPO_FILTER": repo_filter,
+        "FORCE_PATH": "",
+        "PROFILE_FILTER": "",
+        "OTA_VERSION": "v1.1.0",
+        "BUDGET_MINUTES": "5",
+        "PAYLOAD_BUILD_SCRIPT": payload_stub,
+        # Point API + raw calls at mock server
+        "API": api_url,
+        "RAW": api_url,
+        "HOME": str(tmp_path),
+    }
+    if extra_env:
+        env.update(extra_env)
+
+    result = subprocess.run(
+        ["bash", RECONCILE_SCRIPT],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    return result
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+def test_syntax_check():
+    """bash -n must pass on ota-reconcile.sh."""
+    result = subprocess.run(
+        ["bash", "-n", RECONCILE_SCRIPT],
+        capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_path_a_current_sha(tmp_path):
+    """Repo whose .ota/version SHA matches FSA_SHA → path A (stamp only, no PR)."""
+    server = _start_mock_server({"version_sha": FSA_SHA})
+    consumers_file = _write_consumers(tmp_path, [{"name": "test-repo", "profile": "full"}])
+    blocklist_file = _write_blocklist(tmp_path)
+
+    result = _run_reconcile(server, consumers_file, blocklist_file, tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert "Selected path: A" in result.stderr
+    # No PR should be opened
+    assert "post_calls" not in server.config or not any(
+        "/pulls" in c["path"] for c in server.config.get("post_calls", [])
+    )
+    server.shutdown()
+
+
+def test_path_b_behind_no_incomplete(tmp_path):
+    """Repo with stale SHA and no OTA_SYNC_INCOMPLETE → path B (drift PR)."""
+    server = _start_mock_server({
+        "version_sha": OLD_SHA,
+        "sync_incomplete": False,
+        "open_prs": [],
+    })
+    consumers_file = _write_consumers(tmp_path, [{"name": "test-repo", "profile": "full"}])
+    blocklist_file = _write_blocklist(tmp_path)
+
+    result = _run_reconcile(server, consumers_file, blocklist_file, tmp_path,
+                            extra_env={"DRY_RUN": "true"},
+                            payload_has_changes=True)
+
+    assert result.returncode == 0, result.stderr
+    assert "Selected path: B" in result.stderr
+    server.shutdown()
+
+
+def test_path_c_quota_incomplete(tmp_path):
+    """Repo with stale SHA and OTA_SYNC_INCOMPLETE=true → path C."""
+    server = _start_mock_server({
+        "version_sha": OLD_SHA,
+        "sync_incomplete": True,
+        "open_prs": [],
+    })
+    consumers_file = _write_consumers(tmp_path, [{"name": "test-repo", "profile": "full"}])
+    blocklist_file = _write_blocklist(tmp_path)
+
+    result = _run_reconcile(server, consumers_file, blocklist_file, tmp_path,
+                            extra_env={"DRY_RUN": "true"})
+
+    assert result.returncode == 0, result.stderr
+    assert "Selected path: C" in result.stderr
+    server.shutdown()
+
+
+def test_skip_open_pr(tmp_path):
+    """Repo with an existing open reconcile PR → SKIP."""
+    server = _start_mock_server({
+        "version_sha": OLD_SHA,
+        "open_prs": [{"head": {"ref": "ota/reconcile-abc1234"}, "number": 42}],
+    })
+    consumers_file = _write_consumers(tmp_path, [{"name": "test-repo", "profile": "full"}])
+    blocklist_file = _write_blocklist(tmp_path)
+
+    result = _run_reconcile(server, consumers_file, blocklist_file, tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert "open reconcile PR found" in result.stderr
+    server.shutdown()
+
+
+def test_skip_reconcile_false_in_config(tmp_path):
+    """Repo with reconcile: false in .ota/config.yml → SKIP."""
+    server = _start_mock_server({
+        "version_sha": OLD_SHA,
+        "ota_config": "reconcile: false\n",
+        "open_prs": [],
+    })
+    consumers_file = _write_consumers(tmp_path, [{"name": "test-repo", "profile": "full"}])
+    blocklist_file = _write_blocklist(tmp_path)
+
+    result = _run_reconcile(server, consumers_file, blocklist_file, tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert "reconcile: false" in result.stderr
+    server.shutdown()
+
+
+def test_skip_ineligible_profile(tmp_path):
+    """Profile not in reconcile_eligible_profiles → SKIP."""
+    server = _start_mock_server({"version_sha": OLD_SHA})
+    consumers_file = _write_consumers(tmp_path, [{"name": "test-repo", "profile": "full"}])
+    # Blocklist that excludes 'full' from reconcile
+    blocklist_file = _write_blocklist(tmp_path, {
+        "reconcile_eligible_profiles": ["standalone"]
+    })
+
+    result = _run_reconcile(server, consumers_file, blocklist_file, tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert "not in reconcile_eligible_profiles" in result.stderr
+    server.shutdown()
+
+
+def test_force_path_override(tmp_path):
+    """FORCE_PATH=A forces path A even when SHA is behind."""
+    server = _start_mock_server({
+        "version_sha": OLD_SHA,
+        "sync_incomplete": True,
+        "open_prs": [],
+    })
+    consumers_file = _write_consumers(tmp_path, [{"name": "test-repo", "profile": "full"}])
+    blocklist_file = _write_blocklist(tmp_path)
+
+    result = _run_reconcile(server, consumers_file, blocklist_file, tmp_path,
+                            extra_env={"FORCE_PATH": "A"})
+
+    assert result.returncode == 0, result.stderr
+    assert "Selected path: A" in result.stderr
+    server.shutdown()
+
+
+def test_dry_run_no_writes(tmp_path):
+    """DRY_RUN=true produces no PUT calls."""
+    server = _start_mock_server({
+        "version_sha": FSA_SHA,  # current — path A
+    })
+    consumers_file = _write_consumers(tmp_path, [{"name": "test-repo", "profile": "full"}])
+    blocklist_file = _write_blocklist(tmp_path)
+
+    result = _run_reconcile(server, consumers_file, blocklist_file, tmp_path,
+                            extra_env={"DRY_RUN": "true"})
+
+    assert result.returncode == 0, result.stderr
+    assert "DRY" in result.stderr
+    put_calls = server.config.get("put_calls", [])
+    version_puts = [c for c in put_calls if ".ota/version" in c["path"]]
+    assert len(version_puts) == 0, "DRY_RUN should not write .ota/version"
+    server.shutdown()
+
+
+def test_version_stamp_written_path_a(tmp_path):
+    """Path A writes .ota/version via PUT."""
+    server = _start_mock_server({
+        "version_sha": FSA_SHA,
+    })
+    consumers_file = _write_consumers(tmp_path, [{"name": "test-repo", "profile": "full"}])
+    blocklist_file = _write_blocklist(tmp_path)
+
+    result = _run_reconcile(server, consumers_file, blocklist_file, tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    put_calls = server.config.get("put_calls", [])
+    version_puts = [c for c in put_calls if ".ota/version" in c["path"]]
+    assert len(version_puts) == 1, f"Expected 1 .ota/version PUT, got {len(version_puts)}"
+    server.shutdown()
+
+
+def test_sync_incomplete_cleared_after_path_c(tmp_path):
+    """After path C, OTA_SYNC_INCOMPLETE variable is deleted."""
+    server = _start_mock_server({
+        "version_sha": OLD_SHA,
+        "sync_incomplete": True,
+        "open_prs": [],
+    })
+    consumers_file = _write_consumers(tmp_path, [{"name": "test-repo", "profile": "full"}])
+    blocklist_file = _write_blocklist(tmp_path)
+
+    result = _run_reconcile(server, consumers_file, blocklist_file, tmp_path,
+                            extra_env={"DRY_RUN": "true"})
+
+    # In dry-run, path C is selected but no actual PR/delete happens
+    assert "Selected path: C" in result.stderr
+    server.shutdown()
+
+
+def test_missing_version_stamp_triggers_reconcile(tmp_path):
+    """Repo with no .ota/version file → treated as behind → path B or C."""
+    server = _start_mock_server({
+        "version_sha": "404",  # 404 = file missing
+        "sync_incomplete": False,
+        "open_prs": [],
+    })
+    consumers_file = _write_consumers(tmp_path, [{"name": "test-repo", "profile": "full"}])
+    blocklist_file = _write_blocklist(tmp_path)
+
+    result = _run_reconcile(server, consumers_file, blocklist_file, tmp_path,
+                            extra_env={"DRY_RUN": "true"})
+
+    assert result.returncode == 0, result.stderr
+    assert "stamp: missing" in result.stderr
+    assert "Selected path: B" in result.stderr
+    server.shutdown()
+
+
+def test_reconcile_eligible_profiles_in_blocklist():
+    """ota-blocklist.yml must contain reconcile_eligible_profiles."""
+    with open(BLOCKLIST_FILE) as f:
+        data = yaml.safe_load(f)
+    assert "reconcile_eligible_profiles" in data, \
+        "ota-blocklist.yml missing reconcile_eligible_profiles"
+    profiles = data["reconcile_eligible_profiles"]
+    assert "full" in profiles
+    assert "standalone" in profiles
+
+
+def test_workflow_registered_in_sync():
+    """ota-reconcile.yml must appear in config/workflow-sync.yml."""
+    sync_file = os.path.join(REPO_ROOT, "config", "workflow-sync.yml")
+    with open(sync_file) as f:
+        content = f.read()
+    assert "ota-reconcile.yml" in content, \
+        "ota-reconcile.yml not registered in config/workflow-sync.yml"
+
+
+def test_workflow_registered_in_priority_tiers():
+    """OTA Reconcile must appear in config/workflow-priority-tiers.yml."""
+    tiers_file = os.path.join(REPO_ROOT, "config", "workflow-priority-tiers.yml")
+    with open(tiers_file) as f:
+        content = f.read()
+    assert "OTA Reconcile" in content, \
+        "OTA Reconcile not registered in config/workflow-priority-tiers.yml"
+
+
+def test_workflow_registered_in_quota_costs():
+    """OTA Reconcile must appear in config/workflow-quota-costs.yml."""
+    costs_file = os.path.join(REPO_ROOT, "config", "workflow-quota-costs.yml")
+    with open(costs_file) as f:
+        content = f.read()
+    assert "OTA Reconcile" in content, \
+        "OTA Reconcile not registered in config/workflow-quota-costs.yml"


### PR DESCRIPTION
## What

Adds a hybrid drift-detection and quota-recovery layer (`ota-reconcile.sh`) that sits between template sync and OTA delivery. Runs weekly and autonomously selects the best path per repo at runtime.

## Why

Template sync has three silent failure modes:
1. **Quota exhaustion** — propagation stops early; repos after the cutoff never receive the update
2. **Silent drift** — manual edits, failed syncs, or new files added after the last path-filter match
3. **No version record** — no machine-readable way to answer "is this repo current?"

## Three paths, one runtime selector

| Path | Trigger | Action |
|------|---------|--------|
| A | `.ota/version` SHA matches FSA HEAD | Write/update `.ota/version` stamp only — no PR, no noise |
| B | SHA behind, no quota failure detected | Open drift-reconcile PR via `ota-payload-build.sh --full` |
| C | SHA behind + `OTA_SYNC_INCOMPLETE=true` on repo | Open quota-recovery PR, clear the variable after |

Detection order per repo: raw.githubusercontent read (0 quota) → SHA compare → open PR check → OTA_SYNC_INCOMPLETE variable → payload dry-run.

## Changes

**New:** `scripts/ota-reconcile.sh`, `.github/workflows/ota-reconcile.yml`, `DOCS/ota-reconcile.md`, `tests/test_ota_reconcile.py` (16 tests)

**Modified:** `scripts/sync-template.sh` (writes `.ota/version` on success, sets `OTA_SYNC_INCOMPLETE` on quota exit), `config/ota-blocklist.yml`, `config/workflow-sync.yml`, `config/workflow-priority-tiers.yml`, `config/workflow-quota-costs.yml`

## Tests

```
287 passed in 21s
```

Validator: 121 workflows, all checks passed