### PR TITLE
Proposal: add `labeler.yml` skeleton

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: "PR Labeler"
+
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v4
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/New-Cli-Installer/.github/workflows/labeler.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`
