### PR TITLE
Proposal: add `notify-hw-detect-consumers.yml` skeleton

### DIFF
--- a/.github/workflows/notify-hw-detect-consumers.yml
+++ b/.github/workflows/notify-hw-detect-consumers.yml
@@ -1,0 +1,46 @@
+name: Notify HW Detect Consumers
+
+# Fires a repository_dispatch to fork-sync-all whenever the ${REPO_NAME} hardware
+# detection scripts or hardware.conf.tpl change on main.
+# fork-sync-all's propagate-hw-detect workflow then syncs the updated files
+# to all hw_detect consumer repos.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - scripts/kport/kport-detect.sh
+      - scripts/kport/kport-detect-cpu.sh
+      - scripts/kport/kport-detect-gpu.sh
+      - scripts/kport/kport-detect-npu.sh
+      - scripts/kport/kport-build-flags.sh
+      - scripts/kport/kport-toolchain.sh
+      - config/hardware.conf.tpl
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write  # Add permissions to allow dispatching events
+      actions: write    # Added permissions for actions
+      repository_dispatch: write  # Added permissions for dispatching events
+      workflows: write  # Added permissions to trigger workflows
+    steps:
+      - name: Dispatch to fork-sync-all
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}  # Ensure the correct secret is used
+        run: |
+          curl -sf \
+            -X POST \
+            -H "Authorization: token ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${GITHUB_OWNER}/fork-sync-all/dispatches" \
+            -d '{
+              "event_type": "kport-hw-detect-updated",
+              "client_payload": {
+                "source_repo": "${REPO_NAME}",
+                "ref": "${{ github.sha }}",
+                "triggered_by": "${{ github.actor }}"
+              }
+            }' && echo "Dispatched kport-hw-detect-updated to fork-sync-all."


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/KPort/.github/workflows/notify-hw-detect-consumers.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`
