### PR TITLE
Proposal: add `build-go-cli.yml` skeleton

### DIFF
--- a/.github/workflows/build-go-cli.yml
+++ b/.github/workflows/build-go-cli.yml
@@ -1,0 +1,80 @@
+name: Build Go CLI
+
+on:
+  pull_request:
+    paths:
+      - "go-cli/**"
+      - "scripts/build-go-cli.ps1"
+      - "scripts/build-go-cli.sh"
+      - ".github/workflows/build-go-cli.yml"
+      - "README.md"
+      - "docs/getting-started.md"
+      - "docs/deployment-layout.md"
+      - "docs/INSTALLATION-GUIDE-5.0.md"
+      - "docs/CLI-UTILITIES-SPECIFICATION.md"
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build Go CLI (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - name: Checkout ${REPO_NAME}
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go-cli/go.mod
+          cache-dependency-path: go-cli/go.mod
+
+      - name: Show Go version
+        run: go version
+
+      - name: Build Go CLI (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: pwsh -NoProfile -File scripts/build-go-cli.ps1
+
+      - name: Build Go CLI (macOS/Linux)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: bash scripts/build-go-cli.sh
+
+      - name: Verify build outputs (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $files = @(
+            'go-cli/bin/a11y-agents-setup.exe',
+            'go-cli/bin/a11y-agents-health.exe',
+            'go-cli/bin/a11y-agents-repair.exe',
+            'go-cli/bin/a11y-agents-hooks.exe'
+          )
+          foreach ($file in $files) {
+            if (-not (Test-Path $file)) {
+              Write-Error "Missing expected build output: $file"
+              exit 1
+            }
+          }
+
+      - name: Verify build outputs (macOS/Linux)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          test -f go-cli/bin/a11y-agents-setup
+          test -f go-cli/bin/a11y-agents-health
+          test -f go-cli/bin/a11y-agents-repair
+          test -f go-cli/bin/a11y-agents-hooks
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: go-cli-${{ runner.os }}
+          path: go-cli/bin/
+          if-no-files-found: error


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/accessibility-agents/.github/workflows/build-go-cli.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`
