### PR TITLE
Proposal: add `build.yml` skeleton

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,137 @@
+name: Build
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  BUILD_TYPE: debug
+  CTEST_OUTPUT_ON_FAILURE: 1
+
+jobs:
+  build-cmake:
+    name: Build with CMake
+    runs-on: ubuntu-latest
+    container: archlinux:base-devel
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install deps
+        run: |
+          pacman -Syu --noconfirm cmake pkg-config ninja clang mold llvm git
+        shell: bash
+
+      - name: Configure CMake
+        # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCOS_INSTALLER_BUILD_TESTS=ON
+
+      - name: Build & Test
+        # Build your program with the given configuration
+        run: |
+          cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+          cd ${{github.workspace}}/build
+          ./gucc/tests/test-string_utils
+          ./gucc/tests/test-initcpio
+          ./gucc/tests/test-pacmanconf
+          ./gucc/tests/test-mtab
+          ./gucc/tests/test-fstab_gen
+          ./gucc/tests/test-crypttab_gen
+          ./gucc/tests/test-grub_config_gen
+          ./gucc/tests/test-kernel_params
+          ./gucc/tests/test-fetch_file
+          ./gucc/tests/test-locale
+          ./gucc/tests/test-package_profiles
+          ./gucc/tests/test-btrfs
+          ./gucc/tests/test-refind_config_gen
+          ./gucc/tests/test-refind_extra_kern_strings
+          ./gucc/tests/test-partitioning_gen
+          ./gucc/tests/test-limine_config_gen
+          ./gucc/tests/test-block_devices
+          ./gucc/tests/test-crypto_detection
+        shell: bash
+  build-cmake_withoutdev:
+    name: Build with CMake (DEVENV OFF)
+    runs-on: ubuntu-latest
+    container: archlinux:base-devel
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install deps
+        run: |
+          pacman -Syu --noconfirm cmake pkg-config ninja clang mold llvm git
+        shell: bash
+
+      - name: Configure CMake
+        # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DENABLE_DEVENV=OFF
+
+      - name: Build
+        # Build your program with the given configuration
+        run: |
+          cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+        shell: bash
+  build-meson:
+    name: Build with Meson
+    runs-on: ubuntu-latest
+    container: archlinux:base-devel
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install deps
+        run: |
+          pacman -Syu --noconfirm pkg-config ninja meson clang mold llvm git
+        shell: bash
+
+      - name: Configure Meson
+        run: meson setup --buildtype=${{env.BUILD_TYPE}} -Dbuild_tests=true ${{github.workspace}}/build
+
+      - name: Build & Test
+        # Build your program with the given configuration
+        run: |
+          meson compile -C ${{github.workspace}}/build
+          cd ${{github.workspace}}/build
+          ./gucc/tests/test-string_utils
+          ./gucc/tests/test-initcpio
+          ./gucc/tests/test-pacmanconf
+          ./gucc/tests/test-mtab
+          ./gucc/tests/test-fstab_gen
+          ./gucc/tests/test-crypttab_gen
+          ./gucc/tests/test-grub_config_gen
+          ./gucc/tests/test-kernel_params
+          ./gucc/tests/test-fetch_file
+          ./gucc/tests/test-locale
+          ./gucc/tests/test-package_profiles
+          ./gucc/tests/test-btrfs
+          ./gucc/tests/test-refind_config_gen
+          ./gucc/tests/test-refind_extra_kern_strings
+          ./gucc/tests/test-partitioning_gen
+          ./gucc/tests/test-limine_config_gen
+          ./gucc/tests/test-block_devices
+          ./gucc/tests/test-crypto_detection
+        shell: bash
+  build-meson_withoutdev:
+    name: Build with Meson (DEVENV OFF)
+    runs-on: ubuntu-latest
+    container: archlinux:base-devel
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install deps
+        run: |
+          pacman -Syu --noconfirm pkg-config ninja meson clang mold llvm git
+        shell: bash
+
+      - name: Configure CMake
+        run: meson setup --buildtype=${{env.BUILD_TYPE}} -Dbuild_tests=true -Ddevenv=false ${{github.workspace}}/build
+
+      - name: Build
+        # Build your program with the given configuration
+        run: |
+          meson compile -C ${{github.workspace}}/build
+        shell: bash


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/New-Cli-Installer/.github/workflows/build.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`
