### PR TITLE
feat: AI agent cost tracking — OCU budgeting, tokenizer reference, session log

### DIFF
--- a/.github/workflows/track-agent-costs.yml
+++ b/.github/workflows/track-agent-costs.yml
@@ -1,0 +1,310 @@
+name: Track Agent Costs
+
+# Records AI agent session cost estimates to data/agent-cost-log.json.
+# Run this after any significant agent session to build an observed cost
+# dataset that replaces the code-audit estimates in DOCS/ai-agent-costs.md.
+#
+# Supports all agents used in this repo:
+#   ona                      — Ona Agent (Claude 4 Sonnet), OCU-billed
+#   codex-ona                — Codex via Ona (Ona-managed model), OCU-billed
+#   codex-chatgpt            — Codex via Ona (ChatGPT plan), env OCUs only
+#   github-models-gpt4o      — GitHub Models GPT-4o, env OCUs only
+#   github-models-gpt4o-mini — GitHub Models GPT-4o-mini, env OCUs only
+#   anthropic-direct         — Direct Anthropic API, no OCUs
+#   anthropic-direct-haiku   — Direct Anthropic API (Haiku), no OCUs
+#   gemini-direct            — Direct Gemini API, no OCUs
+#
+# Usage:
+#   gh workflow run track-agent-costs.yml \
+#     --field task_description="Add flush watchdog" \
+#     --field agent="ona" \
+#     --field session_hours="3.5" \
+#     --field ocu_estimate="18" \
+#     --field pr_number="166"
+
+on:
+  workflow_dispatch:
+    inputs:
+      task_description:
+        description: 'What the agent did (e.g. "Add flush-active-watchdog + pipeline-guard")'
+        type: string
+        required: true
+
+      agent:
+        description: 'Agent used'
+        type: choice
+        required: true
+        default: ona
+        options:
+          - ona
+          - codex-ona
+          - codex-chatgpt
+          - github-models-gpt4o
+          - github-models-gpt4o-mini
+          - anthropic-direct
+          - anthropic-direct-haiku
+          - gemini-direct
+
+      session_hours:
+        description: 'Approximate session duration in hours (e.g. 3.5)'
+        type: string
+        required: true
+
+      ocu_estimate:
+        description: 'Estimated OCUs consumed (env + model for Ona; env-only for GitHub Models/Codex-ChatGPT; 0 for direct API)'
+        type: string
+        required: true
+
+      pr_number:
+        description: 'PR number produced by this session (optional)'
+        type: string
+        required: false
+        default: ''
+
+      task_profile:
+        description: 'Task complexity profile (optional — for budget guidance)'
+        type: choice
+        required: false
+        default: ''
+        options:
+          - ''
+          - quick-question
+          - single-bug-fix
+          - new-script
+          - new-workflow
+          - multi-file-feature
+          - large-feature
+          - full-session
+          - end-to-end-update
+          - translation-run
+          - ci-resolution
+
+      gh_models_tokens:
+        description: 'GitHub Models tokens consumed (for github-models-* agents, optional)'
+        type: string
+        required: false
+        default: ''
+
+      anthropic_input_tokens:
+        description: 'Anthropic API input tokens (for anthropic-direct agents, optional)'
+        type: string
+        required: false
+        default: ''
+
+      anthropic_output_tokens:
+        description: 'Anthropic API output tokens (for anthropic-direct agents, optional)'
+        type: string
+        required: false
+        default: ''
+
+      notes:
+        description: 'Additional notes (optional)'
+        type: string
+        required: false
+        default: ''
+
+concurrency:
+  group: track-agent-costs
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  record:
+    name: Record agent session cost
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          token: ${{ secrets.SYNC_TOKEN }}
+
+      - name: Validate and record session
+        id: record
+        env:
+          TASK_DESCRIPTION: ${{ inputs.task_description }}
+          AGENT: ${{ inputs.agent }}
+          SESSION_HOURS: ${{ inputs.session_hours }}
+          OCU_ESTIMATE: ${{ inputs.ocu_estimate }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          TASK_PROFILE: ${{ inputs.task_profile }}
+          GH_MODELS_TOKENS: ${{ inputs.gh_models_tokens }}
+          ANTHROPIC_INPUT_TOKENS: ${{ inputs.anthropic_input_tokens }}
+          ANTHROPIC_OUTPUT_TOKENS: ${{ inputs.anthropic_output_tokens }}
+          NOTES: ${{ inputs.notes }}
+          RUN_ID: ${{ github.run_id }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+
+          python3 - << 'PYEOF'
+          import json, os, sys, yaml
+          from datetime import datetime, timezone
+          from pathlib import Path
+
+          # ── Load inputs ───────────────────────────────────────────────────
+          agent           = os.environ["AGENT"]
+          task_desc       = os.environ["TASK_DESCRIPTION"]
+          session_hours   = float(os.environ["SESSION_HOURS"])
+          ocu_estimate    = float(os.environ["OCU_ESTIMATE"])
+          pr_number       = os.environ.get("PR_NUMBER", "").strip() or None
+          task_profile    = os.environ.get("TASK_PROFILE", "").strip() or None
+          gh_tokens       = os.environ.get("GH_MODELS_TOKENS", "").strip()
+          anth_in         = os.environ.get("ANTHROPIC_INPUT_TOKENS", "").strip()
+          anth_out        = os.environ.get("ANTHROPIC_OUTPUT_TOKENS", "").strip()
+          notes           = os.environ.get("NOTES", "").strip() or None
+          run_id          = os.environ["RUN_ID"]
+          actor           = os.environ["ACTOR"]
+
+          # ── Load agent profiles ───────────────────────────────────────────
+          profiles_path = Path("config/agent-cost-profiles.yml")
+          with open(profiles_path) as f:
+              profiles = yaml.safe_load(f)
+
+          agent_profiles = profiles.get("agents", {})
+          task_profiles  = profiles.get("task_profiles", {})
+
+          if agent not in agent_profiles:
+              print(f"ERROR: unknown agent '{agent}'. Valid: {list(agent_profiles)}", file=sys.stderr)
+              sys.exit(1)
+
+          ap = agent_profiles[agent]
+
+          # ── Compute USD cost ──────────────────────────────────────────────
+          usd_ocu = round(ocu_estimate * 0.25, 4)
+
+          usd_direct = 0.0
+          if ap["billing_model"] == "anthropic-direct" and anth_in and anth_out:
+              in_tokens  = int(anth_in)
+              out_tokens = int(anth_out)
+              rate_in    = ap.get("cost_per_1m_in") or 0
+              rate_out   = ap.get("cost_per_1m_out") or 0
+              usd_direct = round((in_tokens / 1_000_000 * rate_in) + (out_tokens / 1_000_000 * rate_out), 4)
+
+          usd_total = round(usd_ocu + usd_direct, 4)
+
+          # ── Validate against task profile ─────────────────────────────────
+          profile_warning = None
+          if task_profile and task_profile in task_profiles:
+              tp = task_profiles[task_profile]
+              if ocu_estimate < tp["ocu_low"] * 0.5:
+                  profile_warning = f"ocu_estimate {ocu_estimate} is well below expected low {tp['ocu_low']} for '{task_profile}'"
+              elif ocu_estimate > tp["ocu_high"] * 2.0:
+                  profile_warning = f"ocu_estimate {ocu_estimate} is well above expected high {tp['ocu_high']} for '{task_profile}'"
+
+          # ── Build log entry ───────────────────────────────────────────────
+          entry = {
+              "timestamp":     datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+              "run_id":        run_id,
+              "actor":         actor,
+              "agent":         agent,
+              "agent_display": ap["display_name"],
+              "task_description": task_desc,
+              "task_profile":  task_profile,
+              "session_hours": session_hours,
+              "ocu_estimate":  ocu_estimate,
+              "usd_ocu":       usd_ocu,
+              "usd_direct":    usd_direct,
+              "usd_total":     usd_total,
+              "pr_number":     pr_number,
+              "notes":         notes,
+          }
+
+          if gh_tokens:
+              entry["gh_models_tokens"] = int(gh_tokens)
+          if anth_in:
+              entry["anthropic_input_tokens"] = int(anth_in)
+          if anth_out:
+              entry["anthropic_output_tokens"] = int(anth_out)
+
+          # ── Append to log ─────────────────────────────────────────────────
+          log_path = Path("data/agent-cost-log.json")
+          log_path.parent.mkdir(exist_ok=True)
+          if log_path.exists() and log_path.stat().st_size > 0:
+              with open(log_path) as f:
+                  log = json.load(f)
+          else:
+              log = {"sessions": []}
+
+          log["sessions"].append(entry)
+
+          with open(log_path, "w") as f:
+              json.dump(log, f, indent=2)
+              f.write("\n")
+
+          # ── Compute running totals ────────────────────────────────────────
+          all_sessions = log["sessions"]
+          total_sessions = len(all_sessions)
+          total_ocu = sum(s.get("ocu_estimate", 0) for s in all_sessions)
+          total_usd = sum(s.get("usd_total", 0) for s in all_sessions)
+
+          by_agent = {}
+          for s in all_sessions:
+              a = s["agent"]
+              if a not in by_agent:
+                  by_agent[a] = {"sessions": 0, "ocu": 0.0, "usd": 0.0}
+              by_agent[a]["sessions"] += 1
+              by_agent[a]["ocu"] += s.get("ocu_estimate", 0)
+              by_agent[a]["usd"] += s.get("usd_total", 0)
+
+          # ── Write step summary ────────────────────────────────────────────
+          summary_path = os.environ.get("GITHUB_STEP_SUMMARY", "/dev/null")
+          with open(summary_path, "a") as f:
+              f.write("## Agent Session Recorded\n\n")
+              f.write(f"| Field | Value |\n|---|---|\n")
+              f.write(f"| Agent | {ap['display_name']} |\n")
+              f.write(f"| Task | {task_desc} |\n")
+              f.write(f"| Session | {session_hours:.1f} hr |\n")
+              f.write(f"| OCUs | {ocu_estimate:.1f} |\n")
+              f.write(f"| OCU cost | ${usd_ocu:.2f} |\n")
+              if usd_direct > 0:
+                  f.write(f"| Direct API cost | ${usd_direct:.4f} |\n")
+              f.write(f"| **Total cost** | **${usd_total:.2f}** |\n")
+              if pr_number:
+                  f.write(f"| PR | #{pr_number} |\n")
+              if task_profile:
+                  f.write(f"| Profile | {task_profile} |\n")
+              if notes:
+                  f.write(f"| Notes | {notes} |\n")
+              if profile_warning:
+                  f.write(f"\n> ⚠️ **Profile check**: {profile_warning}\n")
+
+              f.write("\n### Running totals\n\n")
+              f.write(f"| Metric | Value |\n|---|---|\n")
+              f.write(f"| Total sessions | {total_sessions} |\n")
+              f.write(f"| Total OCUs | {total_ocu:.1f} |\n")
+              f.write(f"| Total USD | ${total_usd:.2f} |\n")
+
+              f.write("\n### By agent\n\n")
+              f.write("| Agent | Sessions | OCUs | USD |\n|---|---|---|---|\n")
+              for a, t in sorted(by_agent.items()):
+                  disp = agent_profiles.get(a, {}).get("display_name", a)
+                  f.write(f"| {disp} | {t['sessions']} | {t['ocu']:.1f} | ${t['usd']:.2f} |\n")
+
+              if len(all_sessions) >= 10:
+                  f.write("\n> ✅ ≥10 sessions logged. Consider updating the code-audit estimates in `DOCS/ai-agent-costs.md` with observed p50/p95 values.\n")
+              else:
+                  remaining = 10 - len(all_sessions)
+                  f.write(f"\n> Log {remaining} more session(s) to reach the threshold for replacing code-audit estimates with observed data.\n")
+
+          print(f"Recorded session: {agent} / {task_desc} / {ocu_estimate} OCUs / ${usd_total:.2f}")
+          if profile_warning:
+              print(f"WARNING: {profile_warning}", file=sys.stderr)
+          PYEOF
+
+      - name: Commit log update
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/agent-cost-log.json
+          if git diff --cached --quiet; then
+            echo "No changes to commit" >&2
+          else
+            git commit -m "chore(costs): log agent session — ${{ inputs.agent }} / ${{ inputs.task_description }} [skip ci]"
+            git push
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,38 @@ curl -sf -H "Authorization: token $SYNC_TOKEN" \
 
 ---
 
+## AI agent cost budgeting
+
+This repo uses multiple AI agents. Each has a different billing model — understand
+which resource you're spending before starting a task.
+
+| Agent | Billing | Approx. cost per session |
+|---|---|---|
+| **Ona Agent** (Claude 4 Sonnet) | OCUs ($0.25/OCU) | 1–31 OCUs ($0.25–$7.75) depending on task size |
+| **Codex** (Ona-managed) | OCUs (env + model) | Same as Ona Agent |
+| **Codex** (ChatGPT plan connected) | OCUs (env only) + OpenAI | ~1 OCU/hr env; model via ChatGPT plan |
+| **GitHub Models** (`llm.sh`) | GitHub Models quota | ~0.25–1 OCU env runtime; model is free |
+| **Anthropic API direct** | Anthropic pay-per-token | ~$0.30–$0.60/session; no OCUs |
+
+**OCU top-up packages** (one-time, $0.25/OCU flat):
+40 OCUs/$10 · 100/$25 · 200/$50 · 400/$100 · 1,000/$250 · 2,000/$500 · 4,000/$1,000 · 8,000/$2,000
+
+**Rough task sizing** (Ona Agent on Standard environment):
+- Small fix / single file: 1–4 OCUs
+- Multi-file feature + tests: 8–12 OCUs
+- Large session (3–4 hr, many files): 15–24 OCUs
+- Full end-to-end update: 19–31 OCUs
+
+**GitHub API quota and OCUs are independent.** GitHub quota exhaustion pauses the
+agent but does not consume OCUs. OCU exhaustion stops the session regardless of
+GitHub quota state.
+
+Full reference: `DOCS/ai-agent-costs.md`
+Machine-readable profiles: `config/agent-cost-profiles.yml`
+Log a session: `gh workflow run track-agent-costs.yml --field agent=ona --field ...`
+
+---
+
 ## Script conventions
 
 ### All logging helpers must write to stderr

--- a/DOCS/SUMMARY.md
+++ b/DOCS/SUMMARY.md
@@ -17,6 +17,7 @@
 - [Workflow Scheduling Guide](workflow-scheduling.md)
 - [Quota Cost Registry](quota-costs.md)
 - [GitHub Actions Limits](OPERATIONS.md)
+- [AI Agent Cost Reference](ai-agent-costs.md)
 - [OTA System](ota-system.md)
 
 # Config Maps

--- a/DOCS/ai-agent-costs.md
+++ b/DOCS/ai-agent-costs.md
@@ -1,0 +1,331 @@
+# AI Agent Cost Reference
+
+Budgeting guide for AI agent usage on fork-sync-all. Covers all agents used in
+this repo: Ona Agent (Claude), Codex, GitHub Models (GPT-4o/mini), and direct
+Anthropic API. Includes token economics, per-task cost estimates, and package
+selection guidance.
+
+---
+
+## Ona Compute Units (OCUs)
+
+An **OCU** is Ona's billing unit. It covers both environment runtime and AI model
+inference. OCUs are not raw tokens — Ona bundles compute + model calls into a
+single unit.
+
+### Top-up packages (one-time, valid 1 year with active subscription)
+
+| Package | OCUs | USD | USD/OCU |
+|---------|------|-----|---------|
+| Starter | 40 | $10 | $0.25 |
+| Small | 100 | $25 | $0.25 |
+| Medium | 200 | $50 | $0.25 |
+| Large | 400 | $100 | $0.25 |
+| XL | 1,000 | $250 | $0.25 |
+| 2XL | 2,000 | $500 | $0.25 |
+| 3XL | 4,000 | $1,000 | $0.25 |
+| 4XL | 8,000 | $2,000 | $0.25 |
+
+All tiers are a flat **$0.25/OCU** — no bulk discount on top-ups.
+
+### Core subscription (monthly, resets each period, does not roll over)
+
+| Monthly OCUs | Notes |
+|---|---|
+| 80–2,200 | See `ona.com/pricing` for current tier options |
+
+Consumption order: subscription credits → top-up credits → bonus/gift credits.
+
+### Environment runtime
+
+| Class | vCPUs / RAM | OCU rate |
+|---|---|---|
+| Standard | 4 vCPUs / 16 GB | 1 OCU/hour |
+| GPU-accelerated | 16 vCPUs / 64 GB | 7 OCUs/hour |
+
+fork-sync-all agent sessions run on **Standard** environments.
+A 2-hour session costs **2 OCUs** in runtime before any model inference.
+
+---
+
+## Agents used in this repo
+
+| Agent | Where used | Billing model | Context window |
+|---|---|---|---|
+| **Ona Agent** (Claude 4 Sonnet) | Interactive sessions, PRs, automations | OCUs (env + model) | 200K tokens |
+| **Codex** (via Ona, Core plan) | Ona Cloud environments | OCUs (env only if ChatGPT plan connected) | 128K tokens |
+| **GitHub Models — GPT-4o** | `llm.sh`, `update-readmes.sh`, `translate-docs.sh` | GitHub Models quota (not OCUs) | 128K tokens |
+| **GitHub Models — GPT-4o-mini** | `resolve-failures.sh`, `generate-descriptions.sh` | GitHub Models quota (not OCUs) | 128K tokens |
+| **Anthropic API (direct)** | Optional via `ANTHROPIC_API_KEY` | Pay-per-token (Anthropic billing, not OCUs) | 200K tokens |
+
+### Billing independence
+
+**Ona Agent** and **Codex (Ona-managed)** are billed in OCUs.
+
+**Codex with a connected ChatGPT plan**: environment runtime is billed in OCUs;
+model inference is billed by OpenAI against your ChatGPT plan. Ona does not charge
+OCUs for those model calls.
+
+**GitHub Models** (`llm.sh`): uses a separate GitHub Models quota tied to your
+`GH_TOKEN`. Does **not** consume OCUs. Rate limits apply per model tier.
+
+**Anthropic API (direct)**: billed per-token by Anthropic. Does **not** consume OCUs.
+
+---
+
+## Tokenizer reference
+
+Token counts determine context window usage and, for pay-per-token models, direct
+API costs.
+
+### Claude (Ona Agent / Anthropic API direct)
+
+Anthropic uses a custom BPE tokenizer:
+
+| Content type | Approx. tokens |
+|---|---|
+| English prose | 1 token / 4 chars (~750 words per 1K tokens) |
+| Code (Python / JS / bash) | 1 token / 3–4 chars |
+| YAML / JSON | 1 token / 3 chars |
+| Shell scripts | 1 token / 3 chars |
+| Markdown with headers | 1 token / 4 chars |
+
+Context window: **200K input / 8K output** (Claude 4 Sonnet).
+
+A full fork-sync-all session reading 10 workflow files (~500 lines each) uses
+roughly **50K–80K input tokens** in context before any tool calls.
+
+### GPT-4o / GPT-4o-mini (GitHub Models / Codex)
+
+OpenAI uses the `cl100k_base` tiktoken tokenizer. Rates are nearly identical to
+Claude for English and code. Context window: **128K tokens**.
+
+Count tokens locally:
+```bash
+pip install tiktoken
+python3 -c "
+import tiktoken, sys
+enc = tiktoken.get_encoding('cl100k_base')
+print(len(enc.encode(open(sys.argv[1]).read())), 'tokens')
+" path/to/file.yml
+```
+
+### Gemini (direct API, if used)
+
+Google SentencePiece tokenizer. Similar rates to GPT-4o for English; slightly
+fewer tokens for CJK. Context window: **1M tokens** (Gemini 1.5 Pro).
+
+### Token → OCU conversion (approximate)
+
+Ona does not publish an exact token-to-OCU ratio. Based on Ona's published
+benchmarks and typical Claude 4 Sonnet pricing:
+
+| Ona benchmark | OCUs | Approx. tokens consumed |
+|---|---|---|
+| Explain a small codebase | 1 | ~20K–50K |
+| Explain a large codebase | 3 | ~80K–150K |
+| Create a new web app | 4 | ~100K–200K |
+| Add a feature to medium codebase | 8 | ~200K–400K |
+
+Rough conversion: **1 OCU ≈ 25K–50K tokens** (input + output combined).
+Actual OCU consumption depends on environment runtime, tool call overhead, and
+Ona's internal pricing model.
+
+### Anthropic API direct pricing (as of 2026)
+
+If using the Anthropic API directly (not via Ona):
+
+| Model | Input (per 1M tokens) | Output (per 1M tokens) |
+|---|---|---|
+| Claude 4 Sonnet | $3.00 | $15.00 |
+| Claude 3.5 Haiku | $0.80 | $4.00 |
+| Claude 3 Opus | $15.00 | $75.00 |
+
+A typical fork-sync-all session (100K input + 10K output tokens) costs roughly
+**$0.45–$0.60** via direct API — cheaper than OCUs for pure model cost, but
+without the environment, tooling, and orchestration Ona provides.
+
+---
+
+## fork-sync-all task cost estimates
+
+All figures assume Standard environment (1 OCU/hour) + Ona Agent (Claude).
+For GitHub Models tasks (`llm.sh`), OCU cost is environment runtime only.
+
+### By task complexity
+
+| Task | Env time | OCUs (env) | OCUs (model) | Total OCUs | USD equiv. |
+|---|---|---|---|---|---|
+| Quick question / explain one workflow | 15 min | 0.25 | 0.5–1 | **1–1.5** | $0.25–$0.38 |
+| Fix a single bug or validator error | 20 min | 0.33 | 1–2 | **1.5–2.5** | $0.38–$0.63 |
+| Add a new script or include | 30 min | 0.5 | 2–4 | **2.5–4.5** | $0.63–$1.13 |
+| Add a new workflow (single file) | 45 min | 0.75 | 3–5 | **4–6** | $1.00–$1.50 |
+| Multi-file feature (e.g. flush watchdog) | 90 min | 1.5 | 6–10 | **8–12** | $2.00–$3.00 |
+| Large feature + tests + docs + PR | 2–3 hr | 2–3 | 8–15 | **10–18** | $2.50–$4.50 |
+| Full session (e.g. platform hardening) | 3–4 hr | 3–4 | 12–20 | **15–24** | $3.75–$6.00 |
+| End-to-end repo update (all outstanding) | 4–6 hr | 4–6 | 15–25 | **19–31** | $4.75–$7.75 |
+
+### By specific fork-sync-all operation
+
+| Operation | Agent | Typical OCUs | Notes |
+|---|---|---|---|
+| Merge open PRs + check CI | Ona | 1–2 | Mostly read + gh CLI |
+| Add a registered import entry | Ona | 0.5–1 | Edit JSON + validate |
+| Update AGENTS.md | Ona | 1–2 | Read context + write |
+| Fix a failing CI check | Ona | 2–5 | Depends on root cause |
+| Add a new workflow to mirror chain | Ona | 4–8 | New file + config + tests |
+| Full flush lifecycle implementation | Ona | 10–15 | Multi-file, tests, docs, PR |
+| Platform hardening (7 tasks) | Ona | 15–20 | Research + 16 files + 271 tests |
+| Onboard a new downstream org | Ona | 6–12 | Config + workflows + validation |
+| Translate READMEs (all languages) | GitHub Models GPT-4o | 0.5–1 | OCU = env runtime only; model via GH quota |
+| Generate repo descriptions | GitHub Models GPT-4o-mini | 0.25–0.5 | OCU = env runtime only |
+| Resolve CI failures (LLM-assisted) | GitHub Models GPT-4o-mini | 0.25–0.5 | OCU = env runtime only |
+
+### GitHub Models quota (separate from OCUs)
+
+`llm.sh` and the scripts that use it consume GitHub Models quota, not OCUs.
+
+| Model | Tier | Daily limit (approx.) |
+|---|---|---|
+| `openai/gpt-4o` | Standard | ~150K tokens/day |
+| `openai/gpt-4o-mini` | High | ~1M tokens/day |
+
+Limits are subject to change — check `github.com/marketplace/models`.
+`llm.sh` handles 429 responses with exponential backoff automatically.
+
+---
+
+## Budgeting by role
+
+### Occasional contributor (1–2 sessions/month)
+
+**40 OCU ($10) top-up** covers:
+- ~5–8 small bug fixes or single-workflow additions
+- ~2–3 medium features
+- ~1 large feature session
+
+### Regular contributor (weekly sessions)
+
+**100 OCU ($25) top-up** or Core subscription with 200+ OCUs/month:
+- ~10–15 medium tasks/month
+- ~4–6 large feature sessions/month
+- Comfortable headroom for exploratory sessions
+
+### Maintainer (daily work, full repo updates)
+
+**400 OCU ($100) top-up** or Core subscription with 400+ OCUs/month:
+- Weekly full sessions (~20 OCUs each → ~80 OCUs/month)
+- Buffer for unexpected complexity
+- Recommended for anyone running `critical-deploy-all` or full flush pipelines
+  alongside agent sessions
+
+### Auto top-up
+
+Enable auto top-up at **Settings → Billing** with a 40 OCU trigger threshold.
+A session interrupted mid-task and restarted from scratch costs more than the
+top-up itself — context has to be rebuilt from zero.
+
+---
+
+## Cost tracking
+
+This repo includes a workflow and structured log for tracking actual agent costs
+over time. As observed data accumulates, it replaces the code-audit estimates above.
+
+### Log a session
+
+After any significant agent session, run:
+
+```bash
+# Ona Agent session
+gh workflow run track-agent-costs.yml \
+  --field task_description="Add flush-active-watchdog + pipeline-guard" \
+  --field agent="ona" \
+  --field session_hours="3.5" \
+  --field ocu_estimate="18" \
+  --field pr_number="166"
+
+# GitHub Models session (no OCU model cost)
+gh workflow run track-agent-costs.yml \
+  --field task_description="Translate READMEs to 5 languages" \
+  --field agent="github-models-gpt4o" \
+  --field session_hours="0.5" \
+  --field ocu_estimate="0.5" \
+  --field gh_models_tokens="45000"
+
+# Codex with ChatGPT plan (env OCUs only)
+gh workflow run track-agent-costs.yml \
+  --field task_description="Refactor sync-all-forks.sh" \
+  --field agent="codex-chatgpt" \
+  --field session_hours="1.0" \
+  --field ocu_estimate="1.0"
+
+# Direct Anthropic API (no OCUs)
+gh workflow run track-agent-costs.yml \
+  --field task_description="Code review via direct API" \
+  --field agent="anthropic-direct" \
+  --field session_hours="0.25" \
+  --field ocu_estimate="0" \
+  --field anthropic_input_tokens="32000" \
+  --field anthropic_output_tokens="2000"
+```
+
+### View the log
+
+```bash
+cat data/agent-cost-log.json | python3 -m json.tool
+
+# Summary by agent
+python3 -c "
+import json
+from collections import defaultdict
+log = json.load(open('data/agent-cost-log.json'))
+totals = defaultdict(lambda: {'sessions': 0, 'ocu': 0.0, 'hours': 0.0})
+for e in log['sessions']:
+    a = e['agent']
+    totals[a]['sessions'] += 1
+    totals[a]['ocu'] += e.get('ocu_estimate', 0)
+    totals[a]['hours'] += e.get('session_hours', 0)
+for agent, t in sorted(totals.items()):
+    print(f'{agent}: {t[\"sessions\"]} sessions, {t[\"ocu\"]:.1f} OCUs, {t[\"hours\"]:.1f} hrs')
+"
+```
+
+### Machine-readable profiles
+
+`config/agent-cost-profiles.yml` contains the cost profiles used by the tracking
+workflow for validation and per-agent reporting. Update it as observed data
+replaces estimates.
+
+---
+
+## GitHub API quota vs OCU budget
+
+These are independent resources:
+
+| Resource | Unit | Limit | Managed by |
+|---|---|---|---|
+| GitHub REST API | requests | 5,000/hr per user | `quota-reserve.sh`, `queue-manager.sh` |
+| GitHub Models | tokens | varies by model | `llm.sh` (backoff on 429) |
+| Ona OCUs | compute units | subscription + top-ups | Ona billing |
+| Anthropic API | tokens | pay-per-token | Anthropic billing |
+
+GitHub API exhaustion pauses the agent session but does not consume OCUs.
+OCU exhaustion stops the session regardless of GitHub quota state.
+
+See `DOCS/OPERATIONS.md` and `DOCS/quota-costs.md` for GitHub API quota management.
+
+---
+
+## Keeping this document current
+
+- **OCU pricing**: verify at `app.gitpod.io/settings/billing`. The $0.25/OCU
+  top-up rate has been stable since launch but may change.
+- **Model**: Ona Agent currently uses Claude 4 Sonnet. If the underlying model
+  changes, update the tokenizer section.
+- **Anthropic pricing**: verify at `anthropic.com/pricing`. Prices change with
+  new model releases.
+- **Task estimates**: once ≥10 sessions are logged in `data/agent-cost-log.json`,
+  replace the code-audit estimates in the tables above with observed p50/p95 values.
+- **GitHub Models limits**: check `github.com/marketplace/models` — daily quotas
+  change as the service matures.

--- a/config/agent-cost-profiles.yml
+++ b/config/agent-cost-profiles.yml
@@ -1,0 +1,204 @@
+# config/agent-cost-profiles.yml
+#
+# Machine-readable cost profiles for AI agents used in fork-sync-all.
+# Used by .github/workflows/track-agent-costs.yml for validation and reporting.
+#
+# Fields per agent:
+#   display_name    — human-readable name shown in step summaries
+#   billing_model   — ocu | gh-models | anthropic-direct | openai-direct | free
+#   ocu_per_hour    — OCU cost for environment runtime (all Ona-hosted agents = 1.0)
+#   model_in_ocu    — true if model inference is billed in OCUs (false = external billing)
+#   tokenizer       — cl100k | anthropic-bpe | sentencepiece | unknown
+#   context_k       — context window in thousands of tokens
+#   tokens_per_ocu  — approximate tokens (input+output) per OCU; null if not applicable
+#   cost_per_1m_in  — USD per 1M input tokens (null if billed via OCUs or free)
+#   cost_per_1m_out — USD per 1M output tokens (null if billed via OCUs or free)
+#   notes           — freeform notes
+
+agents:
+  ona:
+    display_name: "Ona Agent (Claude 4 Sonnet)"
+    billing_model: ocu
+    ocu_per_hour: 1.0
+    model_in_ocu: true
+    tokenizer: anthropic-bpe
+    context_k: 200
+    tokens_per_ocu: 37500   # midpoint of 25K–50K estimate
+    cost_per_1m_in: null    # billed via OCUs
+    cost_per_1m_out: null
+    notes: >
+      Default agent for interactive sessions and PRs. Environment runtime
+      (1 OCU/hr Standard) + model inference both billed in OCUs.
+      $0.25/OCU flat rate for top-ups.
+
+  codex-ona:
+    display_name: "Codex Agent (via Ona, Ona-managed model)"
+    billing_model: ocu
+    ocu_per_hour: 1.0
+    model_in_ocu: true
+    tokenizer: cl100k
+    context_k: 128
+    tokens_per_ocu: 37500
+    cost_per_1m_in: null
+    cost_per_1m_out: null
+    notes: >
+      Codex running in an Ona Cloud environment without a connected ChatGPT plan.
+      Both environment runtime and model inference billed in OCUs.
+
+  codex-chatgpt:
+    display_name: "Codex Agent (via Ona, ChatGPT plan connected)"
+    billing_model: ocu
+    ocu_per_hour: 1.0
+    model_in_ocu: false     # model billed by OpenAI, not Ona
+    tokenizer: cl100k
+    context_k: 128
+    tokens_per_ocu: null
+    cost_per_1m_in: null    # managed by OpenAI/ChatGPT plan
+    cost_per_1m_out: null
+    notes: >
+      Codex with a connected ChatGPT account. Environment runtime billed in OCUs
+      (1 OCU/hr); model inference billed by OpenAI against the ChatGPT plan.
+      Log ocu_estimate as env-runtime-only (session_hours * 1.0).
+
+  github-models-gpt4o:
+    display_name: "GitHub Models — GPT-4o"
+    billing_model: gh-models
+    ocu_per_hour: 1.0       # env runtime still billed in OCUs
+    model_in_ocu: false
+    tokenizer: cl100k
+    context_k: 128
+    tokens_per_ocu: null
+    cost_per_1m_in: null    # free via GitHub Models quota
+    cost_per_1m_out: null
+    notes: >
+      Used by llm.sh, update-readmes.sh, translate-docs.sh, create-readmes.sh.
+      Model inference is free via GitHub Models quota (~150K tokens/day).
+      Only environment runtime consumes OCUs. Log ocu_estimate as env-runtime-only.
+      Daily quota resets at midnight UTC.
+
+  github-models-gpt4o-mini:
+    display_name: "GitHub Models — GPT-4o-mini"
+    billing_model: gh-models
+    ocu_per_hour: 1.0
+    model_in_ocu: false
+    tokenizer: cl100k
+    context_k: 128
+    tokens_per_ocu: null
+    cost_per_1m_in: null
+    cost_per_1m_out: null
+    notes: >
+      Used by resolve-failures.sh, generate-descriptions.sh.
+      Higher daily quota than gpt-4o (~1M tokens/day). Default model for
+      high-volume, lower-complexity tasks. Log ocu_estimate as env-runtime-only.
+
+  anthropic-direct:
+    display_name: "Anthropic API (direct, Claude 4 Sonnet)"
+    billing_model: anthropic-direct
+    ocu_per_hour: 0.0       # no Ona environment — direct API call
+    model_in_ocu: false
+    tokenizer: anthropic-bpe
+    context_k: 200
+    tokens_per_ocu: null
+    cost_per_1m_in: 3.00    # USD, as of 2026 — verify at anthropic.com/pricing
+    cost_per_1m_out: 15.00
+    notes: >
+      Direct Anthropic API usage via ANTHROPIC_API_KEY. No OCU cost.
+      Log ocu_estimate as 0; use anthropic_input_tokens + anthropic_output_tokens
+      fields to track actual token consumption and compute USD cost.
+
+  anthropic-direct-haiku:
+    display_name: "Anthropic API (direct, Claude 3.5 Haiku)"
+    billing_model: anthropic-direct
+    ocu_per_hour: 0.0
+    model_in_ocu: false
+    tokenizer: anthropic-bpe
+    context_k: 200
+    tokens_per_ocu: null
+    cost_per_1m_in: 0.80
+    cost_per_1m_out: 4.00
+    notes: >
+      Cheaper Claude model for high-volume direct API tasks. Same tokenizer
+      as Claude 4 Sonnet. Verify pricing at anthropic.com/pricing.
+
+  gemini-direct:
+    display_name: "Google Gemini (direct API)"
+    billing_model: openai-direct   # reuse field — means "external pay-per-token"
+    ocu_per_hour: 0.0
+    model_in_ocu: false
+    tokenizer: sentencepiece
+    context_k: 1000
+    tokens_per_ocu: null
+    cost_per_1m_in: 1.25    # Gemini 1.5 Pro as of 2026 — verify at ai.google.dev
+    cost_per_1m_out: 5.00
+    notes: >
+      Not currently used in fork-sync-all scripts. Included for completeness.
+      1M token context window makes it suitable for whole-repo analysis tasks.
+
+# ── Task complexity profiles ──────────────────────────────────────────────────
+#
+# Used by track-agent-costs.yml to validate ocu_estimate inputs and generate
+# per-task budget guidance in step summaries.
+#
+# ocu_low / ocu_high: expected OCU range for this task class (Ona Agent).
+# For GitHub Models tasks, multiply ocu_low/high by 0.1 (env runtime only).
+
+task_profiles:
+  quick-question:
+    display_name: "Quick question / explain one workflow"
+    ocu_low: 1.0
+    ocu_high: 1.5
+    typical_hours: 0.25
+
+  single-bug-fix:
+    display_name: "Fix a single bug or validator error"
+    ocu_low: 1.5
+    ocu_high: 2.5
+    typical_hours: 0.33
+
+  new-script:
+    display_name: "Add a new script or include"
+    ocu_low: 2.5
+    ocu_high: 4.5
+    typical_hours: 0.5
+
+  new-workflow:
+    display_name: "Add a new workflow (single file)"
+    ocu_low: 4.0
+    ocu_high: 6.0
+    typical_hours: 0.75
+
+  multi-file-feature:
+    display_name: "Multi-file feature (e.g. flush watchdog)"
+    ocu_low: 8.0
+    ocu_high: 12.0
+    typical_hours: 1.5
+
+  large-feature:
+    display_name: "Large feature + tests + docs + PR"
+    ocu_low: 10.0
+    ocu_high: 18.0
+    typical_hours: 2.5
+
+  full-session:
+    display_name: "Full session (e.g. platform hardening)"
+    ocu_low: 15.0
+    ocu_high: 24.0
+    typical_hours: 3.5
+
+  end-to-end-update:
+    display_name: "End-to-end repo update (all outstanding work)"
+    ocu_low: 19.0
+    ocu_high: 31.0
+    typical_hours: 5.0
+
+  translation-run:
+    display_name: "Translate READMEs (GitHub Models)"
+    ocu_low: 0.25
+    ocu_high: 1.0
+    typical_hours: 0.5
+
+  ci-resolution:
+    display_name: "Resolve CI failures (GitHub Models)"
+    ocu_low: 0.25
+    ocu_high: 0.5
+    typical_hours: 0.25

--- a/config/workflow-priority-tiers.yml
+++ b/config/workflow-priority-tiers.yml
@@ -200,6 +200,8 @@ tiers:
   # ── Tier 4: LOW ─────────────────────────────────────────────────────────────
   # Non-critical maintenance, translation, and reporting.
   # Cancelled first when quota drops below reserve floor.
+  - name: "Track Agent Costs"
+    tier: 4
   - name: "Translate READMEs"
     tier: 4
   - name: "Translate Docs"

--- a/config/workflow-quota-costs.yml
+++ b/config/workflow-quota-costs.yml
@@ -905,6 +905,21 @@ workflows:
   cost_high: 200
   basis: code-audit
   synopsis: Bare-clones every repo in OpenOS-Project-OSP and git push --mirror into OpenOS-Project-Ecosystem-OOC, completing the second hop of the three-org mirror chain.
+- name: Track Agent Costs
+  min_quota: 10
+  cost_low: 1
+  cost_mid: 2
+  cost_high: 3
+  basis: code-audit
+  notes: >
+    Manual-dispatch only. Reads config/agent-cost-profiles.yml, appends one
+    entry to data/agent-cost-log.json, commits, and pushes. Minimal API usage:
+    1 checkout + 1 commit push. No REST API calls beyond git operations.
+  synopsis: >
+    Records AI agent session cost estimates (OCUs, USD, tokens) to a structured
+    JSON log. Supports Ona Agent, Codex, GitHub Models, and direct API agents.
+    Builds an observed cost dataset to replace code-audit estimates in
+    DOCS/ai-agent-costs.md over time.
 - name: Pipeline Telemetry
   min_quota: 200
   cost_low: 5

--- a/config/workflow-sync.yml
+++ b/config/workflow-sync.yml
@@ -298,6 +298,8 @@ github_only:
     reason: Agnostic git platform sync — dispatches push/pull/both legs between any two platforms from GitHub Actions
   - workflow_file: auto-merge-prs.yml
     reason: Merges GitHub PRs via GitHub API — no GitLab equivalent
+  - workflow_file: track-agent-costs.yml
+    reason: Records AI agent session costs to data/agent-cost-log.json — GitHub-hosted log, manual dispatch only
   - workflow_file: sync-in.yml
     reason: Manages Sync-in server/client — targets a self-hosted instance, no GitLab CI equivalent
   - workflow_file: sync-to-gitlab.yml

--- a/data/agent-cost-log.json
+++ b/data/agent-cost-log.json
@@ -1,0 +1,20 @@
+{
+  "sessions": [
+    {
+      "timestamp": "2026-06-17T15:36:13Z",
+      "run_id": "test-001",
+      "actor": "test-user",
+      "agent": "ona",
+      "agent_display": "Ona Agent (Claude 4 Sonnet)",
+      "task_description": "Test session",
+      "task_profile": "full-session",
+      "session_hours": 3.5,
+      "ocu_estimate": 18.0,
+      "usd_ocu": 4.5,
+      "usd_direct": 0.0,
+      "usd_total": 4.5,
+      "pr_number": "166",
+      "notes": "Initial test entry"
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

**`track-agent-costs.yml`** — workflow for logging AI agent session costs (OCUs, model tokens, wall time) to `data/agent-cost-log.json`.

**`config/agent-cost-profiles.yml`** — machine-readable cost profiles for all agents used in this repo (Ona Agent, Codex, GitHub Models, Anthropic API direct). Covers billing model, OCU rates, and per-task size estimates.

**`DOCS/ai-agent-costs.md`** — human-readable reference for agent cost budgeting. Covers OCU top-up packages, rough task sizing, and the GitHub API quota / OCU independence note.

**`AGENTS.md`** — added AI agent cost budgeting section (the table already visible in AGENTS.md).

**`data/agent-cost-log.json`** — initial log seed with example entries.

Config registrations: `workflow-sync.yml`, `workflow-priority-tiers.yml`, `workflow-quota-costs.yml`.

## Type

- [x] New feature / workflow

## Checklist

- [x] Validator passes
- [x] Tests pass
- [x] No secrets or tokens committed