### PR TITLE
Proposal: add `pacscript-ci.yml` skeleton

### DIFF
--- a/.github/workflows/pacscript-ci.yml
+++ b/.github/workflows/pacscript-ci.yml
@@ -1,0 +1,76 @@
+name: Pacscript CI
+
+# Runs on every push and PR that touches packages/, config/, or lib/.
+# Two jobs:
+#   lint     — validates required fields, sha256sums, and duplicate deps
+#   resolver — dry-runs kport_resolve on representative leaf packages
+
+on:
+  push:
+    paths:
+      - 'packages/**'
+      - 'overlays/**'
+      - 'config/**'
+      - 'lib/**'
+      - 'bin/kport'
+      - 'scripts/kport/**'
+  pull_request:
+    paths:
+      - 'packages/**'
+      - 'overlays/**'
+      - 'config/**'
+      - 'lib/**'
+      - 'bin/kport'
+      - 'scripts/kport/**'
+  workflow_dispatch:
+
+concurrency:
+  group: pacscript-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  shell-syntax:
+    name: Shell syntax check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: bash -n on all kport shell scripts
+        run: |
+          find lib/ bin/ scripts/kport/ -type f \( -name "*.sh" -o -name "kport" \) \
+            | sort | tee /dev/stderr | xargs bash -n
+          echo "Shell syntax OK"
+
+  lint:
+    name: Lint pacscripts
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run pacscript linter
+        run: bash scripts/kport/lint-pacscripts.sh
+
+  keyword-tiers:
+    name: Keyword tier unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run keyword tier tests
+        run: bash scripts/kport/keyword-tier-check.sh --verbose
+
+  resolver:
+    name: Resolver dry-run
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run resolver check
+        run: bash scripts/kport/resolver-check.sh


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/KPort/.github/workflows/pacscript-ci.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`
