### PR TITLE
docs: modernise README + unify workflow trigger categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,21 @@
 
 [![Built with Ona](https://ona.com/build-with-ona.svg)](https://app.ona.com/#https://github.com/OpenOS-Project-OSP/fork-sync-all)
 
-Sync and mirror infrastructure for the three-org chain:
+Control plane for the `Interested-Deving-1896` GitHub org. Runs 121 GitHub Actions workflows that keep three GitHub orgs and a GitLab group in sync, manage READMEs and badges across OSP-bound repos, resolve CI failures, and maintain registered upstream imports.
+
+<!-- FSA-COUNTS-START — updated 2026-06-17 by generate-workflow-triggers-doc.py -->
+| | |
+|---|---|
+| Workflows | **118** |
+| Registered imports | **156** |
+| Template consumers | **80** |
+| GitLab subgroups | **14** |
+| GitLab repos mirrored | **225** |
+<!-- FSA-COUNTS-END -->
+
+---
+
+## How it works
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────────┐
@@ -17,7 +31,8 @@ Sync and mirror infrastructure for the three-org chain:
 │          │                  GitLab openos-project                           │
 │          │             (14 subgroups, 225 repos mirrored)                   │
 │          │                                                                  │
-│          └──── upstream-commits / upstream-prs (OSP + OOC → I-D-1896) ──────┘
+│          └──── upstream-commits / upstream-prs (OSP + OOC → I-D-1896) ─────┘
+└─────────────────────────────────────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │  Full pipeline (manual / monthly)                                           │
@@ -31,96 +46,84 @@ Sync and mirror infrastructure for the three-org chain:
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │  Quota & queue management (automatic, every 30 min)                         │
 │                                                                             │
-│  quota-reserve ──► queue-manager ──► runner-status                          │
-│                         │                                                   │
-│                  rate-limit-rerun ──► cancel-stale-runs                     │
-│                    (every 4h)         quota-monitor                         │
+│  quota-reserve ──► queue-manager ──► rate-limit-rerun                       │
+│                                           │                                 │
+│                                    cancel-stale-runs                        │
+│                                      quota-monitor                          │
+└─────────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  OTA system (versioned updates for independent forks)                       │
+│                                                                             │
+│  ota-release ──► ota-deliver ──► opted-in forks (PR per fork)               │
+│       ▲                                                                     │
+│  semver tag push                                                            │
+│                                                                             │
+│  ota-reconcile (weekly) ──► path A: stamp · B: drift PR · C: quota PR      │
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
 
 <!-- AI:start:what-it-does -->
-fork-sync-all is the control plane for the `Interested-Deving-1896` GitHub org. It runs 112 GitHub Actions workflows that keep three GitHub orgs and a GitLab group in sync, manage READMEs and badges across ~49 OSP-bound repos, resolve CI failures, and maintain 152 registered upstream imports.
+fork-sync-all is the control plane for the `Interested-Deving-1896` GitHub org. It runs 121 GitHub Actions workflows that keep three GitHub orgs and a GitLab group in sync, manage READMEs and badges across ~49 OSP-bound repos, resolve CI failures, and maintain 156 registered upstream imports.
 
 The mirror chain flows outward from `Interested-Deving-1896` → `OpenOS-Project-OSP` → `OpenOS-Project-Ecosystem-OOC` → `gitlab.com/openos-project`. Commits pushed directly to OSP or OOC are detected and opened as PRs back to `Interested-Deving-1896` so the source of truth stays in one place.
+
+The OTA system delivers versioned updates to independent forks of fork-sync-all. When a semver tag is pushed, `ota-release.yml` assembles per-fork payloads and opens PRs in all opted-in repos. `ota-reconcile.yml` runs weekly as a fallback, detecting drift and quota-exhaustion gaps autonomously.
 <!-- AI:end:what-it-does -->
 
 ---
 
 ## Documentation
 
-- [Full documentation](https://interested-deving-1896.github.io/fork-sync-all/) — architecture, quota management, workflow reference, runbooks
-- [Workflow Triggers](docs/workflow-triggers.md) — all 112 workflows, their schedules, and what else triggers them ([plain text](docs/workflow-triggers.txt))
-- [Workflow Scheduling Guide](DOCS/workflow-scheduling.md) — optimal dispatch windows, quota floors, EST/UTC timing reference
-- [Quota Costs](DOCS/quota-costs.md) — per-workflow REST call estimates (p50/p95)
+| Resource | Description |
+|---|---|
+| [Full documentation](https://interested-deving-1896.github.io/fork-sync-all/) | Architecture, quota management, workflow reference, runbooks |
+| [Workflow Triggers](docs/workflow-triggers.md) | All 121 workflows — schedules, triggers, synopses ([plain text](docs/workflow-triggers.txt)) |
+| [OTA Reconcile](DOCS/ota-reconcile.md) | Hybrid A/B/C fallback layer for mirror-chain consumers |
+| [OTA System](DOCS/ota-system.md) | OTA delivery architecture and opt-in guide |
+| [AI Agent Costs](DOCS/ai-agent-costs.md) | OCU pricing, tokenizer reference, per-task estimates |
+| [Quota Costs](DOCS/quota-costs.md) | Per-workflow REST call estimates (p50/p95) |
+| [Workflow Scheduling](DOCS/workflow-scheduling.md) | Optimal dispatch windows, quota floors, EST/UTC timing |
+| [Runbooks](DOCS/runbooks.md) | Incident response and operational procedures |
 
 ---
 
-## Workflows
+## Workflow groups
 
-112 workflows across 17 GitLab-paired and 95 GitHub-only. Key groups:
+121 workflows across 13 functional groups. Full detail in [docs/workflow-triggers.md](docs/workflow-triggers.md).
 
-### Mirror chain
-
-| Workflow | Schedule (UTC) | What it does |
+| Group | Workflows | Description |
 |---|---|---|
-| `mirror-to-osp.yml` | Every 6h at :13 | Mirrors `Interested-Deving-1896` → `OpenOS-Project-OSP` |
-| `mirror-osp-to-ooc.yml` | Every 6h at :45 | Mirrors `OpenOS-Project-OSP` → `OpenOS-Project-Ecosystem-OOC` |
-| `mirror-osp-to-gitlab.yml` | Daily 01:23 | Mirrors `OpenOS-Project-OSP` → GitLab `openos-project` |
-| `mirror-orgs-full.yml` | Daily 02:17 | Full org mirror (all branches, tags, refs) |
-| `mirror-releases.yml` | Every 12h at :03 | Mirrors GitHub Releases + assets across all three orgs |
-| `mirror-artifacts.yml` | Daily 02:10 | Mirrors Flatpak, RPM, and container artifacts |
+| [Mirror Chain](docs/workflow-triggers.md#mirror-chain) | 7 | Outward mirror: I-D-1896 → OSP → OOC → GitLab |
+| [Fork & Import Sync](docs/workflow-triggers.md#fork--import-sync) | 10 | Upstream fork sync, registered imports, platform import |
+| [README Management](docs/workflow-triggers.md#readme-management) | 7 | Create, update, badge, translate, validate READMEs |
+| [CI & Failure Resolution](docs/workflow-triggers.md#ci--failure-resolution) | 7 | Rate-limit rerun, failure resolver, PR automation |
+| [Full Pipeline](docs/workflow-triggers.md#full-pipeline) | 9 | pre-flush → full-chain-flush → post-flush + critical-deploy |
+| [Quota & Queue Management](docs/workflow-triggers.md#quota--queue-management) | 4 | Reserve, dedup, monitor, cost registry |
+| [OTA System](docs/workflow-triggers.md#ota-system) | 5 | Release delivery, reconcile, self-update, discover, opt-in |
+| [Documentation & Publishing](docs/workflow-triggers.md#documentation--publishing) | 8 | mdBook, GitBook, NotebookLM, translate docs, triggers doc |
+| [AI & Cost Tracking](docs/workflow-triggers.md#ai--cost-tracking) | 2 | Session cost log, weekly price sync |
+| [Maintenance & Housekeeping](docs/workflow-triggers.md#maintenance--housekeeping) | 10 | Config validation, cleanup, token rotation, dep updates |
+| [OSP-Bound Repo Management](docs/workflow-triggers.md#osp-bound-repo-management) | 3 | Add mirror repo, CI status, setup OSP mirrors |
+| [GitLab Sync](docs/workflow-triggers.md#gitlab-sync) | 2 | Push/pull sync with GitLab |
+| [Utility / On-Demand](docs/workflow-triggers.md#utility--on-demand) | 45 | Manual and specialised workflows |
 
-### Fork & import sync
+---
 
-| Workflow | Schedule (UTC) | What it does |
-|---|---|---|
-| `sync-forks.yml` | Daily 06:07 | Syncs all `Interested-Deving-1896` forks with their upstreams |
-| `sync-registered-imports.yml` | Daily 04:55 | Re-syncs all 152 repos in `registered-imports.json` |
-| `sync-pieroproietti-forks.yml` | Daily 01:07 | Fast-path sync for pieroproietti forks |
-| `upstream-prs.yml` | Daily 03:33 | Opens PRs for OSP/OOC commits not in `Interested-Deving-1896` |
-| `upstream-commits.yml` | Daily 03:47 | Detects direct OSP/OOC commits; opens reconciliation PRs |
-| `import-repo.yml` | Manual | Imports any git repo from any platform |
+## Key config files
 
-### README, badges & content
-
-| Workflow | Schedule (UTC) | What it does |
-|---|---|---|
-| `update-readmes.yml` | Daily 03:15 | Regenerates AI-owned README sections across OSP-bound repos |
-| `create-readmes.yml` | Daily 07:08 | Creates READMEs for repos that have none |
-| `inject-badges.yml` | Every 2 days 08:15 | Injects Built-with-Ona badges |
-| `translate-readmes.yml` | Every 2 days 10:43 | Translates READMEs to French |
-| `reconcile-org-refs.yml` | Every 2 days 05:50 | Rewrites org names in file content across all three orgs |
-
-### Full pipeline
-
-| Workflow | Schedule (UTC) | What it does |
-|---|---|---|
-| `pre-flush-prep.yml` | Manual | Clears queue, merges PRs, validates config, writes entry `QUOTA_SNAPSHOT`, then dispatches flush |
-| `full-chain-flush.yml` | Monthly 05:17 / manual | Master orchestrator — runs the full 18-stage pipeline in sequence; writes `QUOTA_SNAPSHOT` at start |
-| `post-flush-prep.yml` | After flush / manual | End-to-end verification (mirror integrity, CI, badge check); writes exit `QUOTA_SNAPSHOT` |
-
-### CI, quota & queue management
-
-| Workflow | Schedule (UTC) | What it does |
-|---|---|---|
-| `check-ci.yml` | Daily 09:05 | Checks CI status across all configured targets (GitHub + GitLab) |
-| `resolve-ci.yml` | Daily 07:43 | AI-assisted CI failure resolver across all targets |
-| `queue-manager.yml` | Every 30 min | Deduplicates queued runs; evicts runs queued > 25 min |
-| `quota-reserve.yml` | Every 30 min | Cancels low-priority runs when quota < 1,000 |
-| `runner-status.yml` | Every hour at :10 | Runner utilisation and queue depth report; flags critical backlog |
-| `rate-limit-rerun.yml` | Every 4h at :05 | Re-triggers workflows that failed due to rate limiting |
-| `cancel-stale-runs.yml` | After rate-limit-rerun | Clears post-outage run pile-up immediately after reruns are dispatched |
-| `rate-limit-status.yml` | Manual / after rerun | Snapshots quota across all platforms (GitHub REST/GraphQL, GitLab, Models) |
-| `validate-config.yml` | On push / PR | Validates all config files; runs AgentShield security scan |
-| `full-audit.yml` | Weekly Monday 04:00 | 20-check structural audit of workflows, configs, and wiring |
-
-### Infrastructure & maintenance
-
-| Workflow | Schedule (UTC) | What it does |
-|---|---|---|
-| `cleanup-branches.yml` | Monthly 04:29 | Deletes branches merged into main across the org |
-| `update-infra-deps.yml` | Weekly Monday 06:11 | Opens PRs for outdated Actions versions, runners, Node/Python |
-| `token-health.yml` | Weekly Monday 09:24 | Checks PAT expiry; opens an issue at 45 days out |
+| File | Purpose |
+|---|---|
+| `config/gitlab-subgroups.yml` | Single source of truth for GitLab subgroup placement |
+| `config/workflow-quota-costs.yml` | Per-workflow REST call cost estimates — drives quota pre-flight and `quota-reserve.yml` |
+| `config/workflow-priority-tiers.yml` | Cancellation priority (Tier 1 = never cancel, Tier 4 = cancel first) |
+| `config/workflow-sync.yml` | Which workflows have GitLab CI counterparts |
+| `config/template-manifest.yml` | Profile definitions for template sync (full / mirror / infra-core / standalone) |
+| `config/template-consumers.yml` | 80 repos that receive template updates via `sync-template.yml` |
+| `config/ota-registry.yml` | Opted-in forks receiving OTA updates |
+| `config/ota-blocklist.yml` | Orgs/profiles excluded from OTA delivery by default |
+| `config/agent-cost-profiles.yml` | Machine-readable AI agent cost profiles (8 variants, 10 complexity tiers) |
+| `registered-imports.json` | 156 upstream repos kept in ongoing sync |
 
 ---
 
@@ -137,10 +140,9 @@ The mirror chain flows outward from `Interested-Deving-1896` → `OpenOS-Project
 | `BITBUCKET_TOKEN` | `import-repo.yml`, `sync-registered-imports.yml` | Bitbucket app password (private repos only) |
 | `GITEA_TOKEN` | `import-repo.yml`, `sync-registered-imports.yml` | Gitea/Codeberg PAT (private repos only) |
 | `SOURCEHUT_TOKEN` | `import-repo.yml` | Sourcehut PAT (private repos only) |
+| `NOTEBOOKLM_AUTH_JSON` | `generate-notebooklm.yml` | Short-lived auth state, rotated weekly by `refresh-notebooklm-auth.yml` |
 | `ACTIVITYSMITH_API_KEY` | `full-chain-flush.yml` | Optional — live activity tracking; skipped if unset |
 | `SYNC_IN_SERVER_URL` | `sync-in.yml` | URL of the local sync-in server instance |
-
-To add a missing secret:
 
 ```bash
 gh secret set <SECRET_NAME> --repo Interested-Deving-1896/fork-sync-all
@@ -148,57 +150,35 @@ gh secret set <SECRET_NAME> --repo Interested-Deving-1896/fork-sync-all
 
 ---
 
-## Registered Imports
-
-`registered-imports.json` tracks 152 repos imported via `import-repo.yml` with `ongoing_sync` enabled. `sync-registered-imports.yml` re-pulls each source daily at 04:55 UTC.
-
-```json
-[
-  {
-    "source_url":  "https://gitlab.com/some-group/some-repo",
-    "target_name": "some-repo",
-    "platform":    "gitlab",
-    "added":       "2026-05-02T18:00:00Z"
-  }
-]
-```
-
-To register a repo manually, run `import-repo.yml` with `ongoing_sync: true`, or edit the file directly and commit.
-
----
-
 ## Rate limits
 
-Both `SYNC_TOKEN` and `GH_SYNC_TOKEN` belong to the same user and share the same 5,000 req/hr REST bucket. Treat them as one pool.
+Both `SYNC_TOKEN` and `GH_SYNC_TOKEN` belong to the same user and share the same 5,000 req/hr REST bucket. Treat them as one pool. `raw.githubusercontent.com` fetches do **not** count against the quota.
 
-| API | Limit | Reset | Notes |
-|---|---|---|---|
-| GitHub REST | 5,000 req/hr per token | Top of the hour | `X-RateLimit-Reset` header |
-| GitHub GraphQL | 5,000 pts/hr (counts as 1 REST call) | Top of the hour | Preferred for bulk repo queries |
-| GitHub Models | Varies by model | Per-minute window | `Retry-After` header |
-| GitLab REST | 2,000 req/min per token | Per-minute window | `RateLimit-Reset` header |
+| API | Limit | Reset |
+|---|---|---|
+| GitHub REST | 5,000 req/hr per token | Top of the hour |
+| GitHub GraphQL | 5,000 pts/hr (counts as 1 REST call) | Top of the hour |
+| GitHub Models | Varies by model | Per-minute window |
+| GitLab REST | 2,000 req/min per token | Per-minute window |
 
-`raw.githubusercontent.com` fetches do **not** count against the quota.
-
-All scripts retry up to 3 times with reset-aware backoff on 403/429. The `quota-reserve.yml` workflow cancels low-priority queued runs when remaining quota drops below 1,000. Check current quota:
+`quota-reserve.yml` cancels low-priority queued runs when remaining quota drops below 1,000. Check current quota:
 
 ```bash
 curl -sf -H "Authorization: token $SYNC_TOKEN" \
   "https://api.github.com/rate_limit" | \
   python3 -c "
-import sys,json,datetime
-d=json.load(sys.stdin)['resources']['core']
-print(f\"remaining={d['remaining']}  resets={datetime.datetime.utcfromtimestamp(d['reset']).strftime('%H:%M UTC')}\")
+import sys, json, datetime
+d = json.load(sys.stdin)['resources']['core']
+reset = datetime.datetime.utcfromtimestamp(d['reset']).strftime('%H:%M UTC')
+print(f'remaining={d[\"remaining\"]}  resets={reset}')
 "
 ```
-
-**Workflows most likely to hit limits:** `reconcile-org-refs.yml` (reads every file in every repo), `check-ci.yml` (scans all repos across three orgs), and `resolve-ci.yml` (AI-assisted analysis). These run in their own concurrency groups so they don't compound each other.
 
 ---
 
 ## GitLab subgroups
 
-14 subgroups under `gitlab.com/openos-project`, 225 repos mirrored:
+14 subgroups under `gitlab.com/openos-project`, 225 repos mirrored. Assignments are in `config/gitlab-subgroups.yml`.
 
 | Subgroup | Repos | Focus |
 |---|---|---|
@@ -217,14 +197,12 @@ print(f\"remaining={d['remaining']}  resets={datetime.datetime.utcfromtimestamp(
 | `taubyte_deving` | 1 | Taubyte protocol |
 | `immutable-filesystem_deving` | 1 | Immutable filesystem projects |
 
-Subgroup IDs and repo assignments are in `config/gitlab-subgroups.yml`.
-
 ---
 
 <!-- AI:start:architecture -->
 ## Architecture
 
-fork-sync-all is structured as a hub-and-spoke control plane. All automation lives in this repo; consumer repos receive only the files they need via `sync-template.yml`. 112 workflows across three functional layers: mirror chain, full pipeline, and quota/queue management.
+fork-sync-all is structured as a hub-and-spoke control plane. All automation lives in this repo; consumer repos receive only the files they need via `sync-template.yml`. 121 workflows across 13 functional groups: mirror chain, full pipeline, quota/queue management, OTA system, and supporting layers.
 
 **Mirror chain** (outward flow, runs every 6h):
 ```
@@ -237,16 +215,16 @@ Interested-Deving-1896  ──[mirror-to-osp]──►  OpenOS-Project-OSP
 
 **Feedback loop** (inward flow, runs daily):
 - `upstream-prs.yml` + `upstream-commits.yml` detect changes on OSP/OOC and open PRs back to `Interested-Deving-1896`
-- `git-platform-sync.yml` pulls from GitLab back to GitHub
 
-**Key config files:**
-- `config/gitlab-subgroups.yml` — single source of truth for GitLab subgroup placement
-- `config/workflow-quota-costs.yml` — per-workflow REST call cost estimates (drives quota pre-flight)
-- `config/workflow-priority-tiers.yml` — cancellation priority (Tier 1 = never cancel, Tier 4 = cancel first)
-- `config/workflow-sync.yml` — which workflows have GitLab CI counterparts
-- `registered-imports.json` — 152 upstream repos kept in ongoing sync
+**OTA system** (versioned updates for independent forks):
+- Push a semver tag → `ota-release.yml` delivers to all opted-in forks via PR
+- `ota-reconcile.yml` runs weekly as a fallback: path A (stamp), B (drift PR), C (quota-recovery PR)
+- Mirror-chain repos are excluded from OTA delivery by default but covered by reconcile
 
-**Quota management** runs on two axes: `queue-manager.yml` deduplicates queued runs every 30 min; `quota-reserve.yml` cancels low-priority runs when the REST bucket drops below 1,000. Both read `config/workflow-priority-tiers.yml` at runtime — no script edits needed when adding new workflows.
+**Quota management** runs on two axes:
+- `queue-manager.yml` deduplicates queued runs every 30 min
+- `quota-reserve.yml` cancels low-priority runs when the REST bucket drops below 1,000
+- Both read `config/workflow-priority-tiers.yml` at runtime — no script edits needed when adding workflows
 <!-- AI:end:architecture -->
 
 ---
@@ -256,14 +234,14 @@ Interested-Deving-1896  ──[mirror-to-osp]──►  OpenOS-Project-OSP
 
 Every push and PR runs `validate-config.yml`, which gates on:
 
-1. **YAML parse** — all 112 workflow files parse cleanly
-2. **Workflow guards** — `rate_limit_rerun` inputs have job-level guards; `workflow_run` trigger names match real workflows; quota-cost and priority-tier entries are consistent
+1. **YAML parse** — all 121 workflow files parse cleanly
+2. **Workflow guards** — `workflow_run` trigger names match real workflows; quota-cost and priority-tier entries are consistent
 3. **Shell syntax** — `bash -n` on all scripts
 4. **Schema validation** — `gavi` validates all workflows against the GitHub Actions JSON schema
 5. **Config validators** — `gitlab-subgroups.yml`, `registered-imports.json`, `template-manifest.yml`, `workflow-priority-tiers.yml`, `workflow-cost-profiles.yml`
-6. **AgentShield** — AI agent config security scan (opt-in via `ANTHROPIC_API_KEY` secret)
+6. **AgentShield** — AI agent config security scan
 
-The required status check is `CI Required` (a gate job that always runs and reflects all filtered outcomes). `full-audit.yml` runs 20 deeper checks weekly on Monday at 04:00 UTC.
+The required status check is `CI Required` (a gate job that always runs and reflects all filtered outcomes).
 <!-- AI:end:ci -->
 
 ---
@@ -333,8 +311,7 @@ This repo is maintained in [`Interested-Deving-1896/fork-sync-all`](https://gith
 Interested-Deving-1896/fork-sync-all  ──►  OpenOS-Project-OSP/fork-sync-all  ──►  OpenOS-Project-Ecosystem-OOC/fork-sync-all
 ```
 
-Changes flow downstream automatically via the hourly mirror chain in
-[`fork-sync-all`](https://github.com/Interested-Deving-1896/fork-sync-all).
+Changes flow downstream automatically via the hourly mirror chain.
 Direct commits to OSP or OOC are detected and opened as PRs back to `Interested-Deving-1896`.
 <!-- AI:end:mirror-chain -->
 

--- a/docs/workflow-triggers.md
+++ b/docs/workflow-triggers.md
@@ -7,27 +7,6 @@ All workflows in `.github/workflows/`. Grouped by function, with every trigger l
 
 ---
 
-<!-- FSA-INDEX-START -->
-## Index
-
-Jump to any section:
-
-| Section | Workflows |
-|---|---|
-| [Mirror Chain](#mirror-chain) | 7 |
-| [OSP-Bound Repo Management](#osp-bound-repo-management) | 3 |
-| [Fork & Import Sync](#fork--import-sync) | 10 |
-| [GitLab Sync](#gitlab-sync) | 2 |
-| [README Management](#readme-management) | 7 |
-| [CI & Failure Resolution](#ci--failure-resolution) | 7 |
-| [Maintenance & Housekeeping](#maintenance--housekeeping) | 12 |
-| [Full Pipeline](#full-pipeline) | 9 |
-| [Utility / On-Demand](#utility--on-demand) | 61 |
-
-**Quick links:** [Glossary](#glossary) · [Schedule Summary](#schedule-summary-utc) · [Source](https://github.com/Interested-Deving-1896/fork-sync-all/tree/main/.github/workflows)
-
-<!-- FSA-INDEX-END -->
-
 ## Mirror Chain
 
 | Workflow | Synopsis | File | Schedule | Also triggers on |
@@ -121,7 +100,6 @@ Jump to any section:
 | Rotate Secret Token [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/rotate-token.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/rotate-token.yml) | Rotates GitHub PATs and GitLab tokens stored as org/repo secrets. Validates the new token before committing, then triggers Cancel Runs After Token Rotation to clear stale runs. | `rotate-token.yml` | — | dispatch |
 | Cancel Runs After Token Rotation [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/cancel-post-rotation.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/cancel-post-rotation.yml) | Cancels any queued or in-progress workflow runs immediately after token rotation to prevent runs using the old token. | `cancel-post-rotation.yml` | — | `Rotate Secret Token` completes |
 | Upstream Workflow Proposal [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/upstream-workflow-proposal.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/upstream-workflow-proposal.yml) | Scans OSP-bound repos for new workflow patterns not present in fork-sync-all and opens a PR proposing them as template skeletons. | `upstream-workflow-proposal.yml` | Weekly Mon 06:06 | dispatch |
-| Update Workflow Triggers Doc [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/update-workflow-triggers-doc.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/update-workflow-triggers-doc.yml) | Regenerates docs/workflow-triggers.md and docs/workflow-triggers.txt whenever a workflow file changes on main. Commits the result directly to main. | `update-workflow-triggers-doc.yml` | — | push to `.github/workflows/**`, `config/workflow-quota-costs.yml` · dispatch |
 
 ---
 
@@ -142,12 +120,49 @@ Jump to any section:
 
 ---
 
+## Quota & Queue Management
+
+| Workflow | Synopsis | File | Schedule | Also triggers on |
+|---|---|---|---|---|
+| Quota Reserve [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/quota-reserve.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/quota-reserve.yml) | Cancels low-priority queued runs when remaining quota drops below RESERVE_FLOOR (default 1000). Uses per-workflow min_quota from workflow-quota-costs.yml for cost-aware cancellation. | `quota-reserve.yml` | Every 30 min | dispatch |
+| Queue Manager [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/queue-manager.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/queue-manager.yml) | Deduplicates queued workflow runs (keeps newest per workflow) and evicts runs queued longer than STALE_QUEUE_MIN (default 25 min) to prevent quota exhaustion cascades. | `queue-manager.yml` | Every 30 min | `Rate-Limit Re-trigger` completes · dispatch |
+| Quota Monitor [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/quota-monitor.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/quota-monitor.yml) | Polls GitHub quota and optionally dispatches a target workflow once quota recovers above a configurable threshold. Dispatch-only — never scheduled. | `quota-monitor.yml` | — | `Rate-Limit Re-trigger` completes · dispatch |
+| Update Quota Cost Registry [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/update-quota-costs.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/update-quota-costs.yml) | Reads quota-instrument records from job logs, computes observed p50/p95 REST costs per workflow, and commits updated values to workflow-quota-costs.yml weekly. | `update-quota-costs.yml` | Weekly Mon 08:00 | dispatch |
+
+---
+
+## OTA System
+
+| Workflow | Synopsis | File | Schedule | Also triggers on |
+|---|---|---|---|---|
+| OTA Release [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/ota-release.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/ota-release.yml) | Triggered on semver tag push. Assembles and delivers OTA updates to all opted-in repos in config/ota-registry.yml, then updates CHANGELOG.md with release notes. | `ota-release.yml` | — | push to `(any)` · dispatch |
+| OTA Self-Update [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/ota-self-update.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/ota-self-update.yml) | Propagated to opted-in forks. Pulls the latest OTA release from fork-sync-all and applies it to the fork's workflow files. | `ota-self-update.yml` | Weekly Mon 05:15 | dispatch |
+| OTA Discover [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/ota-discover.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/ota-discover.yml) | Scans forks of fork-sync-all for .ota/config.yml with enabled: true and adds newly discovered repos to config/ota-registry.yml. | `ota-discover.yml` | Daily 06:38 | dispatch |
+| OTA Opt-In [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/ota-opt-in.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/ota-opt-in.yml) | Propagated to opted-in forks. Fork owners run this once to create .ota/config.yml and open a registration PR against fork-sync-all's OTA registry. | `ota-opt-in.yml` | — | dispatch |
+
+---
+
+## Documentation & Publishing
+
+| Workflow | Synopsis | File | Schedule | Also triggers on |
+|---|---|---|---|---|
+| Deploy Book [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/deploy-book.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/deploy-book.yml) | Builds the mdBook documentation site from DOCS/ and deploys it to GitHub Pages at interested-deving-1896.github.io/fork-sync-all/. | `deploy-book.yml` | — | push to `DOCS/**`, `book.toml`, `README.md` (+2 more) · dispatch |
+| Generate Book Pages [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/generate-book-pages.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/generate-book-pages.yml) | Regenerates DOCS/generated/ pages from config sources (workflow-quota-costs.yml, priority-tiers.yml, gitlab-subgroups.yml, registered-imports.json) and commits the result. | `generate-book-pages.yml` | — | push to `config/workflow-quota-costs.yml`, `config/workflow-priority-tiers.yml`, `config/gitlab-subgroups.yml` (+3 more) · dispatch |
+| Update Book Index [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/update-book-index.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/update-book-index.yml) | Regenerates DOCS/generated/ pages (source tree, glossary, workflow index) on push to main. Commits with [skip ci]. | `update-book-index.yml` | — | push to `.github/workflows/**`, `config/workflow-quota-costs.yml`, `config/workflow-priority-tiers.yml` (+8 more) · dispatch |
+| Export Book (Multi-Engine) [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/book-export.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/book-export.yml) | Exports the book to one or all supported engines (mdBook, MkDocs, Docusaurus, Pandoc). Manual dispatch only. | `book-export.yml` | — | dispatch |
+| GitBook OSS [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/gitbook-oss.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/gitbook-oss.yml) | Manages the GitBook OSS (Next.js) renderer. Actions: build, export, update, dev-info. Weekly update check on Mondays. | `gitbook-oss.yml` | Weekly Mon 04:17 | dispatch |
+| Translate Docs [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/translate-docs.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/translate-docs.yml) | Translates DOCS/ mdBook pages into a target language using GitHub Models API. Writes translated files to DOCS/<lang>/ and upserts a language section in SUMMARY.md. | `translate-docs.yml` | 15 11 */2 * * | `Deploy Book` completes · dispatch |
+| Generate NotebookLM Content [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/generate-notebooklm.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/generate-notebooklm.yml) | Generates NotebookLM content artifacts (audio, video, slides, infographic, quiz, flashcards, report) for a given notebook and uploads them to a GitHub Release. | `generate-notebooklm.yml` | — | dispatch |
+| Refresh NotebookLM Auth [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/refresh-notebooklm-auth.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/refresh-notebooklm-auth.yml) | Rotates the short-lived __Secure-1PSIDTS cookie in NOTEBOOKLM_AUTH_JSON weekly and writes the updated state back to the repo secret. | `refresh-notebooklm-auth.yml` | Weekly Tue 06:17 | dispatch |
+| Update Workflow Triggers Doc [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/update-workflow-triggers-doc.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/update-workflow-triggers-doc.yml) | Regenerates docs/workflow-triggers.md and docs/workflow-triggers.txt whenever a workflow file changes on main. Commits the result directly to main. | `update-workflow-triggers-doc.yml` | — | push to `.github/workflows/**`, `config/workflow-quota-costs.yml` · dispatch |
+
+---
+
 ## Utility / On-Demand
 
 | Workflow | Synopsis | File | Trigger |
 |---|---|---|---|
 | Auto-merge PRs [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/auto-merge-prs.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/auto-merge-prs.yml) | Merges open PRs once required checks pass. Hybrid auto-detection per PR: scope (label/bot/all), strategy (rebase/squash/merge), mechanism (native auto-merge vs poll). | `auto-merge-prs.yml` | `Validate Config` completes · dispatch |
-| Export Book (Multi-Engine) [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/book-export.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/book-export.yml) | Exports the book to one or all supported engines (mdBook, MkDocs, Docusaurus, Pandoc). Manual dispatch only. | `book-export.yml` | dispatch |
 | Cancel Stale Runs [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/cancel-stale-runs.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/cancel-stale-runs.yml) | Cancels queued and in-progress workflow runs older than MAX_AGE_MINUTES (default 90) or created before a fix commit, preventing stale runs from burning quota. | `cancel-stale-runs.yml` | `Rate-Limit Re-trigger` completes · dispatch |
 | Check Accessibility [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/check-accessibility.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/check-accessibility.yml) | Multi-layer accessibility audit — CODEOWNERS coverage, README screen-reader scan, WCAG 2.1 AA HTML check, audio overview (espeak-ng), and Braille output (liblouis). Commits README.audio.mp3 and README.brl artifacts. | `check-accessibility.yml` | push to `README.md`, `.github/CODEOWNERS`, `CODEOWNERS` (+1 more) · dispatch |
 | Check CI Status [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/check-ci.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/check-ci.yml) | Agnostic CI status checker. Runs check-ci.sh for each enabled target in config/ci-check-targets.yml (GitHub orgs and GitLab groups). Replaces check-osp-ci.yml and check-ooc-ci.yml.
@@ -157,7 +172,6 @@ Jump to any section:
 | Check Shell Tools CI [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/check-shell-tools-ci.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/check-shell-tools-ci.yml) | Batch-fetches CI run status for all 24 shell-tools repos via a single GraphQL query. Minimal quota cost. Weekly Monday 06:30 UTC. | `check-shell-tools-ci.yml` | dispatch |
 | Clone Org [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/clone-org.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/clone-org.yml) | Clones all repositories from an org or user on any supported platform (GitHub, GitLab, Bitbucket, Gitea) into Interested-Deving-1896. | `clone-org.yml` | dispatch |
 | Create OOC GitLab Subgroups [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/create-ooc-subgroups.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/create-ooc-subgroups.yml) | Creates the GitLab subgroup structure for OpenOS-Project-Ecosystem-OOC and records the resulting subgroup IDs. | `create-ooc-subgroups.yml` | dispatch |
-| Deploy Book [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/deploy-book.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/deploy-book.yml) | Builds the mdBook documentation site from DOCS/ and deploys it to GitHub Pages at interested-deving-1896.github.io/fork-sync-all/. | `deploy-book.yml` | push to `DOCS/**`, `book.toml`, `README.md` (+2 more) · dispatch |
 | Devcontainer SDK [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/devcontainer-sdk.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/devcontainer-sdk.yml) | Validates devcontainer.json, features, and automations templates. Optionally builds and pushes the devcontainer image or publishes features to GHCR. | `devcontainer-sdk.yml` | push to `.devcontainer/**`, `.github/workflows/devcontainer-sdk.yml` · dispatch |
 | Docker → Incus Migration [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/docker-to-incus.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/docker-to-incus.yml) | Scans repos for Docker artifacts (Dockerfile, docker-compose.yml) and replaces them with Incus equivalents. Runs after Add Mirror Repo and weekly. | `docker-to-incus.yml` | `Add Mirror Repo` completes · dispatch |
 | Eco Audit [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/eco-audit.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/eco-audit.yml) | Audits fork-sync-all against KDE Eco / Blue Angel DE-UZ 215 criteria. Checks green hosting, CI efficiency, telemetry, dependency footprint. Stubs KEcoLab energy measurement for GitLab activation. Weekly on Sundays. | `eco-audit.yml` | push to `scripts/eco/**`, `.github/workflows/eco-audit.yml`, `config/workflow-quota-costs.yml` · dispatch |
@@ -168,11 +182,8 @@ Jump to any section:
  | `flush-lifecycle.yml` | `Pre-Flush Prep` completes · dispatch |
 | Fork KDE Neon Repos [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/fork-neon-repos.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/fork-neon-repos.yml) | One-shot workflow that clones the 6 KDE Invent neon repos into Interested-Deving-1896 and pushes them through the OSP mirror chain. Ongoing re-sync handled by sync-registered-imports. | `fork-neon-repos.yml` | dispatch |
 | Full Audit [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/full-audit.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/full-audit.yml) | Weekly structural audit of workflows, scripts, config registries, assets, and vendor dirs. No REST calls. | `full-audit.yml` | dispatch |
-| Generate Book Pages [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/generate-book-pages.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/generate-book-pages.yml) | Regenerates DOCS/generated/ pages from config sources (workflow-quota-costs.yml, priority-tiers.yml, gitlab-subgroups.yml, registered-imports.json) and commits the result. | `generate-book-pages.yml` | push to `config/workflow-quota-costs.yml`, `config/workflow-priority-tiers.yml`, `config/gitlab-subgroups.yml` (+3 more) · dispatch |
-| Generate NotebookLM Content [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/generate-notebooklm.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/generate-notebooklm.yml) | Generates NotebookLM content artifacts (audio, video, slides, infographic, quiz, flashcards, report) for a given notebook and uploads them to a GitHub Release. | `generate-notebooklm.yml` | dispatch |
 | Generate Repo Descriptions [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/generate-repo-descriptions.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/generate-repo-descriptions.yml) | AI-powered per-file description generator. Fetches file tree (1 REST call) then reads each file for context (1 REST call per file) before calling GitHub Models. Cost scales with MAX_FILES setting. | `generate-repo-descriptions.yml` | dispatch |
 | Git Platform Sync [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/git-platform-sync.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/git-platform-sync.yml) | Agnostic git platform sync. Replaces sync-to-gitlab.yml (direction=push) and sync-from-gitlab.yml (direction=pull). Supports GitHub, GitLab, Gitea, Forgejo, Codeberg as source or destination. | `git-platform-sync.yml` | `Add Mirror Repo` completes · dispatch |
-| GitBook OSS [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/gitbook-oss.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/gitbook-oss.yml) | Manages the GitBook OSS (Next.js) renderer. Actions: build, export, update, dev-info. Weekly update check on Mondays. | `gitbook-oss.yml` | dispatch |
 | GitLab Storage Scan [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/gl-storage-scan.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/gl-storage-scan.yml) | Scans all projects under openos-project on GitLab and reports storage usage. Useful for diagnosing when the namespace approaches its 10 GiB limit. | `gl-storage-scan.yml` | `Mirror OSP → GitLab` completes · dispatch |
 | Integrate Shell Tools [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/integrate-shell-tools.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/integrate-shell-tools.yml) | Runs smoke tests and integration demos for vendored shell-tools. No GitHub API calls — pure runner execution. Weekly Sunday 03:00 UTC (after sync-shell-tools). | `integrate-shell-tools.yml` | dispatch |
 | List Chromium GitLab Repos [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/list-chromium-repos.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/list-chromium-repos.yml) | Lists all projects under the Chromium_Browser_OS_Deving GitLab group. Informational only — used to audit what has been mirrored. | `list-chromium-repos.yml` | dispatch |
@@ -181,17 +192,9 @@ Jump to any section:
 | Merge Repos into Monorepo [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/merge-to-monorepo.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/merge-to-monorepo.yml) | Merges multiple git repositories into a single monorepo, preserving full commit history, tags, and Git LFS objects. Manual dispatch only. | `merge-to-monorepo.yml` | dispatch |
 | Mirror Chain Dispatch [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/mirror-chain-dispatch.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/mirror-chain-dispatch.yml) | Agnostic mirror-chain backend. Dispatch-only on canonical instance — dedicated mirror workflows own schedules. Downstream forks without dedicated workflows may add a schedule. | `mirror-chain-dispatch.yml` | dispatch |
 | Onboard Repository [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/onboard-repo.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/onboard-repo.yml) | Onboards new repos into the ecosystem — applies labels, branch protection, topics, description, welcome issue, and dispatches sync-template/setup-osp-mirrors/sync-registered-imports. | `onboard-repo.yml` | push to `registered-imports.json`, `config/template-consumers.yml` · dispatch |
-| OTA Discover [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/ota-discover.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/ota-discover.yml) | Scans forks of fork-sync-all for .ota/config.yml with enabled: true and adds newly discovered repos to config/ota-registry.yml. | `ota-discover.yml` | dispatch |
-| OTA Opt-In [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/ota-opt-in.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/ota-opt-in.yml) | Propagated to opted-in forks. Fork owners run this once to create .ota/config.yml and open a registration PR against fork-sync-all's OTA registry. | `ota-opt-in.yml` | dispatch |
-| OTA Release [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/ota-release.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/ota-release.yml) | Triggered on semver tag push. Assembles and delivers OTA updates to all opted-in repos in config/ota-registry.yml, then updates CHANGELOG.md with release notes. | `ota-release.yml` | push to `(any)` · dispatch |
-| OTA Self-Update [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/ota-self-update.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/ota-self-update.yml) | Propagated to opted-in forks. Pulls the latest OTA release from fork-sync-all and applies it to the fork's workflow files. | `ota-self-update.yml` | dispatch |
 | Pipeline Telemetry [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/pipeline-telemetry.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/pipeline-telemetry.yml) | Post-run observability workflow. Fetches completed run data, builds a span tree (workflow→jobs→steps), computes Thoth-equivalent metrics, parses log severity, writes a step summary and trace artifact, and upserts a rolling metrics issue. | `pipeline-telemetry.yml` | `Full Chain Flush` completes · `Pre-Flush Prep` completes · `Mirror Interested-Deving-1896 → OSP` completes · `Mirror OSP → GitLab` completes · `Mirror to OpenOS-Project-Ecosystem-OOC` completes · `Reconcile Org References` completes · `Check OSP-Bound CI Status` completes · `Sync All Forks` completes · `Sync Registered Imports` completes · `Pre-Mirror CI Gate` completes · `Verify Mirror Integrity` completes · `Post-Flush Verification` completes · dispatch |
 | Pre-Mirror CI Gate [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/pre-mirror-ci-gate.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/pre-mirror-ci-gate.yml) | Checks CI status on all OSP-bound repos in Interested-Deving-1896 before mirroring. Dispatches resolve-failures for red repos, waits, then re-checks. Blocks the mirror if repos are still failing. | `pre-mirror-ci-gate.yml` | `Reconcile Org References` completes · dispatch |
-| Queue Manager [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/queue-manager.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/queue-manager.yml) | Deduplicates queued workflow runs (keeps newest per workflow) and evicts runs queued longer than STALE_QUEUE_MIN (default 25 min) to prevent quota exhaustion cascades. | `queue-manager.yml` | `Rate-Limit Re-trigger` completes · dispatch |
-| Quota Monitor [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/quota-monitor.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/quota-monitor.yml) | Polls GitHub quota and optionally dispatches a target workflow once quota recovers above a configurable threshold. Dispatch-only — never scheduled. | `quota-monitor.yml` | `Rate-Limit Re-trigger` completes · dispatch |
-| Quota Reserve [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/quota-reserve.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/quota-reserve.yml) | Cancels low-priority queued runs when remaining quota drops below RESERVE_FLOOR (default 1000). Uses per-workflow min_quota from workflow-quota-costs.yml for cost-aware cancellation. | `quota-reserve.yml` | dispatch |
 | Rebase PRs [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/rebase-prs.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/rebase-prs.yml) | Rebases open PRs in Interested-Deving-1896 onto their base branch when they fall behind, keeping PRs mergeable without manual intervention. | `rebase-prs.yml` | `Validate Config` completes · dispatch |
-| Refresh NotebookLM Auth [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/refresh-notebooklm-auth.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/refresh-notebooklm-auth.yml) | Rotates the short-lived __Secure-1PSIDTS cookie in NOTEBOOKLM_AUTH_JSON weekly and writes the updated state back to the repo secret. | `refresh-notebooklm-auth.yml` | dispatch |
 | Repo Manifest [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/repo-manifest.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/repo-manifest.yml) | Exports a manifest of all repos in an org, or imports repos from a manifest into a target GitHub org. Supports multi-platform bulk import. | `repo-manifest.yml` | dispatch |
 | Resolve CI Failures (Agnostic) [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/resolve-ci.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/resolve-ci.yml) | Agnostic CI failure resolver. Runs resolve-ci.sh for each enabled target in config/ci-check-targets.yml. GitHub targets use LLM analysis and auto-fix; GitLab targets retry failed/canceled pipelines.
  | `resolve-ci.yml` | `Check CI Status` completes · dispatch |
@@ -206,66 +209,11 @@ Jump to any section:
 | Sync Shell Tools Vendor [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/sync-shell-tools.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/sync-shell-tools.yml) | Sparse-clones each of the 24 shell-tools forks and copies entrypoint scripts into vendor/shell-tools/. One clone per tool (~2 REST calls each via git protocol). Weekly Sunday 02:00 UTC. | `sync-shell-tools.yml` | dispatch |
 | Sync UAA Vendor [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/sync-uaa-vendor.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/sync-uaa-vendor.yml) | Syncs vendor/unified-agnostic-api from Interested-Deving-1896/unified-agnostic-api via sparse checkout. Runs on push to vendor/unified-agnostic-api/** or weekly schedule. | `sync-uaa-vendor.yml` | push to `vendor/unified-agnostic-api/**`, `.github/workflows/sync-uaa-vendor.yml` · dispatch |
 | Test Time Format [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/test-time-format.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/test-time-format.yml) | Validates time_format.py portability across glibc, musl, and BSD libc. Runs on push/PR to time_format.py. | `test-time-format.yml` | push to `scripts/includes/time_format.py`, `.github/workflows/test-time-format.yml` · pull_request · dispatch |
-| Translate Docs [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/translate-docs.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/translate-docs.yml) | Translates DOCS/ mdBook pages into a target language using GitHub Models API. Writes translated files to DOCS/<lang>/ and upserts a language section in SUMMARY.md. | `translate-docs.yml` | `Deploy Book` completes · dispatch |
 | Trigger Artifact Mirror [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/trigger-artifact-mirror.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/trigger-artifact-mirror.yml) | Dispatches mirror-artifacts immediately when a release is published in this repo, so OSP and OOC receive the release without waiting for the next scheduled run. | `trigger-artifact-mirror.yml` | — |
-| Update Book Index [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/update-book-index.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/update-book-index.yml) | Regenerates DOCS/generated/ pages (source tree, glossary, workflow index) on push to main. Commits with [skip ci]. | `update-book-index.yml` | push to `.github/workflows/**`, `config/workflow-quota-costs.yml`, `config/workflow-priority-tiers.yml` (+8 more) · dispatch |
-| Update Quota Cost Registry [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/update-quota-costs.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/update-quota-costs.yml) | Reads quota-instrument records from job logs, computes observed p50/p95 REST costs per workflow, and commits updated values to workflow-quota-costs.yml weekly. | `update-quota-costs.yml` | dispatch |
 | Verify Fork Integrity [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/verify-fork-integrity.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/verify-fork-integrity.yml) | Compares this repo's default-branch HEAD against its upstream parent (or upstream_override from .ota/config.yml). Reports sync status; configurable hard-fail on drift. | `verify-fork-integrity.yml` | dispatch |
 | Verify Mirror Integrity [↗](https://github.com/Interested-Deving-1896/fork-sync-all/blob/main/.github/workflows/verify-mirror-integrity.yml) [▶ Run](https://github.com/Interested-Deving-1896/fork-sync-all/actions/workflows/verify-mirror-integrity.yml) | Compares default-branch HEAD SHAs between source and destination for all OSP-bound repos after a mirror stage. Reports mismatches as warnings; configurable hard-fail mode. | `verify-mirror-integrity.yml` | `Mirror Interested-Deving-1896 → OSP` completes · `Mirror to OpenOS-Project-Ecosystem-OOC` completes · `Mirror OSP → GitLab` completes · dispatch |
 
 ---
-
-<!-- FSA-GLOSSARY-START -->
-## Glossary
-
-> Key terms used in this document. Full glossary: [DOCS/generated/glossary.md](generated/glossary.md)
-
-**dispatch**
-: Manual `workflow_dispatch` trigger — run from the Actions UI or via `gh workflow run`.
-
-**workflow_run**
-: Trigger that fires when another named workflow completes. Used to chain workflows.
-
-**quota pre-flight**
-: Step that checks remaining REST quota before doing API work. Sets `skip=true` when below `MIN_QUOTA`.
-
-**MIN_QUOTA**
-: Minimum remaining REST quota required before a workflow proceeds. Per-workflow value from `workflow-quota-costs.yml`.
-
-**OSP**
-: OpenOS-Project-OSP — second org in the mirror chain (GitHub).
-
-**OOC**
-: OpenOS-Project-Ecosystem-OOC — third org in the mirror chain (GitHub).
-
-**mirror chain**
-: Three-org pipeline: Interested-Deving-1896 → OSP → GitLab.
-
-**DRY_RUN**
-: When `true`, scripts print what they would do without making changes.
-
-**SYNC_TOKEN**
-: Cross-org GitHub token. Shares the 5000 req/hr bucket with `GH_TOKEN`.
-
-**OTA**
-: Over-the-air update system delivering workflow/config updates to consumer repos.
-
-**pre-flush-prep**
-: Pre-flight workflow run before full-chain-flush.
-
-**full-chain-flush**
-: End-to-end pipeline: pre-flush-prep → mirror chain → post-flush-prep.
-
-**priority tiers**
-: Tier 1 CRITICAL → Tier 4 LOW. Controls queue-manager and quota-reserve cancellation order.
-
-**consumer repo**
-: Repo receiving template files from fork-sync-all via sync-template.sh.
-
-**OSP-bound repo**
-: Repo mirrored into OSP and managed by fork-sync-all.
-
-<!-- FSA-GLOSSARY-END -->
 
 ## Schedule Summary (UTC)
 

--- a/docs/workflow-triggers.txt
+++ b/docs/workflow-triggers.txt
@@ -371,14 +371,6 @@ Upstream Workflow Proposal  (upstream-workflow-proposal.yml)
   schedule   Weekly Mon 06:06  (6 6 * * 1)
   dispatch
 
-Update Workflow Triggers Doc  (update-workflow-triggers-doc.yml)
-  Regenerates docs/workflow-triggers.md and docs/workflow-triggers.txt
-  whenever a workflow file changes on main. Commits the result directly to
-  main.
-  push       .github/workflows/**
-  push       config/workflow-quota-costs.yml
-  dispatch
-
 
 FULL PIPELINE
 -------------
@@ -436,6 +428,148 @@ GitLab Critical Deploy  (critical-deploy-gitlab.yml)
   dispatch
 
 
+QUOTA & QUEUE MANAGEMENT
+------------------------
+
+Quota Reserve  (quota-reserve.yml)
+  Cancels low-priority queued runs when remaining quota drops below
+  RESERVE_FLOOR (default 1000). Uses per-workflow min_quota from workflow-
+  quota-costs.yml for cost-aware cancellation.
+  schedule   Every 30 min  (*/30 * * * *)
+  dispatch
+
+Queue Manager  (queue-manager.yml)
+  Deduplicates queued workflow runs (keeps newest per workflow) and evicts
+  runs queued longer than STALE_QUEUE_MIN (default 25 min) to prevent quota
+  exhaustion cascades.
+  schedule   Every 30 min  (*/30 * * * *)
+  workflow_run  Rate-Limit Re-trigger
+  dispatch
+
+Quota Monitor  (quota-monitor.yml)
+  Polls GitHub quota and optionally dispatches a target workflow once quota
+  recovers above a configurable threshold. Dispatch-only — never scheduled.
+  workflow_run  Rate-Limit Re-trigger
+  dispatch
+
+Update Quota Cost Registry  (update-quota-costs.yml)
+  Reads quota-instrument records from job logs, computes observed p50/p95 REST
+  costs per workflow, and commits updated values to workflow-quota-costs.yml
+  weekly.
+  schedule   Weekly Mon 08:00  (0 8 * * 1)
+  dispatch
+
+
+OTA SYSTEM
+----------
+
+OTA Release  (ota-release.yml)
+  Triggered on semver tag push. Assembles and delivers OTA updates to all
+  opted-in repos in config/ota-registry.yml, then updates CHANGELOG.md with
+  release notes.
+  push       (any)
+  dispatch
+
+OTA Self-Update  (ota-self-update.yml)
+  Propagated to opted-in forks. Pulls the latest OTA release from fork-sync-
+  all and applies it to the fork's workflow files.
+  schedule   Weekly Mon 05:15  (15 5 * * 1)
+  dispatch
+
+OTA Discover  (ota-discover.yml)
+  Scans forks of fork-sync-all for .ota/config.yml with enabled: true and adds
+  newly discovered repos to config/ota-registry.yml.
+  schedule   Daily 06:38  (38 6 * * *)
+  dispatch
+
+OTA Opt-In  (ota-opt-in.yml)
+  Propagated to opted-in forks. Fork owners run this once to create
+  .ota/config.yml and open a registration PR against fork-sync-all's OTA
+  registry.
+  dispatch
+
+
+DOCUMENTATION & PUBLISHING
+--------------------------
+
+Deploy Book  (deploy-book.yml)
+  Builds the mdBook documentation site from DOCS/ and deploys it to GitHub
+  Pages at interested-deving-1896.github.io/fork-sync-all/.
+  push       DOCS/**
+  push       book.toml
+  push       README.md
+  push       AGENTS.md
+  push       .github/workflows/deploy-book.yml
+  dispatch
+
+Generate Book Pages  (generate-book-pages.yml)
+  Regenerates DOCS/generated/ pages from config sources (workflow-quota-
+  costs.yml, priority-tiers.yml, gitlab-subgroups.yml, registered-
+  imports.json) and commits the result.
+  push       config/workflow-quota-costs.yml
+  push       config/workflow-priority-tiers.yml
+  push       config/gitlab-subgroups.yml
+  push       registered-imports.json
+  push       dep-graph/origins.md
+  push       scripts/generate-book-pages.py
+  dispatch
+
+Update Book Index  (update-book-index.yml)
+  Regenerates DOCS/generated/ pages (source tree, glossary, workflow index) on
+  push to main. Commits with [skip ci].
+  push       .github/workflows/**
+  push       config/workflow-quota-costs.yml
+  push       config/workflow-priority-tiers.yml
+  push       config/gitlab-subgroups.yml
+  push       registered-imports.json
+  push       scripts/generate-book-pages.py
+  push       dep-graph/origins.md
+  push       docs/workflow-triggers.md
+  push       DOCS/**
+  push       assets/brand/**
+  push       vendor/book-engine/**
+  dispatch
+
+Export Book (Multi-Engine)  (book-export.yml)
+  Exports the book to one or all supported engines (mdBook, MkDocs,
+  Docusaurus, Pandoc). Manual dispatch only.
+  dispatch
+
+GitBook OSS  (gitbook-oss.yml)
+  Manages the GitBook OSS (Next.js) renderer. Actions: build, export, update,
+  dev-info. Weekly update check on Mondays.
+  schedule   Weekly Mon 04:17  (17 4 * * 1)
+  dispatch
+
+Translate Docs  (translate-docs.yml)
+  Translates DOCS/ mdBook pages into a target language using GitHub Models
+  API. Writes translated files to DOCS/<lang>/ and upserts a language section
+  in SUMMARY.md.
+  schedule   15 11 */2 * *  (15 11 */2 * *)
+  workflow_run  Deploy Book
+  dispatch
+
+Generate NotebookLM Content  (generate-notebooklm.yml)
+  Generates NotebookLM content artifacts (audio, video, slides, infographic,
+  quiz, flashcards, report) for a given notebook and uploads them to a GitHub
+  Release.
+  dispatch
+
+Refresh NotebookLM Auth  (refresh-notebooklm-auth.yml)
+  Rotates the short-lived __Secure-1PSIDTS cookie in NOTEBOOKLM_AUTH_JSON
+  weekly and writes the updated state back to the repo secret.
+  schedule   Weekly Tue 06:17  (17 6 * * 2)
+  dispatch
+
+Update Workflow Triggers Doc  (update-workflow-triggers-doc.yml)
+  Regenerates docs/workflow-triggers.md and docs/workflow-triggers.txt
+  whenever a workflow file changes on main. Commits the result directly to
+  main.
+  push       .github/workflows/**
+  push       config/workflow-quota-costs.yml
+  dispatch
+
+
 UTILITY / ON-DEMAND
 -------------------
 
@@ -445,11 +579,6 @@ Auto-merge PRs  (auto-merge-prs.yml)
   auto-merge vs poll).
   schedule   Every 6h at :55  (55 */6 * * *)
   workflow_run  Validate Config
-  dispatch
-
-Export Book (Multi-Engine)  (book-export.yml)
-  Exports the book to one or all supported engines (mdBook, MkDocs,
-  Docusaurus, Pandoc). Manual dispatch only.
   dispatch
 
 Cancel Stale Runs  (cancel-stale-runs.yml)
@@ -497,16 +626,6 @@ Clone Org  (clone-org.yml)
 Create OOC GitLab Subgroups  (create-ooc-subgroups.yml)
   Creates the GitLab subgroup structure for OpenOS-Project-Ecosystem-OOC and
   records the resulting subgroup IDs.
-  dispatch
-
-Deploy Book  (deploy-book.yml)
-  Builds the mdBook documentation site from DOCS/ and deploys it to GitHub
-  Pages at interested-deving-1896.github.io/fork-sync-all/.
-  push       DOCS/**
-  push       book.toml
-  push       README.md
-  push       AGENTS.md
-  push       .github/workflows/deploy-book.yml
   dispatch
 
 Devcontainer SDK  (devcontainer-sdk.yml)
@@ -573,24 +692,6 @@ Full Audit  (full-audit.yml)
   schedule   Weekly Mon 04:00  (0 4 * * 1)
   dispatch
 
-Generate Book Pages  (generate-book-pages.yml)
-  Regenerates DOCS/generated/ pages from config sources (workflow-quota-
-  costs.yml, priority-tiers.yml, gitlab-subgroups.yml, registered-
-  imports.json) and commits the result.
-  push       config/workflow-quota-costs.yml
-  push       config/workflow-priority-tiers.yml
-  push       config/gitlab-subgroups.yml
-  push       registered-imports.json
-  push       dep-graph/origins.md
-  push       scripts/generate-book-pages.py
-  dispatch
-
-Generate NotebookLM Content  (generate-notebooklm.yml)
-  Generates NotebookLM content artifacts (audio, video, slides, infographic,
-  quiz, flashcards, report) for a given notebook and uploads them to a GitHub
-  Release.
-  dispatch
-
 Generate Repo Descriptions  (generate-repo-descriptions.yml)
   AI-powered per-file description generator. Fetches file tree (1 REST call)
   then reads each file for context (1 REST call per file) before calling
@@ -605,12 +706,6 @@ Git Platform Sync  (git-platform-sync.yml)
   schedule   Daily 09:23  (23 9 * * *)
   schedule   Daily 04:27  (27 4 * * *)
   workflow_run  Add Mirror Repo
-  dispatch
-
-GitBook OSS  (gitbook-oss.yml)
-  Manages the GitBook OSS (Next.js) renderer. Actions: build, export, update,
-  dev-info. Weekly update check on Mondays.
-  schedule   Weekly Mon 04:17  (17 4 * * 1)
   dispatch
 
 GitLab Storage Scan  (gl-storage-scan.yml)
@@ -663,31 +758,6 @@ Onboard Repository  (onboard-repo.yml)
   push       config/template-consumers.yml
   dispatch
 
-OTA Discover  (ota-discover.yml)
-  Scans forks of fork-sync-all for .ota/config.yml with enabled: true and adds
-  newly discovered repos to config/ota-registry.yml.
-  schedule   Daily 06:38  (38 6 * * *)
-  dispatch
-
-OTA Opt-In  (ota-opt-in.yml)
-  Propagated to opted-in forks. Fork owners run this once to create
-  .ota/config.yml and open a registration PR against fork-sync-all's OTA
-  registry.
-  dispatch
-
-OTA Release  (ota-release.yml)
-  Triggered on semver tag push. Assembles and delivers OTA updates to all
-  opted-in repos in config/ota-registry.yml, then updates CHANGELOG.md with
-  release notes.
-  push       (any)
-  dispatch
-
-OTA Self-Update  (ota-self-update.yml)
-  Propagated to opted-in forks. Pulls the latest OTA release from fork-sync-
-  all and applies it to the fork's workflow files.
-  schedule   Weekly Mon 05:15  (15 5 * * 1)
-  dispatch
-
 Pipeline Telemetry  (pipeline-telemetry.yml)
   Post-run observability workflow. Fetches completed run data, builds a span
   tree (workflow→jobs→steps), computes Thoth-equivalent metrics, parses log
@@ -714,38 +784,11 @@ Pre-Mirror CI Gate  (pre-mirror-ci-gate.yml)
   workflow_run  Reconcile Org References
   dispatch
 
-Queue Manager  (queue-manager.yml)
-  Deduplicates queued workflow runs (keeps newest per workflow) and evicts
-  runs queued longer than STALE_QUEUE_MIN (default 25 min) to prevent quota
-  exhaustion cascades.
-  schedule   Every 30 min  (*/30 * * * *)
-  workflow_run  Rate-Limit Re-trigger
-  dispatch
-
-Quota Monitor  (quota-monitor.yml)
-  Polls GitHub quota and optionally dispatches a target workflow once quota
-  recovers above a configurable threshold. Dispatch-only — never scheduled.
-  workflow_run  Rate-Limit Re-trigger
-  dispatch
-
-Quota Reserve  (quota-reserve.yml)
-  Cancels low-priority queued runs when remaining quota drops below
-  RESERVE_FLOOR (default 1000). Uses per-workflow min_quota from workflow-
-  quota-costs.yml for cost-aware cancellation.
-  schedule   Every 30 min  (*/30 * * * *)
-  dispatch
-
 Rebase PRs  (rebase-prs.yml)
   Rebases open PRs in Interested-Deving-1896 onto their base branch when they
   fall behind, keeping PRs mergeable without manual intervention.
   schedule   10 5 */2 * *  (10 5 */2 * *)
   workflow_run  Validate Config
-  dispatch
-
-Refresh NotebookLM Auth  (refresh-notebooklm-auth.yml)
-  Rotates the short-lived __Secure-1PSIDTS cookie in NOTEBOOKLM_AUTH_JSON
-  weekly and writes the updated state back to the repo secret.
-  schedule   Weekly Tue 06:17  (17 6 * * 2)
   dispatch
 
 Repo Manifest  (repo-manifest.yml)
@@ -839,41 +882,10 @@ Test Time Format  (test-time-format.yml)
   pull_request
   dispatch
 
-Translate Docs  (translate-docs.yml)
-  Translates DOCS/ mdBook pages into a target language using GitHub Models
-  API. Writes translated files to DOCS/<lang>/ and upserts a language section
-  in SUMMARY.md.
-  schedule   15 11 */2 * *  (15 11 */2 * *)
-  workflow_run  Deploy Book
-  dispatch
-
 Trigger Artifact Mirror  (trigger-artifact-mirror.yml)
   Dispatches mirror-artifacts immediately when a release is published in this
   repo, so OSP and OOC receive the release without waiting for the next
   scheduled run.
-
-Update Book Index  (update-book-index.yml)
-  Regenerates DOCS/generated/ pages (source tree, glossary, workflow index) on
-  push to main. Commits with [skip ci].
-  push       .github/workflows/**
-  push       config/workflow-quota-costs.yml
-  push       config/workflow-priority-tiers.yml
-  push       config/gitlab-subgroups.yml
-  push       registered-imports.json
-  push       scripts/generate-book-pages.py
-  push       dep-graph/origins.md
-  push       docs/workflow-triggers.md
-  push       DOCS/**
-  push       assets/brand/**
-  push       vendor/book-engine/**
-  dispatch
-
-Update Quota Cost Registry  (update-quota-costs.yml)
-  Reads quota-instrument records from job logs, computes observed p50/p95 REST
-  costs per workflow, and commits updated values to workflow-quota-costs.yml
-  weekly.
-  schedule   Weekly Mon 08:00  (0 8 * * 1)
-  dispatch
 
 Verify Fork Integrity  (verify-fork-integrity.yml)
   Compares this repo's default-branch HEAD against its upstream parent (or

--- a/scripts/generate-workflow-triggers-doc.py
+++ b/scripts/generate-workflow-triggers-doc.py
@@ -58,7 +58,6 @@ GROUPS = [
         "sync-template", "update-infra-deps", "upstream-workflow-proposal",
         "generate-dep-graph", "token-health", "rotate-token",
         "validate-config", "cancel-post-rotation",
-        "update-workflow-triggers-doc",
     ]),
     ("Full Pipeline", [
         "pre-flush-prep",
@@ -66,8 +65,25 @@ GROUPS = [
         "post-flush-prep",
         "critical-deploy",
     ]),
+    ("Quota & Queue Management", [
+        "quota-reserve", "queue-manager", "quota-monitor",
+        "update-quota-costs",
+    ]),
+    ("OTA System", [
+        "ota-release", "ota-reconcile", "ota-self-update",
+        "ota-discover", "ota-opt-in",
+    ]),
+    ("Documentation & Publishing", [
+        "deploy-book", "generate-book-pages", "update-book-index",
+        "book-export", "gitbook-oss", "translate-docs",
+        "generate-notebooklm", "refresh-notebooklm",
+        "update-workflow-triggers-doc",
+    ]),
+    ("AI & Cost Tracking", [
+        "track-agent-costs", "sync-agent-prices",
+    ]),
     ("Utility / On-Demand", [
-        "cancel-stale-runs", "quota-monitor", "clone-org",
+        "cancel-stale-runs", "clone-org",
         "fork-neon-repos", "merge-to-monorepo", "repo-manifest",
         "sync-eggs-docs", "shallow-reclone", "gl-storage-scan",
         "list-chromium", "setup-gitlab-schedules", "trigger-artifact",
@@ -126,7 +142,6 @@ GROUP_SORT_KEYS: dict[str, list[str]] = {
         "rotate-token",
         "cancel-post-rotation",
         "upstream-workflow-proposal",
-        "update-workflow-triggers-doc",
     ],
     # Full pipeline: prep → flush → verify → emergency fast-lane
     "Full Pipeline": [
@@ -134,6 +149,33 @@ GROUP_SORT_KEYS: dict[str, list[str]] = {
         "full-chain-flush",
         "post-flush-prep",
         "critical-deploy",
+    ],
+    # Quota: reserve (enforcement) → queue (dedup) → monitor (health) → costs (observability)
+    "Quota & Queue Management": [
+        "quota-reserve",
+        "queue-manager",
+        "quota-monitor",
+        "update-quota-costs",
+    ],
+    # OTA: release (push delivery) → reconcile (fallback) → self-update (pull) → discover → opt-in
+    "OTA System": [
+        "ota-release",
+        "ota-reconcile",
+        "ota-self-update",
+        "ota-discover",
+        "ota-opt-in",
+    ],
+    # Docs: build → generate → index → export → gitbook → translate → notebooklm → triggers
+    "Documentation & Publishing": [
+        "deploy-book",
+        "generate-book-pages",
+        "update-book-index",
+        "book-export",
+        "gitbook-oss",
+        "translate-docs",
+        "generate-notebooklm",
+        "refresh-notebooklm",
+        "update-workflow-triggers-doc",
     ],
 }
 
@@ -475,6 +517,95 @@ def load_synopses(repo_root: str) -> dict:
         return {}
 
 
+# ── Collect live counts from config files ────────────────────────────────────
+
+def collect_counts(repo_root: str, wf_count: int) -> dict:
+    """Return a dict of live counts read from config files."""
+    import json as _json
+
+    counts = {"workflows": wf_count}
+
+    # Registered imports
+    try:
+        imports_path = os.path.join(repo_root, "registered-imports.json")
+        with open(imports_path) as f:
+            counts["registered_imports"] = len(_json.load(f))
+    except Exception:
+        counts["registered_imports"] = None
+
+    # GitLab subgroups + mirrored repos
+    try:
+        sg_path = os.path.join(repo_root, "config", "gitlab-subgroups.yml")
+        with open(sg_path) as f:
+            sg_data = yaml.safe_load(f) or {}
+        subgroups = sg_data.get("subgroups", {})
+        counts["gitlab_subgroups"] = len(subgroups)
+        counts["gitlab_repos"] = sum(
+            len(v.get("repos", [])) for v in subgroups.values() if isinstance(v, dict)
+        )
+    except Exception:
+        counts["gitlab_subgroups"] = None
+        counts["gitlab_repos"] = None
+
+    # Template consumers (non-disabled)
+    try:
+        tc_path = os.path.join(repo_root, "config", "template-consumers.yml")
+        with open(tc_path) as f:
+            tc_data = yaml.safe_load(f) or {}
+        consumers = [c for c in (tc_data.get("consumers") or []) if not c.get("disabled")]
+        counts["template_consumers"] = len(consumers)
+    except Exception:
+        counts["template_consumers"] = None
+
+    return counts
+
+
+# ── Update README.md FSA-COUNTS block ────────────────────────────────────────
+
+def update_readme_counts(repo_root: str, counts: dict, now: str) -> bool:
+    """
+    Replace the <!-- FSA-COUNTS-START --> … <!-- FSA-COUNTS-END --> block in
+    README.md with freshly computed counts. Returns True if the file changed.
+    """
+    readme_path = os.path.join(repo_root, "README.md")
+    if not os.path.exists(readme_path):
+        return False
+
+    with open(readme_path) as f:
+        original = f.read()
+
+    def _fmt(v):
+        return str(v) if v is not None else "—"
+
+    block_lines = [
+        f"<!-- FSA-COUNTS-START — updated {now} by generate-workflow-triggers-doc.py -->",
+        f"| | |",
+        f"|---|---|",
+        f"| Workflows | **{_fmt(counts['workflows'])}** |",
+        f"| Registered imports | **{_fmt(counts['registered_imports'])}** |",
+        f"| Template consumers | **{_fmt(counts['template_consumers'])}** |",
+        f"| GitLab subgroups | **{_fmt(counts['gitlab_subgroups'])}** |",
+        f"| GitLab repos mirrored | **{_fmt(counts['gitlab_repos'])}** |",
+        f"<!-- FSA-COUNTS-END -->",
+    ]
+    new_block = "\n".join(block_lines)
+
+    # Replace existing block if present
+    pattern = r"<!-- FSA-COUNTS-START[^>]*-->.*?<!-- FSA-COUNTS-END -->"
+    if re.search(pattern, original, re.DOTALL):
+        updated = re.sub(pattern, new_block, original, flags=re.DOTALL)
+    else:
+        # Block not present — nothing to update (README must be written first)
+        return False
+
+    if updated == original:
+        return False
+
+    with open(readme_path, "w") as f:
+        f.write(updated)
+    return True
+
+
 # ── Main ──────────────────────────────────────────────────────────────────────
 def main():
     repo_root = sys.argv[1] if len(sys.argv) > 1 else os.path.join(os.path.dirname(__file__), "..")
@@ -501,7 +632,7 @@ def main():
         group = assign_group(wf["file"])
         grouped.setdefault(group, []).append(wf)
 
-    # Generate and write
+    # Generate and write triggers doc
     md_path  = os.path.join(docs_dir, "workflow-triggers.md")
     txt_path = os.path.join(docs_dir, "workflow-triggers.txt")
 
@@ -516,6 +647,11 @@ def main():
     print(f"Written: {md_path}")
     print(f"Written: {txt_path}")
     print(f"Workflows processed: {len(all_wfs)}")
+
+    # Update README.md counts block
+    counts = collect_counts(repo_root, len(all_wfs))
+    if update_readme_counts(repo_root, counts, now):
+        print(f"Updated: {os.path.join(repo_root, 'README.md')} (FSA-COUNTS block)")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

**`README.md`** — modernised structure, updated workflow count and descriptions, unified trigger category labels.

**`scripts/generate-workflow-triggers-doc.py`** — extended with unified trigger category logic (+144 lines). Trigger categories are now consistent across the generated doc.

**`docs/workflow-triggers.md` / `docs/workflow-triggers.txt`** — regenerated with updated categories and README-aligned descriptions.

## Type

- [x] Documentation

## Checklist

- [x] Validator passes
- [x] Tests pass
- [x] No secrets or tokens committed