### PR TITLE
fix(template): correct fsa-api propagation to consumer repos

### DIFF
--- a/.github/workflows/audit-arch-repos.yml
+++ b/.github/workflows/audit-arch-repos.yml
@@ -1,0 +1,54 @@
+name: Audit Arch Repos
+
+# Audits which expected repos exist vs are missing across Interested-Deving-1896.
+# Outputs a summary of existing, missing, and unexpected repos.
+
+on:
+  schedule:
+    - cron: '0 4 * * 1'  # Weekly Monday 04:00 UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Report only — do not write outputs'
+        type: boolean
+        default: false
+
+concurrency:
+  group: audit-arch-repos
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Quota pre-flight
+        id: quota
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+        run: |
+          remaining=$(curl -sf -H "Authorization: token $GH_TOKEN" \
+            https://api.github.com/rate_limit | python3 -c \
+            "import json,sys; print(json.load(sys.stdin)['resources']['core']['remaining'])" 2>/dev/null || echo 0)
+          echo "remaining=$remaining" >> "$GITHUB_OUTPUT"
+          [[ "$remaining" -lt 500 ]] && echo "skip=true" >> "$GITHUB_OUTPUT" || echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Audit arch repos
+        if: steps.quota.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: bash scripts/audit-arch-repos.sh
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/bdfs-dev-btrfs.yml
+++ b/.github/workflows/bdfs-dev-btrfs.yml
@@ -1,0 +1,49 @@
+name: BDFS Dev — BTRFS Backend
+
+# Creates a writable BTRFS snapshot of a source path as a bdfs dev workspace.
+# The source must be a BTRFS subvolume or a directory on a BTRFS filesystem.
+
+on:
+  workflow_dispatch:
+    inputs:
+      source:
+        description: 'Source BTRFS subvolume or directory path'
+        type: string
+        required: true
+      workspace:
+        description: 'Workspace name (default: auto-generated)'
+        type: string
+        default: ''
+      dry_run:
+        description: 'Report what would be created — do not snapshot'
+        type: boolean
+        default: false
+
+concurrency:
+  group: bdfs-dev-btrfs-${{ inputs.workspace || 'default' }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  dev-btrfs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Run bdfs-dev-btrfs
+        env:
+          BDFS_SOURCE: ${{ inputs.source }}
+          BDFS_WORKSPACE: ${{ inputs.workspace || '' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: bash scripts/bdfs-dev-btrfs.sh
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/bdfs-dev-dwarfs.yml
+++ b/.github/workflows/bdfs-dev-dwarfs.yml
@@ -1,0 +1,54 @@
+name: BDFS Dev — DwarFS Backend
+
+# Mounts a DwarFS image read-only as the lower layer of an overlayfs,
+# with a writable upper layer (BTRFS subvolume if available, tmpfs otherwise).
+
+on:
+  workflow_dispatch:
+    inputs:
+      image:
+        description: 'Path to DwarFS image file'
+        type: string
+        required: true
+      workspace:
+        description: 'Workspace mountpoint (default: auto-generated)'
+        type: string
+        default: ''
+      upper_path:
+        description: 'Persist upper layer to this path (leave blank for tmpfs)'
+        type: string
+        default: ''
+      dry_run:
+        description: 'Report what would be mounted — do not mount'
+        type: boolean
+        default: false
+
+concurrency:
+  group: bdfs-dev-dwarfs-${{ inputs.workspace || 'default' }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  dev-dwarfs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Run bdfs-dev-dwarfs
+        env:
+          BDFS_IMAGE: ${{ inputs.image }}
+          BDFS_WORKSPACE: ${{ inputs.workspace || '' }}
+          BDFS_UPPER: ${{ inputs.upper_path || '' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: bash scripts/bdfs-dev-dwarfs.sh
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/bdfs-dev-overlay.yml
+++ b/.github/workflows/bdfs-dev-overlay.yml
@@ -1,0 +1,55 @@
+name: BDFS Dev — Overlay Backend
+
+# Creates an overlayfs workspace with the source path as the read-only lower
+# layer and a tmpfs or directory as the writable upper layer.
+# Works on any filesystem — no BTRFS required. Ephemeral by default.
+
+on:
+  workflow_dispatch:
+    inputs:
+      source:
+        description: 'Source path to use as read-only lower layer'
+        type: string
+        required: true
+      workspace:
+        description: 'Workspace mountpoint (default: auto-generated)'
+        type: string
+        default: ''
+      upper_path:
+        description: 'Persist upper layer to this path (leave blank for tmpfs)'
+        type: string
+        default: ''
+      dry_run:
+        description: 'Report what would be mounted — do not mount'
+        type: boolean
+        default: false
+
+concurrency:
+  group: bdfs-dev-overlay-${{ inputs.workspace || 'default' }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  dev-overlay:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Run bdfs-dev-overlay
+        env:
+          BDFS_SOURCE: ${{ inputs.source }}
+          BDFS_WORKSPACE: ${{ inputs.workspace || '' }}
+          BDFS_UPPER: ${{ inputs.upper_path || '' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: bash scripts/bdfs-dev-overlay.sh
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/bdfs-dev.yml
+++ b/.github/workflows/bdfs-dev.yml
@@ -1,0 +1,61 @@
+name: BDFS Dev Workspace
+
+# Creates and manages mutable development workspaces on top of immutable
+# filesystem roots using the bdfs dev framework (btrfs / overlay / dwarfs backends).
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Workspace action'
+        type: choice
+        options: [create, drop, list, commit, status]
+        default: list
+      backend:
+        description: 'Storage backend'
+        type: choice
+        options: [auto, btrfs, overlay, dwarfs]
+        default: auto
+      source:
+        description: 'Source path or DwarFS image (for create)'
+        type: string
+        default: ''
+      workspace:
+        description: 'Workspace name or mountpoint (for drop/commit/status)'
+        type: string
+        default: ''
+      dry_run:
+        description: 'Report what would happen — do not modify state'
+        type: boolean
+        default: false
+
+concurrency:
+  group: bdfs-dev-${{ inputs.workspace || 'default' }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  dev:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Run bdfs dev
+        env:
+          BDFS_ACTION: ${{ inputs.action || 'list' }}
+          BDFS_BACKEND: ${{ inputs.backend || 'auto' }}
+          BDFS_SOURCE: ${{ inputs.source || '' }}
+          BDFS_WORKSPACE: ${{ inputs.workspace || '' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: bash scripts/bdfs-dev.sh
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,6 @@
 name: Build
 on:
+  workflow_dispatch: {}
   push:
     branches:
       - master

--- a/.github/workflows/cancel-post-rotation.yml
+++ b/.github/workflows/cancel-post-rotation.yml
@@ -12,6 +12,7 @@ name: Cancel Runs After Token Rotation
 #   - Quota pre-flight: skips if core remaining < 500
 
 on:
+  workflow_dispatch: {}
   workflow_run:
     workflows:
       - "Rotate Secret Token"

--- a/.github/workflows/check-ooc-ci.yml
+++ b/.github/workflows/check-ooc-ci.yml
@@ -1,0 +1,67 @@
+name: Check OOC CI Status
+
+# Checks the CI status of the default branch HEAD for every OOC-bound repo.
+# Reports failing repos to the step summary.
+
+on:
+  schedule:
+    - cron: '30 6 * * *'  # Daily 06:30 UTC — offset from check-osp-ci
+  workflow_dispatch:
+    inputs:
+      repo_filter:
+        description: 'Substring filter on repo name (leave blank for all)'
+        type: string
+        default: ''
+      dry_run:
+        description: 'Report only — do not post comments or labels'
+        type: boolean
+        default: false
+      rate_limit_rerun:
+        description: 'Set by rate-limit-rerun — prevents re-trigger loops'
+        type: string
+        default: 'false'
+
+concurrency:
+  group: check-ooc-ci
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    if: inputs.rate_limit_rerun != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Quota pre-flight
+        id: quota
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+        run: |
+          remaining=$(curl -sf -H "Authorization: token $GH_TOKEN" \
+            https://api.github.com/rate_limit | python3 -c \
+            "import json,sys; print(json.load(sys.stdin)['resources']['core']['remaining'])" 2>/dev/null || echo 0)
+          echo "remaining=$remaining" >> "$GITHUB_OUTPUT"
+          [[ "$remaining" -lt 500 ]] && echo "skip=true" >> "$GITHUB_OUTPUT" || echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Check OOC CI
+        if: steps.quota.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+          GITHUB_OWNER: OpenOS-Project-Ecosystem-OOC
+          REPO_FILTER: ${{ inputs.repo_filter || '' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          BUDGET_MINUTES: "55"
+          MIN_QUOTA: "500"
+        run: bash scripts/check-ooc-ci.sh
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,6 +12,7 @@
 name: "CodeQL"
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [ "master" ]
   pull_request:

--- a/.github/workflows/flush-active-watchdog.yml
+++ b/.github/workflows/flush-active-watchdog.yml
@@ -15,6 +15,7 @@ name: Flush Active Watchdog
 # cleared after any protected pipeline completes.
 
 on:
+  workflow_dispatch: {}
   workflow_run:
     workflows:
       - "Flush Lifecycle Manager"

--- a/.github/workflows/merge-ready-prs.yml
+++ b/.github/workflows/merge-ready-prs.yml
@@ -1,0 +1,58 @@
+name: Merge Ready PRs
+
+# Waits for CI then merges all open PRs with passing checks across
+# fork-sync-all and btrfs-dwarfs-framework.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Report which PRs would be merged — do not merge'
+        type: boolean
+        default: true
+      repos:
+        description: 'Comma-separated list of owner/repo to check (default: hardcoded list in script)'
+        type: string
+        default: ''
+
+concurrency:
+  group: merge-ready-prs
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Quota pre-flight
+        id: quota
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+        run: |
+          remaining=$(curl -sf -H "Authorization: token $GH_TOKEN" \
+            https://api.github.com/rate_limit | python3 -c \
+            "import json,sys; print(json.load(sys.stdin)['resources']['core']['remaining'])" 2>/dev/null || echo 0)
+          echo "remaining=$remaining" >> "$GITHUB_OUTPUT"
+          [[ "$remaining" -lt 500 ]] && echo "skip=true" >> "$GITHUB_OUTPUT" || echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Merge ready PRs
+        if: steps.quota.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run || 'true' }}
+          REPOS: ${{ inputs.repos || '' }}
+        run: bash scripts/merge-ready-prs.sh
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/mirror-flatpak.yml
+++ b/.github/workflows/mirror-flatpak.yml
@@ -1,0 +1,71 @@
+name: Mirror Flatpak Repo
+
+# Builds and publishes a self-hosted Flatpak repo on GitHub Pages.
+# For each OSP/OOC repo with a Flatpak manifest, downloads the bundle
+# from the upstream release and imports it into the org's flatpak-repo.
+
+on:
+  schedule:
+    - cron: '0 5 * * *'  # Daily 05:00 UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Report which repos would be mirrored — do not push'
+        type: boolean
+        default: false
+      repo_filter:
+        description: 'Substring filter on repo name (leave blank for all)'
+        type: string
+        default: ''
+      rate_limit_rerun:
+        description: 'Set by rate-limit-rerun — prevents re-trigger loops'
+        type: string
+        default: 'false'
+
+concurrency:
+  group: mirror-flatpak
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  mirror:
+    if: inputs.rate_limit_rerun != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install Flatpak tools
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y flatpak flatpak-builder ostree
+
+      - name: Quota pre-flight
+        id: quota
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+        run: |
+          remaining=$(curl -sf -H "Authorization: token $GH_TOKEN" \
+            https://api.github.com/rate_limit | python3 -c \
+            "import json,sys; print(json.load(sys.stdin)['resources']['core']['remaining'])" 2>/dev/null || echo 0)
+          echo "remaining=$remaining" >> "$GITHUB_OUTPUT"
+          [[ "$remaining" -lt 500 ]] && echo "skip=true" >> "$GITHUB_OUTPUT" || echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Mirror Flatpak repo
+        if: steps.quota.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          REPO_FILTER: ${{ inputs.repo_filter || '' }}
+          BUDGET_MINUTES: "115"
+        run: bash scripts/mirror-flatpak.sh
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/mirror-ghcr.yml
+++ b/.github/workflows/mirror-ghcr.yml
@@ -1,0 +1,74 @@
+name: Mirror GHCR Images
+
+# Re-tags and pushes GHCR images from an upstream owner into OSP and OOC orgs.
+
+on:
+  schedule:
+    - cron: '0 3 * * *'  # Daily 03:00 UTC
+  workflow_dispatch:
+    inputs:
+      upstream_owner:
+        description: 'Source GHCR owner (e.g. upstream-org)'
+        type: string
+        required: true
+      dry_run:
+        description: 'Report which images would be mirrored — do not push'
+        type: boolean
+        default: false
+      rate_limit_rerun:
+        description: 'Set by rate-limit-rerun — prevents re-trigger loops'
+        type: string
+        default: 'false'
+
+concurrency:
+  group: mirror-ghcr
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  mirror:
+    if: inputs.rate_limit_rerun != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.SYNC_TOKEN }}
+
+      - name: Quota pre-flight
+        id: quota
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+        run: |
+          remaining=$(curl -sf -H "Authorization: token $GH_TOKEN" \
+            https://api.github.com/rate_limit | python3 -c \
+            "import json,sys; print(json.load(sys.stdin)['resources']['core']['remaining'])" 2>/dev/null || echo 0)
+          echo "remaining=$remaining" >> "$GITHUB_OUTPUT"
+          [[ "$remaining" -lt 500 ]] && echo "skip=true" >> "$GITHUB_OUTPUT" || echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Mirror GHCR images
+        if: steps.quota.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+          UPSTREAM_OWNER: ${{ inputs.upstream_owner || '' }}
+          OSP_ORG: OpenOS-Project-OSP
+          OOC_ORG: OpenOS-Project-Ecosystem-OOC
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          BUDGET_MINUTES: "115"
+        run: bash scripts/mirror-ghcr.sh
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/mirror-orgs-watchdog.yml
+++ b/.github/workflows/mirror-orgs-watchdog.yml
@@ -13,6 +13,7 @@ name: Mirror Watchdog
 #   Mirror Artifacts                     (mirror-artifacts.yml)      — hourly at :00
 
 on:
+  workflow_dispatch: {}
   workflow_run:
     workflows:
       - "Mirror Interested-Deving-1896 → OSP"

--- a/.github/workflows/mirror-pypi.yml
+++ b/.github/workflows/mirror-pypi.yml
@@ -1,0 +1,72 @@
+name: Mirror PyPI Packages
+
+# Re-publishes PyPI packages from upstream repos to OSP/OOC with
+# org-prefixed package names (e.g. osp-linux-kernel-manager).
+
+on:
+  workflow_dispatch:
+    inputs:
+      upstream_owner:
+        description: 'Source GitHub org/user whose PyPI packages to mirror'
+        type: string
+        required: true
+      dry_run:
+        description: 'Report which packages would be published — do not upload'
+        type: boolean
+        default: true
+      repo_filter:
+        description: 'Substring filter on repo name (leave blank for all)'
+        type: string
+        default: ''
+
+concurrency:
+  group: mirror-pypi
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write  # OIDC trusted publishing
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install build tools
+        run: pip install build twine
+
+      - name: Quota pre-flight
+        id: quota
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+        run: |
+          remaining=$(curl -sf -H "Authorization: token $GH_TOKEN" \
+            https://api.github.com/rate_limit | python3 -c \
+            "import json,sys; print(json.load(sys.stdin)['resources']['core']['remaining'])" 2>/dev/null || echo 0)
+          echo "remaining=$remaining" >> "$GITHUB_OUTPUT"
+          [[ "$remaining" -lt 500 ]] && echo "skip=true" >> "$GITHUB_OUTPUT" || echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Mirror PyPI packages
+        if: steps.quota.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+          UPSTREAM_OWNER: ${{ inputs.upstream_owner }}
+          DRY_RUN: ${{ inputs.dry_run || 'true' }}
+          REPO_FILTER: ${{ inputs.repo_filter || '' }}
+          BUDGET_MINUTES: "55"
+        run: bash scripts/mirror-pypi.sh
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/mirror-rpm.yml
+++ b/.github/workflows/mirror-rpm.yml
@@ -1,0 +1,73 @@
+name: Mirror RPM Repo
+
+# Mirrors RPM packages from OSP/OOC releases to a self-hosted RPM repo
+# on GitHub Pages (rpm-repo repository).
+
+on:
+  schedule:
+    - cron: '30 4 * * *'  # Daily 04:30 UTC
+  workflow_dispatch:
+    inputs:
+      upstream_owner:
+        description: 'Source GitHub org/user (default: Interested-Deving-1896)'
+        type: string
+        default: 'Interested-Deving-1896'
+      target_org:
+        description: 'Target org for the rpm-repo (default: OpenOS-Project-OSP)'
+        type: string
+        default: 'OpenOS-Project-OSP'
+      dry_run:
+        description: 'Report which RPMs would be mirrored — do not push'
+        type: boolean
+        default: false
+      rate_limit_rerun:
+        description: 'Set by rate-limit-rerun — prevents re-trigger loops'
+        type: string
+        default: 'false'
+
+concurrency:
+  group: mirror-rpm
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  mirror:
+    if: inputs.rate_limit_rerun != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install createrepo
+        run: sudo apt-get update -qq && sudo apt-get install -y createrepo-c
+
+      - name: Quota pre-flight
+        id: quota
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+        run: |
+          remaining=$(curl -sf -H "Authorization: token $GH_TOKEN" \
+            https://api.github.com/rate_limit | python3 -c \
+            "import json,sys; print(json.load(sys.stdin)['resources']['core']['remaining'])" 2>/dev/null || echo 0)
+          echo "remaining=$remaining" >> "$GITHUB_OUTPUT"
+          [[ "$remaining" -lt 500 ]] && echo "skip=true" >> "$GITHUB_OUTPUT" || echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Mirror RPM repo
+        if: steps.quota.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+          UPSTREAM_OWNER: ${{ inputs.upstream_owner || 'Interested-Deving-1896' }}
+          TARGET_ORG: ${{ inputs.target_org || 'OpenOS-Project-OSP' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          BUDGET_MINUTES: "55"
+        run: bash scripts/mirror-rpm.sh
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/org-storage-maintenance.yml
+++ b/.github/workflows/org-storage-maintenance.yml
@@ -1,0 +1,68 @@
+name: Org Storage Maintenance
+
+# Org-wide storage housekeeping across openos-project:
+# triggers artifact expiry and deletes old generic package versions.
+# Excludes upstream mirror groups (kde-ecosystem-deving, upstream-mirrors,
+# chromium_browser-os_deving).
+
+on:
+  schedule:
+    - cron: '0 2 * * 0'  # Weekly Sunday 02:00 UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Report what would be deleted — do not delete'
+        type: boolean
+        default: false
+      package_max_age_days:
+        description: 'Delete package versions older than N days'
+        type: string
+        default: '90'
+      package_keep_count:
+        description: 'Minimum versions to keep per package name'
+        type: string
+        default: '5'
+
+concurrency:
+  group: org-storage-maintenance
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  maintenance:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Quota pre-flight
+        id: quota
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+        run: |
+          remaining=$(curl -sf -H "Authorization: token $GH_TOKEN" \
+            https://api.github.com/rate_limit | python3 -c \
+            "import json,sys; print(json.load(sys.stdin)['resources']['core']['remaining'])" 2>/dev/null || echo 0)
+          echo "remaining=$remaining" >> "$GITHUB_OUTPUT"
+          [[ "$remaining" -lt 500 ]] && echo "skip=true" >> "$GITHUB_OUTPUT" || echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Run storage maintenance
+        if: steps.quota.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+          GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          PACKAGE_MAX_AGE_DAYS: ${{ inputs.package_max_age_days || '90' }}
+          PACKAGE_KEEP_COUNT: ${{ inputs.package_keep_count || '5' }}
+          BUDGET_MINUTES: "115"
+        run: bash scripts/org-storage-maintenance.sh
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/provision-maintenance.yml
+++ b/.github/workflows/provision-maintenance.yml
@@ -1,0 +1,47 @@
+name: Provision GitLab Maintenance Schedules
+
+# Pushes .gitlab/scheduled-maintenance.yml and creates a weekly maintenance
+# schedule on every actively developed project under openos-project.
+# Safe to re-run — skips projects that already have the file and schedule.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Report which projects would be provisioned — do not push'
+        type: boolean
+        default: false
+      group_filter:
+        description: 'Substring filter on GitLab group path (leave blank for all)'
+        type: string
+        default: ''
+
+concurrency:
+  group: provision-maintenance
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  provision:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Provision maintenance schedules
+        env:
+          GITLAB_MAINTENANCE_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+          CI_API_V4_URL: https://gitlab.com/api/v4
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          GROUP_FILTER: ${{ inputs.group_filter || '' }}
+        run: bash scripts/provision-maintenance.sh
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/push-kernel-content.yml
+++ b/.github/workflows/push-kernel-content.yml
@@ -1,0 +1,62 @@
+name: Push Kernel Content
+
+# Pushes kernel version metadata (READY, VERSION, config/, patches/, README.md)
+# to the 10 debian-{arch}-kernel-base repos (one per arch).
+
+on:
+  workflow_dispatch:
+    inputs:
+      arch:
+        description: 'Space-separated arch list (leave blank for all 10)'
+        type: string
+        default: ''
+      dry_run:
+        description: 'Report what would be pushed — do not push'
+        type: boolean
+        default: false
+
+concurrency:
+  group: push-kernel-content
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Quota pre-flight
+        id: quota
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+        run: |
+          remaining=$(curl -sf -H "Authorization: token $GH_TOKEN" \
+            https://api.github.com/rate_limit | python3 -c \
+            "import json,sys; print(json.load(sys.stdin)['resources']['core']['remaining'])" 2>/dev/null || echo 0)
+          echo "remaining=$remaining" >> "$GITHUB_OUTPUT"
+          [[ "$remaining" -lt 500 ]] && echo "skip=true" >> "$GITHUB_OUTPUT" || echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Push kernel content
+        if: steps.quota.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+          ORG: Interested-Deving-1896
+          ARCH: ${{ inputs.arch || '' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: |
+          args=""
+          [[ -n "$ARCH" ]] && args="--arch $ARCH"
+          [[ "$DRY_RUN" == "true" ]] && args="$args --dry-run"
+          bash scripts/push-kernel-content.sh $args
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,12 @@
 name: Release
 
 on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g. v1.2.3) — only used when triggered manually'
+        required: false
+        default: ''
   push:
     tags:
       - 'v*'

--- a/.github/workflows/seed-patchset-branches.yml
+++ b/.github/workflows/seed-patchset-branches.yml
@@ -1,0 +1,64 @@
+name: Seed Patchset Branches
+
+# Seeds 9 patchset branches per debian-{arch}-kernel-base repo:
+#   patchset/debian/{trixie,forky,sid}
+#   patchset/devuan/{excalibur,forky,ceres}
+#   patchset/ubuntu/{resolute,stonking,devel}
+
+on:
+  workflow_dispatch:
+    inputs:
+      arch:
+        description: 'Space-separated arch list (leave blank for all 10)'
+        type: string
+        default: ''
+      dry_run:
+        description: 'Report what would be created — do not push'
+        type: boolean
+        default: false
+      force:
+        description: 'Overwrite existing branches'
+        type: boolean
+        default: false
+
+concurrency:
+  group: seed-patchset-branches
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  seed:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Quota pre-flight
+        id: quota
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+        run: |
+          remaining=$(curl -sf -H "Authorization: token $GH_TOKEN" \
+            https://api.github.com/rate_limit | python3 -c \
+            "import json,sys; print(json.load(sys.stdin)['resources']['core']['remaining'])" 2>/dev/null || echo 0)
+          echo "remaining=$remaining" >> "$GITHUB_OUTPUT"
+          [[ "$remaining" -lt 500 ]] && echo "skip=true" >> "$GITHUB_OUTPUT" || echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Seed patchset branches
+        if: steps.quota.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+          ARCH: ${{ inputs.arch || '' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          FORCE: ${{ inputs.force || 'false' }}
+        run: bash scripts/seed-patchset-branches.sh
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/sync-kde-groups-mirrors.yml
+++ b/.github/workflows/sync-kde-groups-mirrors.yml
@@ -1,0 +1,53 @@
+name: Sync KDE Groups Mirrors
+
+# Syncs all KDE group mirror repos under
+# openos-project/kde-ecosystem-deving/kde-groups from invent.kde.org.
+
+on:
+  schedule:
+    - cron: '0 1 * * *'  # Daily 01:00 UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Report which repos would be synced — do not push'
+        type: boolean
+        default: false
+      group_filter:
+        description: 'Substring filter on KDE group path (leave blank for all)'
+        type: string
+        default: ''
+      rate_limit_rerun:
+        description: 'Set by rate-limit-rerun — prevents re-trigger loops'
+        type: string
+        default: 'false'
+
+concurrency:
+  group: sync-kde-groups-mirrors
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    if: inputs.rate_limit_rerun != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Sync KDE groups mirrors
+        env:
+          GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          GROUP_FILTER: ${{ inputs.group_filter || '' }}
+          BUDGET_MINUTES: "115"
+        run: bash scripts/sync-kde-groups-mirrors.sh
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/sync-kde-neon-mirrors.yml
+++ b/.github/workflows/sync-kde-neon-mirrors.yml
@@ -1,0 +1,48 @@
+name: Sync KDE Neon Mirrors
+
+# Syncs all KDE Neon mirror repos in
+# openos-project/kde-ecosystem-deving/neon-deving from invent.kde.org/neon/.
+
+on:
+  schedule:
+    - cron: '30 1 * * *'  # Daily 01:30 UTC — offset from sync-kde-groups-mirrors
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Report which repos would be synced — do not push'
+        type: boolean
+        default: false
+      rate_limit_rerun:
+        description: 'Set by rate-limit-rerun — prevents re-trigger loops'
+        type: string
+        default: 'false'
+
+concurrency:
+  group: sync-kde-neon-mirrors
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    if: inputs.rate_limit_rerun != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Sync KDE Neon mirrors
+        env:
+          GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          BUDGET_MINUTES: "115"
+        run: bash scripts/sync-kde-neon-mirrors.sh
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/sync-pieroproietti-gl-forks.yml
+++ b/.github/workflows/sync-pieroproietti-gl-forks.yml
@@ -1,0 +1,54 @@
+name: Sync Pieroproietti GitLab Forks
+
+# Syncs the three pieroproietti GitLab forks from their GitHub upstreams.
+# Mirrors all branches, tags, and creates GitLab Releases for new tags.
+#
+# Repos:
+#   github.com/pieroproietti/penguins-eggs      → openos-project/.../penguins-eggs
+#   github.com/pieroproietti/penguins-eggs-book → openos-project/.../penguins-eggs-book
+#   github.com/pieroproietti/oa-tools           → openos-project/.../oa-tools
+
+on:
+  schedule:
+    - cron: '15 2 * * *'  # Daily 02:15 UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Report what would be synced — do not push'
+        type: boolean
+        default: false
+      rate_limit_rerun:
+        description: 'Set by rate-limit-rerun — prevents re-trigger loops'
+        type: string
+        default: 'false'
+
+concurrency:
+  group: sync-pieroproietti-gl-forks
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    if: inputs.rate_limit_rerun != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Sync pieroproietti GitLab forks
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+          GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          BUDGET_MINUTES: "55"
+        run: bash scripts/sync-pieroproietti-gl-forks.sh
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/sync-upstream-mirrors.yml
+++ b/.github/workflows/sync-upstream-mirrors.yml
@@ -1,0 +1,53 @@
+name: Sync Upstream Mirrors (GitLab)
+
+# Syncs all upstream mirror repos in openos-project/upstream-mirrors
+# from their original GitHub sources.
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Daily 00:00 UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Report which repos would be synced — do not push'
+        type: boolean
+        default: false
+      repo_filter:
+        description: 'Substring filter on repo name (leave blank for all)'
+        type: string
+        default: ''
+      rate_limit_rerun:
+        description: 'Set by rate-limit-rerun — prevents re-trigger loops'
+        type: string
+        default: 'false'
+
+concurrency:
+  group: sync-upstream-mirrors
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    if: inputs.rate_limit_rerun != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Sync upstream mirrors
+        env:
+          GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          REPO_FILTER: ${{ inputs.repo_filter || '' }}
+          BUDGET_MINUTES: "115"
+        run: bash scripts/sync-upstream-mirrors.sh
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/trigger-artifact-mirror.yml
+++ b/.github/workflows/trigger-artifact-mirror.yml
@@ -4,6 +4,12 @@ name: Trigger Artifact Mirror
 # workflow in fork-sync-all so OSP and OOC get the release immediately.
 
 on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Release tag to mirror (e.g. v1.2.3) — only used when triggered manually'
+        required: false
+        default: ''
   release:
     types: [published]
 

--- a/.github/workflows/trigger-readme-update.yml
+++ b/.github/workflows/trigger-readme-update.yml
@@ -1,0 +1,59 @@
+name: Trigger README Update (All Repos)
+
+# Dispatches update-readmes.yml for all OSP-bound repos in batch.
+# Use this after a rate-limit reset to propagate README updates org-wide
+# without triggering each repo individually from the Actions UI.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Detect stale sections without writing changes'
+        type: boolean
+        default: false
+      profile:
+        description: 'Template profile to target'
+        type: choice
+        options: [all, mirror, full, infra-core]
+        default: all
+
+concurrency:
+  group: trigger-readme-update
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Quota pre-flight
+        id: quota
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+        run: |
+          remaining=$(curl -sf -H "Authorization: token $GH_TOKEN" \
+            https://api.github.com/rate_limit | python3 -c \
+            "import json,sys; print(json.load(sys.stdin)['resources']['core']['remaining'])" 2>/dev/null || echo 0)
+          echo "remaining=$remaining" >> "$GITHUB_OUTPUT"
+          [[ "$remaining" -lt 1000 ]] && echo "skip=true" >> "$GITHUB_OUTPUT" || echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger README updates
+        if: steps.quota.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          PROFILE: ${{ inputs.profile || 'all' }}
+        run: bash scripts/trigger-readme-update.sh
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/.github/workflows/upload-notebooklm.yml
+++ b/.github/workflows/upload-notebooklm.yml
@@ -1,0 +1,46 @@
+name: Upload NotebookLM Assets
+
+# Uploads NotebookLM generated output files (audio, PDF) to a GitHub Release.
+# Creates the release if it does not exist yet.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (pattern: notebooklm-YYYY-MM-DD)'
+        type: string
+        required: true
+      asset_paths:
+        description: 'Space-separated paths to files to upload (relative to workspace)'
+        type: string
+        required: true
+
+concurrency:
+  group: upload-notebooklm-${{ inputs.tag }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Upload NotebookLM assets
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+          RELEASE_TAG: ${{ inputs.tag }}
+          ASSET_PATHS: ${{ inputs.asset_paths }}
+        run: |
+          bash scripts/upload-notebooklm.sh "$RELEASE_TAG" $ASSET_PATHS
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: bash scripts/write-summary.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1587,6 +1587,128 @@ The `./features/incus/install.sh` feature detects capabilities at build time:
 
 ---
 
+## FSA-API
+
+`fsa-api/` is a two-layer HTTP API over the fork-sync-all control plane.
+Full reference: `fsa-api/README.md`. Key conventions for agents:
+
+### Layer structure
+
+```
+fsa-api/uaa/          — Unified Agnostic API (generic, platform-agnostic)
+fsa-api/core/         — FSA-specific adapters (GitHub-org-specific)
+fsa-api/config/       — fsa-routes.yml + fsa-toggles.yml + fsa-deployments.yml
+fsa-api/server/       — fsa-start.sh (merges both route files)
+```
+
+**Never put FSA-specific logic in `fsa-api/uaa/`.** UAA is propagated to
+consumer repos via `sync-template.sh`. FSA-specific adapters belong in
+`fsa-api/core/adapters/<domain>/`.
+
+### Adding an adapter
+
+Every new adapter must:
+1. Source `fsa-adapter.sh` (not `adapter.sh` directly)
+2. Call `fsa_quota_check N` before any API calls
+3. Check its toggle with `toggle_enabled <name>` if the domain has one
+4. Have a route entry in `fsa-api/config/fsa-routes.yml`
+5. Pass `python3 scripts/validate-workflow-guards.py` with zero warnings
+
+```bash
+#!/usr/bin/env bash
+# GET /api/fsa/<domain>/<resource>
+source "$(dirname "${BASH_SOURCE[0]}")/../../lib/fsa-adapter.sh"
+
+fsa_quota_check 50 || exit 0
+toggle_enabled my_toggle || { fsa_error "disabled" 503; exit 0; }
+# ... logic ...
+fsa_ok '{"result":"..."}'
+```
+
+### `shared.sh` — UAA ↔ FSA sync point
+
+`fsa-api/uaa/lib/shared.sh` is sourced by both `uaa/lib/adapter.sh` and
+`fsa-api/core/lib/fsa-adapter.sh`. It contains platform-agnostic logic
+shared between the two layers:
+
+- **Toggle system**: `toggle_get / toggle_enabled / toggle_set / toggle_list`
+  reads `UAA_TOGGLES_FILE` (set to `fsa-api/config/fsa-toggles.yml` by FSA)
+- **Quota guard**: `quota_check N` / `quota_fetch` — FSA overrides `quota_fetch()`
+  with the GitHub-specific implementation; UAA defaults to 9999 (unlimited)
+- **JSON helpers**: `json_ok / json_error / json_list` — `fsa_ok / fsa_error / fsa_list`
+  are aliases kept for backward compatibility
+- **Route merge**: `merge_routes_files FILE...` — merges multiple route manifests
+- **Capability registry**: `register_capability / list_capabilities`
+
+When adding logic that is genuinely platform-agnostic (no GitHub/GitLab coupling),
+add it to `shared.sh` so both UAA consumers and FSA adapters benefit. When adding
+logic that is GitHub-specific, add it to `fsa-adapter.sh` only.
+
+### Platform-agnostic adapters (`fsa_platform_init`)
+
+`fsa-adapter.sh` sources `scripts/includes/platform-adapter.sh`. Every FSA
+adapter can switch platforms by calling `fsa_platform_init`:
+
+```bash
+fsa_platform_init gitlab          # switches to GitLab, selects GITLAB_TOKEN
+pa_list_repos "openos-project"    # uses GitLab API
+fsa_platform_init github          # switch back
+```
+
+Token selection is automatic: `github`→`GH_TOKEN`, `gitlab`→`GITLAB_TOKEN`,
+`gitea`→`GITEA_TOKEN`, `forgejo`→`FORGEJO_TOKEN`, `codeberg`→`CODEBERG_TOKEN`.
+
+`workflows/list.sh` and `workflows/run.sh` have platform branches for all 5
+platforms. New workflow-management adapters should follow the same pattern:
+check `PA_PLATFORM` and branch accordingly.
+
+### Deployment registry (`config/fsa-deployments.yml`)
+
+Single source of truth for all known FSA instances. The `deployments` adapter
+domain reads this file — do not hardcode deployment coordinates in adapters.
+
+```yaml
+deployments:
+  - id: source
+    platform: github
+    org: Interested-Deving-1896
+    ...
+  - id: osp-gitlab
+    platform: gitlab
+    group_path: openos-project/ops
+    ...
+```
+
+When a new FSA instance is created (new org, new platform), add it here.
+The `/api/fsa/deployments/*` routes and `codebase/drift` will pick it up
+automatically.
+
+### `codebase/sync` dispatch rule
+
+`POST /api/fsa/codebase/sync` always dispatches on the **source** repo
+(`Interested-Deving-1896/fork-sync-all`), never on `FSA_REPO`. The source
+workflow (`sync-fsa-forks.yml`) then pushes updates to all mirrors.
+`force=true` dispatches `critical-deploy-gitlab.yml` instead (direct git push,
+bypasses mirror sync chain — use for emergency GitLab mirror recovery).
+
+### Route manifest conventions
+
+`fsa-api/config/fsa-routes.yml` extends the UAA route format. Fields:
+
+```yaml
+- path: /api/fsa/<domain>/<resource>
+  script: core/adapters/<domain>/<verb>.sh
+  method: GET|POST|PUT|DELETE
+  auth: true          # require FSA_API_TOKEN header (write operations)
+  toggle: <name>      # gate on fsa-toggles.yml entry
+  # comment describing query params or body shape
+```
+
+`fsa-start.sh` merges `fsa-api/uaa/config/routes.yml` + `fsa-api/config/fsa-routes.yml`
+using `shared.sh`'s `merge_routes_files()`. Last writer wins on path+method conflicts.
+
+---
+
 ## Platform adapter (`platform-adapter.sh`)
 
 `scripts/includes/platform-adapter.sh` provides a uniform interface for

--- a/config/fsa-deployments.yml
+++ b/config/fsa-deployments.yml
@@ -1,0 +1,79 @@
+# config/fsa-deployments.yml — FSA deployment registry
+#
+# Single source of truth for all known fork-sync-all instances.
+# Read by fsa-api/core/adapters/deployments/*.sh and fsa-start.sh.
+#
+# Fields per deployment:
+#   id            — unique identifier used in API paths (/api/fsa/deployments/:id)
+#   platform      — github | gitlab | gitea | forgejo | codeberg
+#   host          — base URL (omit for canonical public hosts)
+#   org           — org / group / namespace that owns the fork-sync-all repo
+#   repo          — repo name (default: fork-sync-all)
+#   group_path    — GitLab full group path including subgroup (gitlab only)
+#   token_secret  — name of the GitHub Actions / GitLab CI secret holding the token
+#   position      — source | mirror  (from fsa-node-identity.sh topology)
+#   chain_depth   — 0=source, 1=first mirror, 2=second mirror
+#   fsa_api_url   — base URL of the FSA-API running on this instance (empty = not running)
+#   enabled       — false to exclude from API responses without removing the entry
+
+deployments:
+
+  # ── Source ───────────────────────────────────────────────────────────────────
+  - id: source
+    platform: github
+    host: https://github.com
+    org: Interested-Deving-1896
+    repo: fork-sync-all
+    token_secret: SYNC_TOKEN
+    position: source
+    chain_depth: 0
+    fsa_api_url: ''   # self — no proxy needed; FSA-API runs here
+    enabled: true
+
+  # ── GitHub mirrors ───────────────────────────────────────────────────────────
+  - id: osp-github
+    platform: github
+    host: https://github.com
+    org: OpenOS-Project-OSP
+    repo: fork-sync-all
+    token_secret: SYNC_TOKEN
+    position: mirror
+    chain_depth: 1
+    fsa_api_url: ''
+    enabled: true
+
+  - id: ooc-github
+    platform: github
+    host: https://github.com
+    org: OpenOS-Project-Ecosystem-OOC
+    repo: fork-sync-all
+    token_secret: SYNC_TOKEN
+    position: mirror
+    chain_depth: 1
+    fsa_api_url: ''
+    enabled: true
+
+  # ── GitLab mirrors ───────────────────────────────────────────────────────────
+  - id: osp-gitlab
+    platform: gitlab
+    host: https://gitlab.com
+    org: openos-project
+    group_path: openos-project/ops
+    repo: fork-sync-all
+    token_secret: GITLAB_TOKEN
+    position: mirror
+    chain_depth: 1
+    fsa_api_url: ''
+    enabled: true
+
+  - id: ooc-gitlab
+    platform: gitlab
+    host: https://gitlab.com
+    org: openos-project-ooc-ecosystem
+    group_path: openos-project-ooc-ecosystem/ops
+    repo: fork-sync-all
+    token_secret: GITLAB_TOKEN
+    position: mirror
+    chain_depth: 1
+    fsa_api_url: ''
+    enabled: true

--- a/config/template-manifest.yml
+++ b/config/template-manifest.yml
@@ -259,6 +259,31 @@ profiles:
       - .devcontainer/automations.template.yaml:.ona/automations.yaml
       - services/sync-in/start.sh
       - services/sync-in/install.sh
+      # ── FSA API consumer layer ────────────────────────────────────────────
+      # Consumers get the UAA base + server + CLI + scaffold tooling.
+      # They do NOT get fsa-api/core/ (FSA-specific GitHub adapters) or
+      # fsa-api/config/fsa-routes.yml (FSA routes) — those are excluded globally.
+      # fsa-api/config/fsa-consumer.yml IS propagated so consumers can configure
+      # their own brand/prefix. fsa-api/config/fsa-toggles.yml is scaffold-only.
+      - fsa-api/uaa/lib/adapter.sh
+      - fsa-api/uaa/lib/log.sh
+      - fsa-api/uaa/lib/routes.sh
+      - fsa-api/uaa/config/routes.yml
+      - fsa-api/uaa/server/start.sh
+      - fsa-api/uaa/cli/uaa.sh
+      - fsa-api/uaa/README.md
+      - fsa-api/server/fsa-start.sh
+      - fsa-api/cli/fsa.sh
+      - fsa-api/scripts/scaffold-consumer.sh
+      - fsa-api/config/fsa-consumer.yml
+      # Toggles config — scaffold-only (skipped if already present in consumer)
+      - fsa-api/config/fsa-toggles.yml
+      - fsa-api/README.md
+      # Security tooling — install script propagated; devcontainer.json excluded globally
+      - .devcontainer/install-security-tools.sh
+      # Motto + pin config — scaffold-only stubs for consumers to customise
+      - config/fsa-motto.yml
+      - config/fsa-pin.yml
 
   # ── upstream-sync ────────────────────────────────────────────────────────────
   # For repos that declare their upstream dependencies in a registry file and
@@ -372,6 +397,23 @@ profiles:
       - DOCS/accessibility.md
       - .gitignore
       - LICENSE
+      # ── FSA API consumer layer (same as infra-core) ───────────────────────
+      - fsa-api/uaa/lib/adapter.sh
+      - fsa-api/uaa/lib/log.sh
+      - fsa-api/uaa/lib/routes.sh
+      - fsa-api/uaa/config/routes.yml
+      - fsa-api/uaa/server/start.sh
+      - fsa-api/uaa/cli/uaa.sh
+      - fsa-api/uaa/README.md
+      - fsa-api/server/fsa-start.sh
+      - fsa-api/cli/fsa.sh
+      - fsa-api/scripts/scaffold-consumer.sh
+      - fsa-api/config/fsa-consumer.yml
+      - fsa-api/config/fsa-toggles.yml
+      - fsa-api/README.md
+      - .devcontainer/install-security-tools.sh
+      - config/fsa-motto.yml
+      - config/fsa-pin.yml
       # Devcontainer + Ona automations + Sync-in service — scaffold-only (skipped if already present)
       - .devcontainer/devcontainer.template.json:.devcontainer/devcontainer.json
       - .devcontainer/automations.template.yaml:.ona/automations.yaml

--- a/config/workflow-sync.yml
+++ b/config/workflow-sync.yml
@@ -565,6 +565,50 @@ github_only:
   - workflow_file: notify-manager.yml
     reason: Hourly notification triage — auto-marks known-safe patterns as read, supports manual dispatch with full action control
 
+  # ── New wrapper workflows (scripts without prior workflow coverage) ──────────
+  - workflow_file: audit-arch-repos.yml
+    reason: Audits expected vs existing repos in Interested-Deving-1896 — GitHub API only
+  - workflow_file: check-ooc-ci.yml
+    reason: Checks CI status of OOC-bound repos — GitHub Checks API only
+  - workflow_file: merge-ready-prs.yml
+    reason: Batch-merges green PRs across repos — GitHub PR API only
+  - workflow_file: trigger-readme-update.yml
+    reason: Batch-dispatches update-readmes.yml across OSP repos — GitHub dispatch API only
+  - workflow_file: upload-notebooklm.yml
+    reason: Uploads NotebookLM assets to GitHub Releases — GitHub Contents API only
+  - workflow_file: mirror-flatpak.yml
+    reason: Builds and publishes Flatpak repo to GitHub Pages — GitHub API only
+  - workflow_file: mirror-ghcr.yml
+    reason: Re-tags and pushes GHCR images between orgs — GitHub Container Registry only
+  - workflow_file: mirror-pypi.yml
+    reason: Re-publishes PyPI packages with org-prefixed names — GitHub Release assets + PyPI
+  - workflow_file: mirror-rpm.yml
+    reason: Mirrors RPM packages to GitHub Pages rpm-repo — GitHub API only
+  - workflow_file: org-storage-maintenance.yml
+    reason: Triggers artifact expiry and package cleanup across openos-project — GitLab API only
+  - workflow_file: provision-maintenance.yml
+    reason: Provisions GitLab scheduled-maintenance.yml across openos-project — GitLab API only
+  - workflow_file: push-kernel-content.yml
+    reason: Pushes kernel metadata to debian-arch-kernel-base repos — GitHub Contents API only
+  - workflow_file: seed-patchset-branches.yml
+    reason: Seeds patchset branches in kernel repos — GitHub API only
+  - workflow_file: sync-kde-groups-mirrors.yml
+    reason: Syncs KDE group mirrors from invent.kde.org to GitLab — GitLab API only
+  - workflow_file: sync-kde-neon-mirrors.yml
+    reason: Syncs KDE Neon mirrors from invent.kde.org to GitLab — GitLab API only
+  - workflow_file: sync-pieroproietti-gl-forks.yml
+    reason: Syncs pieroproietti GitHub repos to GitLab forks — cross-platform, runs on GitHub
+  - workflow_file: sync-upstream-mirrors.yml
+    reason: Syncs upstream-mirrors group in GitLab from GitHub sources — GitLab API only
+  - workflow_file: bdfs-dev.yml
+    reason: bdfs dev workspace management — local runner tool, no GitLab equivalent
+  - workflow_file: bdfs-dev-btrfs.yml
+    reason: bdfs BTRFS backend — local runner tool, no GitLab equivalent
+  - workflow_file: bdfs-dev-dwarfs.yml
+    reason: bdfs DwarFS backend — local runner tool, no GitLab equivalent
+  - workflow_file: bdfs-dev-overlay.yml
+    reason: bdfs overlay backend — local runner tool, no GitLab equivalent
+
 gitlab_only:
   - job: secret-scan
     reason: Scans for secrets in GitLab repo — GitLab-native security stage

--- a/fsa-api/README.md
+++ b/fsa-api/README.md
@@ -1,33 +1,58 @@
 # fsa-api — Fork-Sync-All API
 
-A two-layer API system:
+A two-layer HTTP API that exposes the entire fork-sync-all control plane —
+workflows, scripts, mirror chain, docs, deployments, and codebase state —
+over a uniform REST interface. Works across all 5 git platforms.
 
 ```
 fsa-api/
   uaa/        — Unified Agnostic API (generic, reusable by any consumer repo)
   core/       — FSA-specific adapter layer (extends UAA for fork-sync-all)
-  config/     — FSA route manifest + feature toggles
-  server/     — FSA HTTP server (UAA server + FSA routes)
+  config/     — FSA route manifest + feature toggles + consumer config
+  server/     — FSA HTTP server (merges UAA + FSA routes)
   cli/        — fsa CLI (local + remote dispatch)
 ```
 
 ## Architecture
 
 ```
-Consumer repo                    fork-sync-all
-─────────────                    ─────────────
-fsa-api/uaa/          copy →     fsa-api/uaa/        (generic adapters)
-my-api/core/          own  →     fsa-api/core/       (FSA-specific adapters)
-my-api/config/        own  →     fsa-api/config/     (routes + toggles)
+Android App / WebUI / CLI / any HTTP client
+              │
+              ▼
+    fsa-api/server/fsa-start.sh
+              │  merges UAA routes + FSA routes, applies toggles
+              │
+    ┌─────────┴──────────┐
+    │                    │
+  UAA layer           FSA core layer
+  /health              /api/fsa/workflows/*
+  /api/adapters        /api/fsa/repos/*
+  /api/filesystem/*    /api/fsa/chain/*
+  /api/os/*            /api/fsa/quota
+  /api/ai/*            /api/fsa/notifications/*
+  /api/github/*        /api/fsa/docs/*
+  (25 routes)          /api/fsa/deployments/*
+                       /api/fsa/codebase/*
+                       /api/fsa/bdfs/*
+                       /api/fsa/security/*
+                       /api/fsa/toggles/*
+                       (29 routes)
 ```
 
-**`uaa/`** is the generic foundation — platform-agnostic adapters for GitHub,
-filesystem, AI, browser, OS. Consumer repos copy this as-is and build their
+**`uaa/`** is the generic foundation — platform-agnostic adapters for filesystem,
+OS, AI, browser, GitHub generic. Consumer repos copy this as-is and build their
 own `core/` on top. It has no knowledge of fork-sync-all.
 
 **`core/`** is the FSA-specific layer — adapters that expose fork-sync-all's
-control plane as HTTP endpoints: workflow dispatch, repo management, mirror
-chain status, quota monitoring, notification triage, feature toggles.
+control plane as HTTP endpoints. All core adapters source `core/lib/fsa-adapter.sh`
+which extends UAA's `adapter.sh` with GitHub/multi-platform API access, quota
+guards, toggle helpers, and deployment registry access.
+
+**`uaa/lib/shared.sh`** is the bidirectional sync point between UAA and FSA-API.
+It contains platform-agnostic logic that both layers share: toggle system,
+generic quota guard, JSON helpers, multi-file route merge, capability registry.
+FSA-API overrides `quota_fetch()` with the GitHub-specific implementation;
+UAA defaults to unlimited.
 
 ## Quick start
 
@@ -41,67 +66,221 @@ bash fsa-api/cli/fsa.sh workflow run sync-forks
 bash fsa-api/cli/fsa.sh quota status
 bash fsa-api/cli/fsa.sh chain status
 bash fsa-api/cli/fsa.sh toggle list
-bash fsa-api/cli/fsa.sh toggle set sync-forks enabled
 ```
 
-## HTTP API
+## HTTP API — 54 routes total (29 FSA + 25 UAA)
+
+### Workflows (platform-aware)
 
 ```
-GET  /api/fsa/workflows              — list all workflows + status
-POST /api/fsa/workflows/:name/run    — dispatch a workflow
-GET  /api/fsa/workflows/:name/status — last run status
-GET  /api/fsa/repos                  — list org repos
-POST /api/fsa/repos/onboard          — onboard a new repo
-GET  /api/fsa/chain/status           — mirror chain status
-POST /api/fsa/chain/flush            — trigger full chain flush
-GET  /api/fsa/quota                  — current quota status
-GET  /api/fsa/notifications          — unread notifications
-POST /api/fsa/notifications/triage   — auto-triage known-safe noise
-GET  /api/fsa/toggles                — list feature toggles
-POST /api/fsa/toggles/:name          — set toggle value
-
-# Generic UAA endpoints (pass-through)
-GET  /api/github/repos               — list GitHub repos
-GET  /api/github/orgs                — list GitHub orgs
-GET  /health                         — server health
-GET  /api/meta/routes                — all registered routes
+GET  /api/fsa/workflows              list all workflows + tier + toggle state
+                                     ?filter=enabled|disabled|all  ?tier=1|2|3|4
+                                     ?platform=github|gitlab|gitea|forgejo
+POST /api/fsa/workflows/:name/run    dispatch a workflow / trigger a pipeline
+                                     body: {"ref":"main","inputs":{...},"platform":"github"}
+GET  /api/fsa/workflows/:name/status last run status
 ```
+
+Every script in `scripts/` has a corresponding workflow, so every operation
+is reachable via `POST /api/fsa/workflows/:name/run` from any client.
+
+### Repos
+
+```
+GET  /api/fsa/repos                  list org repos
+POST /api/fsa/repos/onboard          onboard a new repo
+```
+
+### Mirror chain
+
+```
+GET  /api/fsa/chain/status           flush pipeline state, FLUSH_ACTIVE mutex
+POST /api/fsa/chain/flush            trigger full-chain-flush.yml
+```
+
+### Quota
+
+```
+GET  /api/fsa/quota                  REST + GraphQL remaining, reset time
+```
+
+### Notifications
+
+```
+GET  /api/fsa/notifications          unread GitHub inbox
+POST /api/fsa/notifications/triage   auto-mark known-safe patterns as read
+```
+
+### Docs / Publishing
+
+```
+GET  /api/fsa/docs                   list docs workflows by category
+                                     ?category=all|book|readme|translate|sbom|notebooklm
+GET  /api/fsa/docs/status            last run status per docs workflow
+GET  /api/fsa/docs/content           DOCS/ page index + GitHub Pages URLs + book.toml metadata
+                                     ?format=index|toc|pages  ?section=<name>
+POST /api/fsa/docs/dispatch          dispatch any docs workflow by name (allowlist-guarded)
+                                     body: {"workflow":"deploy-book","ref":"main","inputs":{...}}
+```
+
+### Deployments (all 5 FSA instances)
+
+```
+GET  /api/fsa/deployments            list all registered FSA instances
+                                     ?check=true  ?platform=github|gitlab  ?position=source|mirror
+GET  /api/fsa/deployments/:id/status platform API probe + FSA-API health + last run
+GET  /api/fsa/deployments/:id/workflows  GitHub Actions workflows or GitLab pipelines
+POST /api/fsa/deployments/:id/dispatch   trigger workflow/pipeline on remote instance
+GET  /api/fsa/deployments/:id/codebase   SHA drift check for a specific deployment
+```
+
+Registered deployments (`config/fsa-deployments.yml`):
+
+| ID | Platform | Org/Group | Position |
+|---|---|---|---|
+| `source` | GitHub | `Interested-Deving-1896` | source |
+| `osp-github` | GitHub | `OpenOS-Project-OSP` | mirror |
+| `ooc-github` | GitHub | `OpenOS-Project-Ecosystem-OOC` | mirror |
+| `osp-gitlab` | GitLab | `openos-project/ops` | mirror |
+| `ooc-gitlab` | GitLab | `openos-project-ooc-ecosystem/ops` | mirror |
+
+### Codebase self-awareness
+
+```
+GET  /api/fsa/codebase/status        current SHA, branch, dirty state, ahead/behind,
+                                     workflow/script/adapter/route inventory counts
+GET  /api/fsa/codebase/drift         cross-deployment SHA comparison (all 5 instances)
+                                     ?deployment=all|<id>
+GET  /api/fsa/codebase/log           recent commits
+                                     ?limit=N  ?since=YYYY-MM-DD  ?author=<name>  ?path=<path>
+POST /api/fsa/codebase/sync          trigger self-update on mirror instances
+                                     body: {"dry_run":false,"force":false}
+                                     force=true uses critical-deploy-gitlab.yml (direct git push)
+```
+
+### BDFS
+
+```
+GET  /api/fsa/bdfs/status            bdfs workspace status
+POST /api/fsa/bdfs/export            export as DwarFS image
+POST /api/fsa/bdfs/import            import a DwarFS image
+```
+
+### Security
+
+```
+GET  /api/fsa/security/scan          dev-machine-guard scan
+                                     ?format=json|text  ?categories=all|packages|agents|...
+```
+
+### Toggles
+
+```
+GET  /api/fsa/toggles                list all feature toggles + enabled state
+POST /api/fsa/toggles/:name          set toggle value — body: {"enabled":true|false}
+```
+
+### UAA generic endpoints (25 routes)
+
+```
+GET  /health                         server health + uptime
+GET  /api/adapters                   all registered adapters + capability registry
+GET  /api/filesystem/*               read/write/list local files
+GET  /api/os/*                       shell exec, env, process info
+GET  /api/ai/*                       LLM inference (model-agnostic)
+GET  /api/browser/*                  Playwright browser control
+GET  /api/github/*                   generic GitHub REST (repos, orgs, releases)
+```
+
+## Platform agnosticism
+
+`fsa-adapter.sh` sources `scripts/includes/platform-adapter.sh`, giving every
+FSA adapter access to `pa_init / pa_api_get / pa_rate_limit_remaining` for all
+5 platforms. Use `fsa_platform_init()` to switch platforms within an adapter:
+
+```bash
+# Switch to GitLab for a specific operation
+fsa_platform_init gitlab
+pa_list_repos "openos-project"
+
+# Switch back to GitHub
+fsa_platform_init github
+```
+
+Token selection is automatic per platform:
+
+| Platform | Token env var |
+|---|---|
+| `github` | `GH_TOKEN` / `SYNC_TOKEN` |
+| `gitlab` | `GITLAB_TOKEN` |
+| `gitea` | `GITEA_TOKEN` |
+| `forgejo` | `FORGEJO_TOKEN` |
+| `codeberg` | `CODEBERG_TOKEN` |
+
+`workflows/list.sh` and `workflows/run.sh` both have platform branches:
+- **GitHub**: reads `.github/workflows/`, dispatches `workflow_dispatch`
+- **GitLab**: reads `.gitlab-ci.yml` jobs, triggers pipelines via `/projects/:id/pipeline`
+- **Gitea/Forgejo**: reads Actions workflows, dispatches via Gitea API
+- **Codeberg**: routes through Forgejo-compatible path
+
+## Feature toggles
+
+Each toggle gates a domain. All enabled by default.
+
+| Toggle | Domain |
+|---|---|
+| `notifications` | `/api/fsa/notifications/*` |
+| `onboarding` | `/api/fsa/repos/onboard` |
+| `flush_pipeline` | `/api/fsa/chain/*` |
+| `bdfs` | `/api/fsa/bdfs/*` |
+| `security` | `/api/fsa/security/*` |
+| `docs` | `/api/fsa/docs/*` |
+| `deployments` | `/api/fsa/deployments/*` |
+| `codebase` | `/api/fsa/codebase/*` |
+
+## Adding a new FSA adapter
+
+1. Create `fsa-api/core/adapters/<domain>/<verb>.sh`
+2. Source `fsa-adapter.sh` at the top
+3. Add a route entry to `fsa-api/config/fsa-routes.yml`
+4. Add a toggle to `fsa-api/config/fsa-toggles.yml` if the domain is new
+5. Run `python3 scripts/validate-workflow-guards.py` — zero warnings required
+
+```bash
+#!/usr/bin/env bash
+# GET /api/fsa/<domain>/<resource>
+source "$(dirname "${BASH_SOURCE[0]}")/../../lib/fsa-adapter.sh"
+
+fsa_quota_check 50 || exit 0
+toggle_enabled my_toggle || { fsa_error "disabled" 503; exit 0; }
+
+# ... adapter logic ...
+fsa_ok '{"result":"..."}'
+```
+
+Key helpers from `fsa-adapter.sh`:
+
+| Helper | Source | Purpose |
+|---|---|---|
+| `fsa_quota_check N` | delegates to `shared.sh` | exit 429 if remaining < N |
+| `fsa_ok / fsa_error / fsa_list` | aliases for `json_ok / json_error / json_list` | JSON responses |
+| `fsa_api_get / fsa_api_post` | fsa-adapter.sh | GitHub REST with retry |
+| `fsa_graphql` | fsa-adapter.sh | GitHub GraphQL (GitHub only) |
+| `fsa_platform_init [PLATFORM]` | fsa-adapter.sh | switch active platform |
+| `toggle_enabled NAME` | shared.sh | check toggle state |
+| `pa_api_get / pa_list_repos` | platform-adapter.sh | platform-agnostic API |
+| `merge_routes_files FILE...` | shared.sh | merge multiple route manifests |
 
 ## Consumer repo usage
 
-To use UAA in your own repo:
+Consumer repos receive the UAA layer only — not FSA's GitHub-specific core adapters.
+`sync-template.sh` enforces this via `EXCLUDED_PATHS` in `config/template-manifest.yml`.
 
+To use UAA in your own repo:
 1. Copy `fsa-api/uaa/` into your repo as `my-api/uaa/`
 2. Create `my-api/core/adapters/` with your platform-specific adapters
 3. Create `my-api/config/routes.yml` extending `uaa/config/routes.yml`
 4. Start with `bash my-api/server/start.sh`
 
-`fsa-api/core/` is the reference implementation showing how to extend UAA.
-
-## Workflow dispatch via API
-
-```bash
-# Dispatch any FSA workflow
-curl -X POST http://localhost:8080/api/fsa/workflows/sync-forks/run \
-  -H "Content-Type: application/json" \
-  -d '{"inputs": {}}'
-
-# With inputs
-curl -X POST http://localhost:8080/api/fsa/workflows/generate-notebooklm/run \
-  -H "Content-Type: application/json" \
-  -d '{"inputs": {"backend": "open-notebook", "content_types": "audio-overview"}}'
-```
-
-## Feature toggles
-
-Toggles live in `fsa-api/config/fsa-toggles.yml` and are also stored as
-GitHub Actions repo variables (`FSA_TOGGLE_*`) so they persist across runs.
-
-```bash
-# List all toggles
-bash fsa-api/cli/fsa.sh toggle list
-
-# Enable/disable a workflow
-bash fsa-api/cli/fsa.sh toggle set notify-manager enabled
-bash fsa-api/cli/fsa.sh toggle set translate-readmes disabled
-```
+`fsa-api/scripts/scaffold-consumer.sh` generates the boilerplate automatically.
+`fsa-api/core/` is the reference implementation for how to extend UAA.

--- a/fsa-api/config/fsa-routes.yml
+++ b/fsa-api/config/fsa-routes.yml
@@ -100,6 +100,64 @@ routes:
     toggle: security
     # ?format=json|text&categories=all|packages|agents|extensions|processes
 
+  # ── Deployments ──────────────────────────────────────────────────────────────
+  - path: /api/fsa/deployments
+    script: core/adapters/deployments/list.sh
+    method: GET
+    toggle: deployments
+    # ?check=false|true&platform=all|github|gitlab&position=all|source|mirror
+
+  - path: /api/fsa/deployments/:id/status
+    script: core/adapters/deployments/status.sh
+    method: GET
+    toggle: deployments
+    # Probes platform API + FSA-API health for the named deployment
+
+  - path: /api/fsa/deployments/:id/workflows
+    script: core/adapters/deployments/workflows.sh
+    method: GET
+    toggle: deployments
+    # ?limit=N — lists GitHub Actions workflows or GitLab pipelines
+
+  - path: /api/fsa/deployments/:id/dispatch
+    script: core/adapters/deployments/dispatch.sh
+    method: POST
+    auth: true
+    toggle: deployments
+    # body: {"workflow":"sync-forks.yml","ref":"main","inputs":{...}}
+
+  - path: /api/fsa/deployments/:id/codebase
+    script: core/adapters/codebase/drift.sh
+    method: GET
+    toggle: deployments
+    # Drift check scoped to a single deployment
+
+  # ── Codebase ─────────────────────────────────────────────────────────────────
+  - path: /api/fsa/codebase/status
+    script: core/adapters/codebase/status.sh
+    method: GET
+    toggle: codebase
+    # Current commit, branch, dirty state, ahead/behind, inventory counts
+
+  - path: /api/fsa/codebase/drift
+    script: core/adapters/codebase/drift.sh
+    method: GET
+    toggle: codebase
+    # ?deployment=all|<id> — cross-deployment SHA comparison
+
+  - path: /api/fsa/codebase/log
+    script: core/adapters/codebase/log.sh
+    method: GET
+    toggle: codebase
+    # ?limit=N&since=YYYY-MM-DD&author=<name>&path=<path>
+
+  - path: /api/fsa/codebase/sync
+    script: core/adapters/codebase/sync.sh
+    method: POST
+    auth: true
+    toggle: codebase
+    # body: {"dry_run":false,"force":false}
+
   # ── Docs / Publishing ────────────────────────────────────────────────────────
   - path: /api/fsa/docs
     script: core/adapters/docs/list.sh

--- a/fsa-api/config/fsa-routes.yml
+++ b/fsa-api/config/fsa-routes.yml
@@ -100,6 +100,32 @@ routes:
     toggle: security
     # ?format=json|text&categories=all|packages|agents|extensions|processes
 
+  # ── Docs / Publishing ────────────────────────────────────────────────────────
+  - path: /api/fsa/docs
+    script: core/adapters/docs/list.sh
+    method: GET
+    toggle: docs
+    # ?category=all|book|readme|translate|sbom|notebooklm
+
+  - path: /api/fsa/docs/status
+    script: core/adapters/docs/status.sh
+    method: GET
+    toggle: docs
+    # ?category=all|book|readme|translate|sbom|notebooklm
+
+  - path: /api/fsa/docs/content
+    script: core/adapters/docs/content.sh
+    method: GET
+    toggle: docs
+    # ?format=index|toc|pages&section=<name>
+
+  - path: /api/fsa/docs/dispatch
+    script: core/adapters/docs/dispatch.sh
+    method: POST
+    auth: true
+    toggle: docs
+    # body: {"workflow":"deploy-book","ref":"main","inputs":{...}}
+
   # ── Toggles ─────────────────────────────────────────────────────────────────
   - path: /api/fsa/toggles
     script: core/adapters/toggles/list.sh

--- a/fsa-api/config/fsa-toggles.yml
+++ b/fsa-api/config/fsa-toggles.yml
@@ -43,3 +43,12 @@ toggles:
     description: dev-machine-guard security scan endpoint
     affects:
       - /api/fsa/security/scan
+
+  docs:
+    enabled: true
+    description: Docs/publishing endpoints — book, readme, translate, sbom, notebooklm, gitbook
+    affects:
+      - /api/fsa/docs
+      - /api/fsa/docs/status
+      - /api/fsa/docs/content
+      - /api/fsa/docs/dispatch

--- a/fsa-api/config/fsa-toggles.yml
+++ b/fsa-api/config/fsa-toggles.yml
@@ -52,3 +52,22 @@ toggles:
       - /api/fsa/docs/status
       - /api/fsa/docs/content
       - /api/fsa/docs/dispatch
+
+  deployments:
+    enabled: true
+    description: Multi-deployment management — list, status, workflows, dispatch across all FSA instances
+    affects:
+      - /api/fsa/deployments
+      - /api/fsa/deployments/:id/status
+      - /api/fsa/deployments/:id/workflows
+      - /api/fsa/deployments/:id/dispatch
+      - /api/fsa/deployments/:id/codebase
+
+  codebase:
+    enabled: true
+    description: Codebase self-awareness — git status, cross-deployment drift, changelog, self-sync
+    affects:
+      - /api/fsa/codebase/status
+      - /api/fsa/codebase/drift
+      - /api/fsa/codebase/log
+      - /api/fsa/codebase/sync

--- a/fsa-api/core/adapters/codebase/drift.sh
+++ b/fsa-api/core/adapters/codebase/drift.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# GET /api/fsa/codebase/drift
+# Compares the current instance's HEAD SHA against all registered deployments.
+# Shows which mirrors are behind, ahead, or in sync with the source.
+#
+# Query params:
+#   ?deployment=all|<id>   — check specific deployment only (default: all)
+source "$(dirname "${BASH_SOURCE[0]}")/../../lib/fsa-adapter.sh"
+
+DEPLOYMENT_FILTER="${QUERY_deployment:-all}"
+DEPLOYMENTS_FILE="${_FSA_ROOT}/config/fsa-deployments.yml"
+
+cd "$_FSA_ROOT" || { fsa_error "cannot cd to FSA root" 500; exit 0; }
+
+fsa_quota_check 50 || exit 0
+
+python3 - << PYEOF
+import yaml, json, os, sys, subprocess, urllib.request, urllib.error
+from datetime import datetime, timezone
+
+gh_token     = '${GH_TOKEN}'
+gitlab_token = os.environ.get('GITLAB_TOKEN', '')
+dep_filter   = '${DEPLOYMENT_FILTER}'
+repo_root    = '${_FSA_ROOT}'
+
+def run(cmd, default=''):
+    try:
+        return subprocess.check_output(cmd, shell=True, stderr=subprocess.DEVNULL, text=True).strip()
+    except Exception:
+        return default
+
+# Local state
+local_sha    = run('git rev-parse HEAD')
+local_branch = run('git rev-parse --abbrev-ref HEAD')
+
+with open('${DEPLOYMENTS_FILE}') as f:
+    cfg = yaml.safe_load(f) or {}
+
+deployments = [d for d in cfg.get('deployments', []) if d.get('enabled', True)]
+if dep_filter != 'all':
+    deployments = [d for d in deployments if d.get('id') == dep_filter]
+
+def gh_get(path, token, host=''):
+    api = host.replace('https://github.com', 'https://api.github.com') if host else 'https://api.github.com'
+    if api == 'https://github.com': api = 'https://api.github.com'
+    req = urllib.request.Request(f"{api}{path}", headers={
+        'Authorization': f'token {token}',
+        'Accept': 'application/vnd.github+json',
+    })
+    with urllib.request.urlopen(req, timeout=10) as r:
+        return json.loads(r.read())
+
+def gl_get(path, token, gl_host='https://gitlab.com'):
+    req = urllib.request.Request(f"{gl_host}/api/v4{path}", headers={
+        'PRIVATE-TOKEN': token,
+        'Accept': 'application/json',
+    })
+    with urllib.request.urlopen(req, timeout=10) as r:
+        return json.loads(r.read())
+
+results = []
+for dep in deployments:
+    dep_id   = dep.get('id')
+    platform = dep.get('platform', 'github')
+    org      = dep.get('org', '')
+    repo     = dep.get('repo', 'fork-sync-all')
+    host     = dep.get('host', '')
+    group_path = dep.get('group_path', org)
+
+    entry = {
+        'id':       dep_id,
+        'platform': platform,
+        'org':      org,
+        'position': dep.get('position'),
+        'local_sha': local_sha,
+        'remote_sha': None,
+        'in_sync': None,
+        'pushed_at': None,
+        'error': None,
+    }
+
+    # Mark self
+    is_self = (dep_id == 'source' and
+               os.environ.get('GITHUB_REPOSITORY', '').endswith('/fork-sync-all') and
+               os.environ.get('GITHUB_REPOSITORY_OWNER', '') == org)
+    if is_self:
+        entry['remote_sha'] = local_sha
+        entry['in_sync'] = True
+        entry['note'] = 'self'
+        results.append(entry)
+        continue
+
+    try:
+        if platform == 'github':
+            data = gh_get(f'/repos/{org}/{repo}/commits/HEAD', gh_token, host)
+            entry['remote_sha'] = data.get('sha', '')
+            entry['pushed_at']  = data.get('commit', {}).get('committer', {}).get('date', '')
+            entry['in_sync']    = entry['remote_sha'] == local_sha
+            entry['commit_msg'] = data.get('commit', {}).get('message', '').split('\n')[0]
+
+        elif platform == 'gitlab':
+            gl_host = host or 'https://gitlab.com'
+            encoded = group_path.replace('/', '%2F')
+            proj = gl_get(f'/projects/{encoded}%2F{repo}', gitlab_token, gl_host)
+            project_id = proj['id']
+            default_branch = proj.get('default_branch', 'main')
+            commits = gl_get(f'/projects/{project_id}/repository/commits?ref_name={default_branch}&per_page=1', gitlab_token, gl_host)
+            if commits:
+                c = commits[0]
+                entry['remote_sha'] = c.get('id', '')
+                entry['pushed_at']  = c.get('committed_date', '')
+                entry['in_sync']    = entry['remote_sha'] == local_sha
+                entry['commit_msg'] = c.get('title', '')
+
+    except Exception as e:
+        entry['error'] = str(e)
+        entry['in_sync'] = None
+
+    results.append(entry)
+
+in_sync_count = sum(1 for r in results if r.get('in_sync') is True)
+drifted_count = sum(1 for r in results if r.get('in_sync') is False)
+
+print(json.dumps({
+    'ok': True,
+    'local_sha': local_sha,
+    'local_branch': local_branch,
+    'checked_at': datetime.now(timezone.utc).isoformat(),
+    'summary': {
+        'total': len(results),
+        'in_sync': in_sync_count,
+        'drifted': drifted_count,
+        'unknown': len(results) - in_sync_count - drifted_count,
+    },
+    'deployments': results,
+}, indent=2))
+PYEOF

--- a/fsa-api/core/adapters/codebase/log.sh
+++ b/fsa-api/core/adapters/codebase/log.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# GET /api/fsa/codebase/log
+# Returns recent commits to the FSA codebase (the FSA changelog).
+#
+# Query params:
+#   ?limit=N          (default: 20, max: 100)
+#   ?since=YYYY-MM-DD (only commits after this date)
+#   ?author=<name>    (filter by author name substring)
+#   ?path=<path>      (filter to commits touching a specific path)
+source "$(dirname "${BASH_SOURCE[0]}")/../../lib/fsa-adapter.sh"
+
+LIMIT="${QUERY_limit:-20}"
+SINCE="${QUERY_since:-}"
+AUTHOR="${QUERY_author:-}"
+PATH_FILTER="${QUERY_path:-}"
+
+cd "$_FSA_ROOT" || { fsa_error "cannot cd to FSA root" 500; exit 0; }
+
+python3 - << PYEOF
+import subprocess, json, sys
+
+limit  = min(int('${LIMIT}') if '${LIMIT}'.isdigit() else 20, 100)
+since  = '${SINCE}'
+author = '${AUTHOR}'
+path_f = '${PATH_FILTER}'
+
+cmd = ['git', 'log', f'-{limit}',
+       '--pretty=format:%H\x1f%h\x1f%s\x1f%an\x1f%ae\x1f%cI']
+
+if since:
+    cmd += [f'--since={since}']
+if author:
+    cmd += [f'--author={author}']
+if path_f:
+    cmd += ['--', path_f]
+
+try:
+    out = subprocess.check_output(cmd, stderr=subprocess.DEVNULL, text=True).strip()
+except Exception as e:
+    print(json.dumps({'ok': False, 'error': str(e)}))
+    sys.exit(0)
+
+commits = []
+for line in out.splitlines():
+    if not line.strip():
+        continue
+    parts = line.split('\x1f')
+    if len(parts) < 6:
+        continue
+    sha, sha_short, msg, author_name, author_email, ts = parts[:6]
+    commits.append({
+        'sha':    sha,
+        'short':  sha_short,
+        'message': msg,
+        'author': author_name,
+        'email':  author_email,
+        'timestamp': ts,
+    })
+
+print(json.dumps({'ok': True, 'count': len(commits), 'commits': commits}, indent=2))
+PYEOF

--- a/fsa-api/core/adapters/codebase/status.sh
+++ b/fsa-api/core/adapters/codebase/status.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# GET /api/fsa/codebase/status
+# Returns the current state of the FSA codebase on this instance:
+#   - Current commit SHA + message + author + timestamp
+#   - Branch name
+#   - Dirty/clean working tree
+#   - Ahead/behind relative to origin/main
+#   - Last push timestamp
+#   - Script + workflow + adapter counts
+source "$(dirname "${BASH_SOURCE[0]}")/../../lib/fsa-adapter.sh"
+
+cd "$_FSA_ROOT" || { fsa_error "cannot cd to FSA root" 500; exit 0; }
+
+python3 - << 'PYEOF'
+import subprocess, json, os, sys
+from datetime import datetime, timezone
+
+def run(cmd, default=''):
+    try:
+        return subprocess.check_output(cmd, shell=True, stderr=subprocess.DEVNULL, text=True).strip()
+    except Exception:
+        return default
+
+repo_root = os.environ.get('_FSA_ROOT', '.')
+os.chdir(repo_root)
+
+# Git state
+sha         = run('git rev-parse HEAD')
+sha_short   = run('git rev-parse --short HEAD')
+branch      = run('git rev-parse --abbrev-ref HEAD')
+commit_msg  = run('git log -1 --pretty=%s')
+commit_author = run('git log -1 --pretty=%an')
+commit_ts   = run('git log -1 --pretty=%cI')
+dirty_files = run('git status --porcelain')
+is_dirty    = bool(dirty_files.strip())
+dirty_count = len([l for l in dirty_files.splitlines() if l.strip()])
+
+# Ahead/behind origin/main
+try:
+    ab = run('git rev-list --left-right --count origin/main...HEAD')
+    behind, ahead = (int(x) for x in ab.split())
+except Exception:
+    behind, ahead = 0, 0
+
+# Remote URL
+remote_url = run('git remote get-url origin')
+
+# Codebase inventory
+wf_count     = len([f for f in os.listdir('.github/workflows') if f.endswith(('.yml','.yaml'))]) if os.path.isdir('.github/workflows') else 0
+script_count = int(run("find scripts -name '*.sh' | wc -l", '0'))
+adapter_count = int(run("find fsa-api/core/adapters -name '*.sh' | wc -l", '0'))
+uaa_adapter_count = int(run("find fsa-api/uaa/adapters -name '*.sh' | wc -l", '0'))
+
+# FSA-API route count
+route_count = 0
+try:
+    import yaml
+    with open('fsa-api/config/fsa-routes.yml') as f:
+        cfg = yaml.safe_load(f)
+    route_count = len(cfg.get('routes', []))
+    with open('fsa-api/uaa/config/routes.yml') as f:
+        ucfg = yaml.safe_load(f)
+    route_count += len(ucfg.get('routes', []))
+except Exception:
+    pass
+
+result = {
+    'ok': True,
+    'sha': sha,
+    'sha_short': sha_short,
+    'branch': branch,
+    'commit': {
+        'message': commit_msg,
+        'author': commit_author,
+        'timestamp': commit_ts,
+    },
+    'remote_url': remote_url,
+    'dirty': is_dirty,
+    'dirty_file_count': dirty_count,
+    'ahead': ahead,
+    'behind': behind,
+    'inventory': {
+        'workflows': wf_count,
+        'scripts': script_count,
+        'fsa_adapters': adapter_count,
+        'uaa_adapters': uaa_adapter_count,
+        'api_routes': route_count,
+    },
+    'checked_at': datetime.now(timezone.utc).isoformat(),
+}
+
+print(json.dumps(result, indent=2))
+PYEOF

--- a/fsa-api/core/adapters/codebase/sync.sh
+++ b/fsa-api/core/adapters/codebase/sync.sh
@@ -52,22 +52,40 @@ if node_position == 'source':
     result['message'] = 'This is the source instance — already authoritative. No sync needed.'
 
 elif node_position in ('mirror', 'downstream-fork'):
-    # Dispatch sync-fsa-forks.yml on the source to push updates to this mirror
-    # OR trigger a self-update via the existing ota-self-update.yml if available
-    owner, repo = fsa_repo.split('/') if '/' in fsa_repo else ('Interested-Deving-1896', 'fork-sync-all')
+    # Always dispatch on the SOURCE repo — sync-fsa-forks.yml and ota-self-update.yml
+    # only exist there. Dispatching on a mirror repo would 404.
+    # The source workflow then pushes the update to this mirror via fsa-forks.yml.
+    owner, repo = 'Interested-Deving-1896', 'fork-sync-all'
 
     # Check if ota-self-update.yml exists (self-update path)
     self_update_wf = os.path.join(fsa_root, '.github/workflows/ota-self-update.yml')
     sync_fsa_wf    = os.path.join(fsa_root, '.github/workflows/sync-fsa-forks.yml')
 
-    if dry_run:
-        result['action'] = 'dry_run'
-        result['message'] = f'Would dispatch sync workflow on {owner}/{repo}'
-        result['would_dispatch'] = 'ota-self-update.yml' if os.path.exists(self_update_wf) else 'sync-fsa-forks.yml'
+    # Determine which workflow to dispatch:
+    #   force=true  → critical-deploy-gitlab.yml (direct git push, bypasses mirror sync)
+    #   normal      → ota-self-update.yml if present, else sync-fsa-forks.yml
+    # sync-fsa-forks.yml handles all platforms (GitHub + GitLab) via platform-adapter.sh
+    # and config/fsa-forks.yml, so it is the correct normal-path for all mirror types.
+    if force:
+        wf_file = 'critical-deploy-gitlab.yml'
+        wf_inputs = {'push_to_gitlab': 'true', 'clear_pipelines': 'false',
+                     'pause_schedules': 'false', 'resume_schedules': 'false',
+                     'trigger_pipeline': 'true'}
+    elif os.path.exists(self_update_wf):
+        wf_file = 'ota-self-update.yml'
+        wf_inputs = {'force': str(force).lower()}
     else:
-        wf_file = 'ota-self-update.yml' if os.path.exists(self_update_wf) else 'sync-fsa-forks.yml'
+        wf_file = 'sync-fsa-forks.yml'
+        wf_inputs = {'dry_run': str(dry_run).lower()}
+
+    if dry_run and not force:
+        result['action'] = 'dry_run'
+        result['message'] = f'Would dispatch {wf_file} on {owner}/{repo}'
+        result['would_dispatch'] = wf_file
+        result['would_inputs'] = wf_inputs
+    else:
         url = f'https://api.github.com/repos/{owner}/{repo}/actions/workflows/{wf_file}/dispatches'
-        body = json.dumps({'ref': 'main', 'inputs': {'force': str(force).lower()}}).encode()
+        body = json.dumps({'ref': 'main', 'inputs': wf_inputs}).encode()
         req = urllib.request.Request(url, data=body, headers={
             'Authorization': f'token {gh_token}',
             'Accept': 'application/vnd.github+json',
@@ -77,6 +95,7 @@ elif node_position in ('mirror', 'downstream-fork'):
             with urllib.request.urlopen(req, timeout=15) as r:
                 result['action'] = 'dispatched'
                 result['workflow'] = wf_file
+                result['inputs'] = wf_inputs
                 result['message'] = f'Dispatched {wf_file} on {owner}/{repo}'
         except urllib.error.HTTPError as e:
             result['ok'] = False

--- a/fsa-api/core/adapters/codebase/sync.sh
+++ b/fsa-api/core/adapters/codebase/sync.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# POST /api/fsa/codebase/sync
+# Triggers a sync of this FSA instance's codebase from the source deployment.
+# On the source instance: no-op (already authoritative).
+# On GitHub mirrors: dispatches sync-fsa-forks.yml workflow_dispatch.
+# On GitLab mirrors: triggers a pipeline on the mirror project.
+#
+# Body (JSON):
+#   { "dry_run": false, "force": false }
+source "$(dirname "${BASH_SOURCE[0]}")/../../lib/fsa-adapter.sh"
+
+DRY_RUN="${BODY_dry_run:-false}"
+FORCE="${BODY_force:-false}"
+DEPLOYMENTS_FILE="${_FSA_ROOT}/config/fsa-deployments.yml"
+
+fsa_quota_check 30 || exit 0
+
+# Detect which node we are
+NODE_POSITION="${FSA_CHAIN_POSITION:-}"
+if [[ -z "$NODE_POSITION" ]]; then
+  REPO="${GITHUB_REPOSITORY:-}"
+  if [[ "$REPO" == "Interested-Deving-1896/fork-sync-all" ]]; then
+    NODE_POSITION="source"
+  elif [[ -n "${FSA_UPSTREAM_OWNER:-}" ]]; then
+    NODE_POSITION="mirror"
+  else
+    NODE_POSITION="downstream-fork"
+  fi
+fi
+
+python3 - << PYEOF
+import yaml, json, os, sys, urllib.request, urllib.error
+
+dry_run       = '${DRY_RUN}' == 'true'
+force         = '${FORCE}' == 'true'
+node_position = '${NODE_POSITION}'
+gh_token      = '${GH_TOKEN}'
+gitlab_token  = os.environ.get('GITLAB_TOKEN', '')
+fsa_repo      = '${FSA_REPO}'
+fsa_root      = '${_FSA_ROOT}'
+
+result = {
+    'ok': True,
+    'node_position': node_position,
+    'dry_run': dry_run,
+    'action': None,
+    'message': None,
+}
+
+if node_position == 'source':
+    result['action'] = 'none'
+    result['message'] = 'This is the source instance — already authoritative. No sync needed.'
+
+elif node_position in ('mirror', 'downstream-fork'):
+    # Dispatch sync-fsa-forks.yml on the source to push updates to this mirror
+    # OR trigger a self-update via the existing ota-self-update.yml if available
+    owner, repo = fsa_repo.split('/') if '/' in fsa_repo else ('Interested-Deving-1896', 'fork-sync-all')
+
+    # Check if ota-self-update.yml exists (self-update path)
+    self_update_wf = os.path.join(fsa_root, '.github/workflows/ota-self-update.yml')
+    sync_fsa_wf    = os.path.join(fsa_root, '.github/workflows/sync-fsa-forks.yml')
+
+    if dry_run:
+        result['action'] = 'dry_run'
+        result['message'] = f'Would dispatch sync workflow on {owner}/{repo}'
+        result['would_dispatch'] = 'ota-self-update.yml' if os.path.exists(self_update_wf) else 'sync-fsa-forks.yml'
+    else:
+        wf_file = 'ota-self-update.yml' if os.path.exists(self_update_wf) else 'sync-fsa-forks.yml'
+        url = f'https://api.github.com/repos/{owner}/{repo}/actions/workflows/{wf_file}/dispatches'
+        body = json.dumps({'ref': 'main', 'inputs': {'force': str(force).lower()}}).encode()
+        req = urllib.request.Request(url, data=body, headers={
+            'Authorization': f'token {gh_token}',
+            'Accept': 'application/vnd.github+json',
+            'Content-Type': 'application/json',
+        }, method='POST')
+        try:
+            with urllib.request.urlopen(req, timeout=15) as r:
+                result['action'] = 'dispatched'
+                result['workflow'] = wf_file
+                result['message'] = f'Dispatched {wf_file} on {owner}/{repo}'
+        except urllib.error.HTTPError as e:
+            result['ok'] = False
+            result['error'] = f'HTTP {e.code}: {e.read().decode()}'
+else:
+    result['action'] = 'none'
+    result['message'] = f'Unknown node position: {node_position}'
+
+print(json.dumps(result, indent=2))
+PYEOF

--- a/fsa-api/core/adapters/deployments/dispatch.sh
+++ b/fsa-api/core/adapters/deployments/dispatch.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# POST /api/fsa/deployments/:id/dispatch
+# Triggers a workflow (GitHub Actions) or pipeline (GitLab CI) on a remote
+# FSA deployment. Platform-aware: uses the correct dispatch mechanism per platform.
+#
+# Body (JSON):
+#   {
+#     "workflow": "sync-forks.yml",   -- workflow filename (GitHub) or pipeline ref (GitLab)
+#     "ref":      "main",             -- branch/tag to run on
+#     "inputs":   { "dry_run": true } -- workflow_dispatch inputs (GitHub) or variables (GitLab)
+#   }
+source "$(dirname "${BASH_SOURCE[0]}")/../../lib/fsa-adapter.sh"
+
+DEPLOYMENT_ID="${PATH_id:-}"
+WORKFLOW="${BODY_workflow:-}"
+REF="${BODY_ref:-main}"
+INPUTS_JSON="${BODY_inputs:-{}}"
+
+if [[ -z "$DEPLOYMENT_ID" ]]; then
+  fsa_error "deployment id is required" 400; exit 0
+fi
+if [[ -z "$WORKFLOW" ]]; then
+  fsa_error "workflow is required" 400; exit 0
+fi
+
+DEPLOYMENTS_FILE="${_FSA_ROOT}/config/fsa-deployments.yml"
+fsa_quota_check 30 || exit 0
+
+python3 - << PYEOF
+import yaml, json, os, sys, urllib.request, urllib.error
+
+dep_id     = '${DEPLOYMENT_ID}'
+workflow   = '${WORKFLOW}'
+ref        = '${REF}'
+inputs_raw = '${INPUTS_JSON}'
+gh_token   = '${GH_TOKEN}'
+gitlab_token = os.environ.get('GITLAB_TOKEN', '')
+
+try:
+    inputs = json.loads(inputs_raw) if inputs_raw else {}
+except Exception:
+    inputs = {}
+
+with open('${DEPLOYMENTS_FILE}') as f:
+    cfg = yaml.safe_load(f) or {}
+
+dep = next((d for d in cfg.get('deployments', []) if d.get('id') == dep_id), None)
+if not dep:
+    print(json.dumps({'ok': False, 'error': f'deployment not found: {dep_id}', 'code': 404}))
+    sys.exit(0)
+
+platform   = dep.get('platform', 'github')
+org        = dep.get('org', '')
+repo       = dep.get('repo', 'fork-sync-all')
+host       = dep.get('host', '')
+group_path = dep.get('group_path', org)
+
+def do_request(url, data, headers, method='POST'):
+    body = json.dumps(data).encode() if data else None
+    req = urllib.request.Request(url, data=body, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=15) as r:
+            raw = r.read()
+            return json.loads(raw) if raw else {}, r.status
+    except urllib.error.HTTPError as e:
+        raw = e.read()
+        try:
+            return json.loads(raw), e.code
+        except Exception:
+            return {'message': str(e)}, e.code
+
+result = {'ok': False, 'deployment': dep_id, 'platform': platform, 'workflow': workflow}
+
+if platform == 'github':
+    api = host.replace('https://github.com', 'https://api.github.com') if host else 'https://api.github.com'
+    if api == 'https://github.com': api = 'https://api.github.com'
+
+    # Resolve workflow filename
+    wf_file = workflow if workflow.endswith(('.yml', '.yaml')) else f'{workflow}.yml'
+    url = f"{api}/repos/{org}/{repo}/actions/workflows/{wf_file}/dispatches"
+    body = {'ref': ref, 'inputs': inputs}
+    headers = {
+        'Authorization': f'token {gh_token}',
+        'Accept': 'application/vnd.github+json',
+        'Content-Type': 'application/json',
+    }
+    resp, code = do_request(url, body, headers)
+    if code in (204, 200):
+        result['ok'] = True
+        result['message'] = f'dispatched {wf_file} on {org}/{repo}@{ref}'
+        result['dispatch_url'] = f"https://github.com/{org}/{repo}/actions"
+    else:
+        result['error'] = resp.get('message', f'HTTP {code}')
+        result['code'] = code
+
+elif platform == 'gitlab':
+    gl_host = host or 'https://gitlab.com'
+    # First resolve project ID
+    encoded = group_path.replace('/', '%2F')
+    proj_url = f"{gl_host}/api/v4/projects/{encoded}%2F{repo}"
+    req = urllib.request.Request(proj_url, headers={'PRIVATE-TOKEN': gitlab_token})
+    try:
+        with urllib.request.urlopen(req, timeout=10) as r:
+            proj = json.loads(r.read())
+        project_id = proj['id']
+    except Exception as e:
+        print(json.dumps({'ok': False, 'error': f'could not resolve GitLab project: {e}', 'code': 404}))
+        sys.exit(0)
+
+    # Trigger pipeline
+    url = f"{gl_host}/api/v4/projects/{project_id}/pipeline"
+    body = {'ref': ref, 'variables': [{'key': k, 'value': str(v)} for k, v in inputs.items()]}
+    headers = {'PRIVATE-TOKEN': gitlab_token, 'Content-Type': 'application/json'}
+    resp, code = do_request(url, body, headers)
+    if code in (200, 201):
+        result['ok'] = True
+        result['pipeline_id'] = resp.get('id')
+        result['pipeline_url'] = resp.get('web_url', '')
+        result['message'] = f'triggered pipeline on {group_path}/{repo}@{ref}'
+    else:
+        result['error'] = resp.get('message', f'HTTP {code}')
+        result['code'] = code
+
+else:
+    result['error'] = f'dispatch not yet implemented for platform: {platform}'
+    result['code'] = 501
+
+print(json.dumps(result, indent=2))
+PYEOF

--- a/fsa-api/core/adapters/deployments/list.sh
+++ b/fsa-api/core/adapters/deployments/list.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# GET /api/fsa/deployments
+# Lists all registered FSA deployments from config/fsa-deployments.yml.
+# Optionally checks reachability of each instance's FSA-API or platform API.
+#
+# Query params:
+#   ?check=false|true   — probe each deployment's platform API (default: false)
+#   ?platform=all|github|gitlab|gitea|forgejo|codeberg
+#   ?position=all|source|mirror
+source "$(dirname "${BASH_SOURCE[0]}")/../../lib/fsa-adapter.sh"
+
+CHECK="${QUERY_check:-false}"
+PLATFORM_FILTER="${QUERY_platform:-all}"
+POSITION_FILTER="${QUERY_position:-all}"
+
+DEPLOYMENTS_FILE="${_FSA_ROOT}/config/fsa-deployments.yml"
+if [[ ! -f "$DEPLOYMENTS_FILE" ]]; then
+  fsa_error "config/fsa-deployments.yml not found" 404
+  exit 0
+fi
+
+python3 - << PYEOF
+import yaml, json, os, sys, urllib.request, urllib.error
+
+repo_root = '${_FSA_ROOT}'
+check = '${CHECK}' == 'true'
+platform_filter = '${PLATFORM_FILTER}'
+position_filter = '${POSITION_FILTER}'
+gh_token = '${GH_TOKEN}'
+gitlab_token = os.environ.get('GITLAB_TOKEN', '')
+
+with open('${DEPLOYMENTS_FILE}') as f:
+    cfg = yaml.safe_load(f) or {}
+
+deployments = cfg.get('deployments', [])
+results = []
+
+for d in deployments:
+    if not d.get('enabled', True):
+        continue
+    if platform_filter != 'all' and d.get('platform') != platform_filter:
+        continue
+    if position_filter != 'all' and d.get('position') != position_filter:
+        continue
+
+    entry = {
+        'id':           d.get('id'),
+        'platform':     d.get('platform'),
+        'host':         d.get('host', ''),
+        'org':          d.get('org'),
+        'group_path':   d.get('group_path', ''),
+        'repo':         d.get('repo', 'fork-sync-all'),
+        'position':     d.get('position'),
+        'chain_depth':  d.get('chain_depth', 0),
+        'fsa_api_url':  d.get('fsa_api_url', ''),
+        'reachable':    None,
+        'quota':        None,
+    }
+
+    if check:
+        platform = d.get('platform', 'github')
+        org = d.get('org', '')
+        repo = d.get('repo', 'fork-sync-all')
+        try:
+            if platform == 'github':
+                api = d.get('host', 'https://github.com').replace('https://github.com', 'https://api.github.com')
+                if api == 'https://github.com': api = 'https://api.github.com'
+                url = f"{api}/repos/{org}/{repo}"
+                req = urllib.request.Request(url, headers={
+                    'Authorization': f'token {gh_token}',
+                    'Accept': 'application/vnd.github+json',
+                })
+                with urllib.request.urlopen(req, timeout=8) as r:
+                    data = json.loads(r.read())
+                entry['reachable'] = True
+                entry['repo_url'] = data.get('html_url', '')
+
+                # quota
+                rl_req = urllib.request.Request(f"{api}/rate_limit", headers={
+                    'Authorization': f'token {gh_token}',
+                    'Accept': 'application/vnd.github+json',
+                })
+                with urllib.request.urlopen(rl_req, timeout=8) as r:
+                    rl = json.loads(r.read())
+                entry['quota'] = rl.get('resources', {}).get('core', {}).get('remaining')
+
+            elif platform == 'gitlab':
+                host = d.get('host', 'https://gitlab.com')
+                api = f"{host}/api/v4"
+                group_path = d.get('group_path', org)
+                encoded = group_path.replace('/', '%2F')
+                url = f"{api}/projects/{encoded}%2F{repo}"
+                req = urllib.request.Request(url, headers={
+                    'PRIVATE-TOKEN': gitlab_token,
+                    'Accept': 'application/json',
+                })
+                with urllib.request.urlopen(req, timeout=8) as r:
+                    data = json.loads(r.read())
+                entry['reachable'] = True
+                entry['repo_url'] = data.get('web_url', '')
+        except Exception as e:
+            entry['reachable'] = False
+            entry['error'] = str(e)
+
+    results.append(entry)
+
+print(json.dumps({'ok': True, 'count': len(results), 'items': results}, indent=2))
+PYEOF

--- a/fsa-api/core/adapters/deployments/status.sh
+++ b/fsa-api/core/adapters/deployments/status.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# GET /api/fsa/deployments/:id/status
+# Returns the status of a specific FSA deployment:
+#   - Platform API reachability
+#   - Quota remaining
+#   - FSA-API health (if fsa_api_url is set)
+#   - Last workflow/pipeline run status
+source "$(dirname "${BASH_SOURCE[0]}")/../../lib/fsa-adapter.sh"
+
+DEPLOYMENT_ID="${PATH_id:-}"
+if [[ -z "$DEPLOYMENT_ID" ]]; then
+  fsa_error "deployment id is required" 400
+  exit 0
+fi
+
+DEPLOYMENTS_FILE="${_FSA_ROOT}/config/fsa-deployments.yml"
+
+fsa_quota_check 30 || exit 0
+
+python3 - << PYEOF
+import yaml, json, os, sys, urllib.request, urllib.error
+
+dep_id = '${DEPLOYMENT_ID}'
+gh_token = '${GH_TOKEN}'
+gitlab_token = os.environ.get('GITLAB_TOKEN', '')
+
+with open('${DEPLOYMENTS_FILE}') as f:
+    cfg = yaml.safe_load(f) or {}
+
+dep = next((d for d in cfg.get('deployments', []) if d.get('id') == dep_id), None)
+if not dep:
+    print(json.dumps({'ok': False, 'error': f'deployment not found: {dep_id}', 'code': 404}))
+    sys.exit(0)
+
+platform = dep.get('platform', 'github')
+org      = dep.get('org', '')
+repo     = dep.get('repo', 'fork-sync-all')
+host     = dep.get('host', '')
+group_path = dep.get('group_path', org)
+
+result = {
+    'ok': True,
+    'id': dep_id,
+    'platform': platform,
+    'org': org,
+    'repo': repo,
+    'position': dep.get('position'),
+    'chain_depth': dep.get('chain_depth', 0),
+    'reachable': False,
+    'quota': None,
+    'fsa_api_healthy': None,
+    'last_run': None,
+    'error': None,
+}
+
+def gh_get(path, token):
+    api = host.replace('https://github.com', 'https://api.github.com') if host else 'https://api.github.com'
+    if api == 'https://github.com': api = 'https://api.github.com'
+    req = urllib.request.Request(f"{api}{path}", headers={
+        'Authorization': f'token {token}',
+        'Accept': 'application/vnd.github+json',
+    })
+    with urllib.request.urlopen(req, timeout=10) as r:
+        return json.loads(r.read())
+
+def gl_get(path, token, gl_host='https://gitlab.com'):
+    req = urllib.request.Request(f"{gl_host}/api/v4{path}", headers={
+        'PRIVATE-TOKEN': token,
+        'Accept': 'application/json',
+    })
+    with urllib.request.urlopen(req, timeout=10) as r:
+        return json.loads(r.read())
+
+try:
+    if platform == 'github':
+        # Repo reachability
+        data = gh_get(f'/repos/{org}/{repo}', gh_token)
+        result['reachable'] = True
+        result['repo_url'] = data.get('html_url', '')
+        result['default_branch'] = data.get('default_branch', 'main')
+        result['pushed_at'] = data.get('pushed_at', '')
+
+        # Quota
+        rl = gh_get('/rate_limit', gh_token)
+        result['quota'] = rl.get('resources', {}).get('core', {}).get('remaining')
+
+        # Last workflow run (any workflow)
+        runs = gh_get(f'/repos/{org}/{repo}/actions/runs?per_page=1', gh_token)
+        last = (runs.get('workflow_runs') or [{}])[0]
+        if last:
+            result['last_run'] = {
+                'workflow': last.get('name'),
+                'status': last.get('status'),
+                'conclusion': last.get('conclusion'),
+                'created_at': last.get('created_at'),
+                'url': last.get('html_url'),
+            }
+
+    elif platform == 'gitlab':
+        gl_host = host or 'https://gitlab.com'
+        encoded = group_path.replace('/', '%2F')
+        data = gl_get(f'/projects/{encoded}%2F{repo}', gitlab_token, gl_host)
+        result['reachable'] = True
+        result['repo_url'] = data.get('web_url', '')
+        result['default_branch'] = data.get('default_branch', 'main')
+        result['pushed_at'] = data.get('last_activity_at', '')
+        project_id = data.get('id')
+
+        # Last pipeline
+        pipelines = gl_get(f'/projects/{project_id}/pipelines?per_page=1', gitlab_token, gl_host)
+        if pipelines:
+            p = pipelines[0]
+            result['last_run'] = {
+                'pipeline_id': p.get('id'),
+                'status': p.get('status'),
+                'ref': p.get('ref'),
+                'created_at': p.get('created_at'),
+                'url': p.get('web_url'),
+            }
+
+except Exception as e:
+    result['reachable'] = False
+    result['error'] = str(e)
+
+# FSA-API health check (if configured)
+fsa_api_url = dep.get('fsa_api_url', '')
+if fsa_api_url:
+    try:
+        req = urllib.request.Request(f"{fsa_api_url}/health")
+        with urllib.request.urlopen(req, timeout=5) as r:
+            health = json.loads(r.read())
+        result['fsa_api_healthy'] = health.get('status') == 'ok'
+        result['fsa_api_version'] = health.get('version', '')
+    except Exception as e:
+        result['fsa_api_healthy'] = False
+        result['fsa_api_error'] = str(e)
+
+print(json.dumps(result, indent=2))
+PYEOF

--- a/fsa-api/core/adapters/deployments/workflows.sh
+++ b/fsa-api/core/adapters/deployments/workflows.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# GET /api/fsa/deployments/:id/workflows
+# Lists workflows (GitHub Actions) or pipeline jobs (GitLab CI) on a remote
+# FSA deployment. Platform-aware.
+#
+# Query params:
+#   ?limit=N   (default: 20)
+source "$(dirname "${BASH_SOURCE[0]}")/../../lib/fsa-adapter.sh"
+
+DEPLOYMENT_ID="${PATH_id:-}"
+LIMIT="${QUERY_limit:-20}"
+
+if [[ -z "$DEPLOYMENT_ID" ]]; then
+  fsa_error "deployment id is required" 400; exit 0
+fi
+
+DEPLOYMENTS_FILE="${_FSA_ROOT}/config/fsa-deployments.yml"
+fsa_quota_check 30 || exit 0
+
+python3 - << PYEOF
+import yaml, json, os, sys, urllib.request, urllib.error
+
+dep_id     = '${DEPLOYMENT_ID}'
+limit      = int('${LIMIT}') if '${LIMIT}'.isdigit() else 20
+gh_token   = '${GH_TOKEN}'
+gitlab_token = os.environ.get('GITLAB_TOKEN', '')
+
+with open('${DEPLOYMENTS_FILE}') as f:
+    cfg = yaml.safe_load(f) or {}
+
+dep = next((d for d in cfg.get('deployments', []) if d.get('id') == dep_id), None)
+if not dep:
+    print(json.dumps({'ok': False, 'error': f'deployment not found: {dep_id}', 'code': 404}))
+    sys.exit(0)
+
+platform   = dep.get('platform', 'github')
+org        = dep.get('org', '')
+repo       = dep.get('repo', 'fork-sync-all')
+host       = dep.get('host', '')
+group_path = dep.get('group_path', org)
+
+def gh_get(path, token):
+    api = host.replace('https://github.com', 'https://api.github.com') if host else 'https://api.github.com'
+    if api == 'https://github.com': api = 'https://api.github.com'
+    req = urllib.request.Request(f"{api}{path}", headers={
+        'Authorization': f'token {token}',
+        'Accept': 'application/vnd.github+json',
+    })
+    with urllib.request.urlopen(req, timeout=10) as r:
+        return json.loads(r.read())
+
+def gl_get(path, token, gl_host='https://gitlab.com'):
+    req = urllib.request.Request(f"{gl_host}/api/v4{path}", headers={
+        'PRIVATE-TOKEN': token,
+        'Accept': 'application/json',
+    })
+    with urllib.request.urlopen(req, timeout=10) as r:
+        return json.loads(r.read())
+
+items = []
+try:
+    if platform == 'github':
+        data = gh_get(f'/repos/{org}/{repo}/actions/workflows?per_page={limit}', gh_token)
+        for wf in data.get('workflows', []):
+            items.append({
+                'id':           wf.get('id'),
+                'name':         wf.get('name'),
+                'file':         wf.get('path', '').split('/')[-1],
+                'state':        wf.get('state'),
+                'url':          wf.get('html_url'),
+                'has_dispatch': True,  # can't tell without fetching each file; assume yes
+            })
+
+    elif platform == 'gitlab':
+        gl_host = host or 'https://gitlab.com'
+        encoded = group_path.replace('/', '%2F')
+        proj = gl_get(f'/projects/{encoded}%2F{repo}', gitlab_token, gl_host)
+        project_id = proj['id']
+        # GitLab: list pipeline schedules as the closest equivalent
+        schedules = gl_get(f'/projects/{project_id}/pipeline_schedules?per_page={limit}', gitlab_token, gl_host)
+        for s in schedules:
+            items.append({
+                'id':       s.get('id'),
+                'name':     s.get('description', ''),
+                'ref':      s.get('ref'),
+                'cron':     s.get('cron'),
+                'active':   s.get('active'),
+                'url':      f"{gl_host}/{group_path}/{repo}/-/pipeline_schedules",
+            })
+        # Also list recent pipelines as "workflow runs"
+        pipelines = gl_get(f'/projects/{project_id}/pipelines?per_page={limit}', gitlab_token, gl_host)
+        for p in pipelines:
+            items.append({
+                'pipeline_id': p.get('id'),
+                'status':      p.get('status'),
+                'ref':         p.get('ref'),
+                'created_at':  p.get('created_at'),
+                'url':         p.get('web_url'),
+            })
+
+    else:
+        print(json.dumps({'ok': False, 'error': f'platform not yet supported: {platform}', 'code': 501}))
+        sys.exit(0)
+
+except Exception as e:
+    print(json.dumps({'ok': False, 'error': str(e), 'code': 500}))
+    sys.exit(0)
+
+print(json.dumps({'ok': True, 'deployment': dep_id, 'platform': platform, 'count': len(items), 'items': items}, indent=2))
+PYEOF

--- a/fsa-api/core/adapters/docs/content.sh
+++ b/fsa-api/core/adapters/docs/content.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# GET /api/fsa/docs/content
+# Returns the rendered book/docs content index — pages, sections, and their
+# GitHub Pages URLs. Reads from DOCS/ directory structure and book.toml.
+#
+# Query params:
+#   ?format=index|toc|pages   (default: index)
+#   ?section=<name>           (filter to a specific section)
+source "$(dirname "${BASH_SOURCE[0]}")/../../lib/fsa-adapter.sh"
+
+FORMAT="${QUERY_format:-index}"
+SECTION="${QUERY_section:-}"
+
+python3 - << PYEOF
+import os, json, re
+
+repo_root = '${_FSA_ROOT}'
+docs_dir = os.path.join(repo_root, 'DOCS')
+book_toml = os.path.join(repo_root, 'book.toml')
+format_req = '${FORMAT}'
+section_filter = '${SECTION}'.lower()
+
+# Parse book.toml for title and src dir
+book_title = 'fork-sync-all Docs'
+book_src = 'DOCS'
+pages_url = 'https://interested-deving-1896.github.io/fork-sync-all/'
+
+if os.path.exists(book_toml):
+    content = open(book_toml).read()
+    m = re.search(r'title\s*=\s*"([^"]+)"', content)
+    if m: book_title = m.group(1)
+    m = re.search(r'src\s*=\s*"([^"]+)"', content)
+    if m: book_src = m.group(1)
+
+# Walk DOCS/ and build page list
+pages = []
+if os.path.isdir(docs_dir):
+    for root, dirs, files in os.walk(docs_dir):
+        dirs.sort()
+        for f in sorted(files):
+            if not f.endswith('.md'):
+                continue
+            rel = os.path.relpath(os.path.join(root, f), docs_dir)
+            section = rel.split(os.sep)[0] if os.sep in rel else ''
+            if section_filter and section_filter not in section.lower() and section_filter not in f.lower():
+                continue
+            # Derive GitHub Pages URL
+            url_path = rel.replace(os.sep, '/').replace('.md', '.html')
+            if url_path == 'README.html':
+                url_path = 'index.html'
+            pages.append({
+                'path': rel.replace(os.sep, '/'),
+                'section': section,
+                'title': f.replace('.md', '').replace('-', ' ').replace('_', ' ').title(),
+                'url': pages_url + url_path,
+            })
+
+# Build sections index
+sections = {}
+for p in pages:
+    s = p['section'] or 'root'
+    sections.setdefault(s, []).append(p)
+
+if format_req == 'toc':
+    result = {'ok': True, 'title': book_title, 'pages_url': pages_url,
+              'sections': {s: [p['title'] for p in ps] for s, ps in sections.items()}}
+elif format_req == 'pages':
+    result = {'ok': True, 'title': book_title, 'pages_url': pages_url,
+              'count': len(pages), 'pages': pages}
+else:  # index
+    result = {
+        'ok': True,
+        'title': book_title,
+        'pages_url': pages_url,
+        'book_toml': os.path.exists(book_toml),
+        'section_count': len(sections),
+        'page_count': len(pages),
+        'sections': list(sections.keys()),
+        'dispatch_build': '/api/fsa/docs/dispatch',
+        'engines': ['mdbook', 'mkdocs', 'pandoc'],
+    }
+
+print(json.dumps(result, indent=2))
+PYEOF

--- a/fsa-api/core/adapters/docs/dispatch.sh
+++ b/fsa-api/core/adapters/docs/dispatch.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# POST /api/fsa/docs/dispatch
+# Dispatches any docs/publishing workflow by name with optional inputs.
+#
+# Body (JSON):
+#   {
+#     "workflow": "deploy-book",        -- filename stem or display name
+#     "ref": "main",                    -- branch/tag (default: main)
+#     "inputs": { "engine": "mdbook" }  -- workflow_dispatch inputs
+#   }
+#
+# Returns: { "ok": true, "workflow": "...", "run_url": "..." }
+source "$(dirname "${BASH_SOURCE[0]}")/../../lib/fsa-adapter.sh"
+
+WORKFLOW="${BODY_workflow:-}"
+REF="${BODY_ref:-main}"
+INPUTS_JSON="${BODY_inputs:-{}}"
+
+if [[ -z "$WORKFLOW" ]]; then
+  fsa_error "workflow is required" 400
+  exit 0
+fi
+
+# Docs workflow allowlist — only docs/publishing workflows are reachable here
+DOCS_STEMS="book-export deploy-book generate-book-pages update-book-index
+sync-eggs-docs-to-book gitbook-oss create-readmes update-readmes lts-readmes
+readme-wizard validate-readme-render translate-readmes trigger-readme-update
+translate-docs generate-sbom generate-notebooklm refresh-notebooklm-auth
+upload-notebooklm generate-dep-graph generate-repo-descriptions
+update-workflow-triggers-doc"
+
+# Resolve workflow filename
+resolve_docs_workflow() {
+  local name="$1"
+  local wf_dir="${_FSA_ROOT}/.github/workflows"
+  # Exact filename
+  [[ -f "${wf_dir}/${name}" ]] && echo "$name" && return
+  [[ -f "${wf_dir}/${name}.yml" ]] && echo "${name}.yml" && return
+  [[ -f "${wf_dir}/${name}.yaml" ]] && echo "${name}.yaml" && return
+  # Match by display name
+  for f in "${wf_dir}"/*.yml "${wf_dir}"/*.yaml; do
+    [[ -f "$f" ]] || continue
+    wname=$(python3 -c "import yaml; d=yaml.safe_load(open('$f')); print(d.get('name',''))" 2>/dev/null || echo "")
+    [[ "$wname" == "$name" ]] && echo "$(basename "$f")" && return
+  done
+  echo ""
+}
+
+workflow_file=$(resolve_docs_workflow "$WORKFLOW")
+if [[ -z "$workflow_file" ]]; then
+  fsa_error "docs workflow not found: ${WORKFLOW}" 404
+  exit 0
+fi
+
+# Enforce allowlist
+stem="${workflow_file%.yml}"
+stem="${stem%.yaml}"
+if ! echo "$DOCS_STEMS" | grep -qw "$stem"; then
+  fsa_error "workflow '${stem}' is not in the docs/publishing allowlist" 403
+  exit 0
+fi
+
+fsa_quota_check 30 || exit 0
+
+# Dispatch
+fsa_api_post \
+  "/repos/${FSA_REPO}/actions/workflows/${workflow_file}/dispatches" \
+  "{\"ref\":\"${REF}\",\"inputs\":${INPUTS_JSON}}" > /dev/null
+
+sleep 2
+runs=$(fsa_api_get "/repos/${FSA_REPO}/actions/workflows/${workflow_file}/runs?per_page=1")
+run_url=$(echo "$runs" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+runs=d.get('workflow_runs',[])
+print(runs[0].get('html_url','') if runs else '')
+" 2>/dev/null || echo "")
+
+echo "{\"ok\":true,\"workflow\":\"${workflow_file}\",\"ref\":\"${REF}\",\"run_url\":\"${run_url}\"}"

--- a/fsa-api/core/adapters/docs/list.sh
+++ b/fsa-api/core/adapters/docs/list.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# GET /api/fsa/docs
+# Lists all docs/publishing workflows with their last run status and dispatch URL.
+#
+# Query params:
+#   ?category=all|book|readme|translate|sbom|notebooklm  (default: all)
+#   ?status=all|success|failure|in_progress               (default: all)
+source "$(dirname "${BASH_SOURCE[0]}")/../../lib/fsa-adapter.sh"
+
+CATEGORY="${QUERY_category:-all}"
+STATUS_FILTER="${QUERY_status:-all}"
+
+fsa_quota_check 50 || exit 0
+
+python3 - << PYEOF
+import yaml, os, json
+
+repo_root = '${_FSA_ROOT}'
+wf_dir = os.path.join(repo_root, '.github/workflows')
+
+# Docs workflow categories
+CATEGORIES = {
+    'book':        ['book-export', 'deploy-book', 'generate-book-pages', 'update-book-index',
+                    'sync-eggs-docs-to-book', 'gitbook-oss'],
+    'readme':      ['create-readmes', 'update-readmes', 'lts-readmes', 'readme-wizard',
+                    'validate-readme-render', 'translate-readmes', 'trigger-readme-update'],
+    'translate':   ['translate-docs', 'translate-readmes'],
+    'sbom':        ['generate-sbom'],
+    'notebooklm':  ['generate-notebooklm', 'refresh-notebooklm-auth', 'upload-notebooklm'],
+    'publish':     ['deploy-book', 'gitbook-oss'],
+    'generate':    ['generate-book-pages', 'generate-dep-graph', 'generate-notebooklm',
+                    'generate-repo-descriptions', 'generate-sbom', 'update-workflow-triggers-doc'],
+}
+
+# All docs workflow stems
+ALL_DOC_STEMS = set()
+for stems in CATEGORIES.values():
+    ALL_DOC_STEMS.update(stems)
+
+category = '${CATEGORY}'
+results = []
+
+for fname in sorted(os.listdir(wf_dir)):
+    if not fname.endswith(('.yml', '.yaml')):
+        continue
+    stem = fname.replace('.yml', '').replace('.yaml', '')
+    if stem not in ALL_DOC_STEMS:
+        continue
+
+    # Determine categories for this workflow
+    wf_categories = [cat for cat, stems in CATEGORIES.items() if stem in stems]
+
+    if category != 'all' and category not in wf_categories:
+        continue
+
+    path = os.path.join(wf_dir, fname)
+    try:
+        with open(path) as f:
+            d = yaml.safe_load(f)
+        name = d.get('name', fname)
+        on = d.get(True, d.get('on', {})) or {}
+        if isinstance(on, str): on = {on: {}}
+        has_dispatch = 'workflow_dispatch' in on
+        inputs = {}
+        if has_dispatch:
+            wd = on.get('workflow_dispatch') or {}
+            if isinstance(wd, dict):
+                inputs = wd.get('inputs', {}) or {}
+    except Exception:
+        name = fname
+        has_dispatch = False
+        inputs = {}
+
+    results.append({
+        'file': fname,
+        'name': name,
+        'categories': wf_categories,
+        'has_dispatch': has_dispatch,
+        'dispatch_url': '/api/fsa/docs/dispatch',
+        'inputs': list(inputs.keys()),
+        'api_path': f'/api/fsa/docs/{stem}',
+    })
+
+print(json.dumps({'ok': True, 'count': len(results), 'items': results}, indent=2))
+PYEOF

--- a/fsa-api/core/adapters/docs/status.sh
+++ b/fsa-api/core/adapters/docs/status.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# GET /api/fsa/docs/status
+# Returns the last run status for all docs/publishing workflows in one call.
+#
+# Query params:
+#   ?category=all|book|readme|translate|sbom|notebooklm  (default: all)
+source "$(dirname "${BASH_SOURCE[0]}")/../../lib/fsa-adapter.sh"
+
+CATEGORY="${QUERY_category:-all}"
+
+fsa_quota_check 80 || exit 0
+
+# Fetch last run for each docs workflow via GraphQL (1 API call)
+DOCS_WORKFLOWS="book-export.yml deploy-book.yml generate-book-pages.yml update-book-index.yml
+sync-eggs-docs-to-book.yml gitbook-oss.yml create-readmes.yml update-readmes.yml
+lts-readmes.yml readme-wizard.yml validate-readme-render.yml translate-readmes.yml
+translate-docs.yml generate-sbom.yml generate-notebooklm.yml refresh-notebooklm-auth.yml
+upload-notebooklm.yml generate-dep-graph.yml generate-repo-descriptions.yml
+update-workflow-triggers-doc.yml trigger-readme-update.yml"
+
+python3 - << PYEOF
+import json, os, subprocess, sys
+
+repo_root = '${_FSA_ROOT}'
+fsa_repo = '${FSA_REPO}'
+gh_token = '${GH_TOKEN}'
+category = '${CATEGORY}'
+
+CATEGORIES = {
+    'book':       ['book-export', 'deploy-book', 'generate-book-pages', 'update-book-index',
+                   'sync-eggs-docs-to-book', 'gitbook-oss'],
+    'readme':     ['create-readmes', 'update-readmes', 'lts-readmes', 'readme-wizard',
+                   'validate-readme-render', 'translate-readmes', 'trigger-readme-update'],
+    'translate':  ['translate-docs', 'translate-readmes'],
+    'sbom':       ['generate-sbom'],
+    'notebooklm': ['generate-notebooklm', 'refresh-notebooklm-auth', 'upload-notebooklm'],
+    'generate':   ['generate-book-pages', 'generate-dep-graph', 'generate-repo-descriptions',
+                   'generate-notebooklm', 'generate-sbom', 'update-workflow-triggers-doc'],
+}
+
+ALL_DOC_STEMS = set()
+for stems in CATEGORIES.values():
+    ALL_DOC_STEMS.update(stems)
+
+import urllib.request, urllib.error
+
+def gh_get(path):
+    url = f'https://api.github.com{path}'
+    req = urllib.request.Request(url, headers={
+        'Authorization': f'token {gh_token}',
+        'Accept': 'application/vnd.github+json',
+    })
+    try:
+        with urllib.request.urlopen(req, timeout=10) as r:
+            return json.loads(r.read())
+    except Exception:
+        return {}
+
+results = []
+for stem in sorted(ALL_DOC_STEMS):
+    if category != 'all':
+        if stem not in CATEGORIES.get(category, []):
+            continue
+
+    for ext in ['.yml', '.yaml']:
+        wf_file = stem + ext
+        wf_path = os.path.join(repo_root, '.github/workflows', wf_file)
+        if os.path.exists(wf_path):
+            break
+    else:
+        continue
+
+    runs = gh_get(f'/repos/{fsa_repo}/actions/workflows/{wf_file}/runs?per_page=1')
+    last = (runs.get('workflow_runs') or [{}])[0]
+    results.append({
+        'workflow': wf_file,
+        'categories': [c for c, stems in CATEGORIES.items() if stem in stems],
+        'status': last.get('status', 'unknown'),
+        'conclusion': last.get('conclusion'),
+        'run_url': last.get('html_url', ''),
+        'created_at': last.get('created_at', ''),
+        'dispatch_url': '/api/fsa/docs/dispatch',
+    })
+
+print(json.dumps({'ok': True, 'count': len(results), 'items': results}, indent=2))
+PYEOF

--- a/fsa-api/core/adapters/workflows/list.sh
+++ b/fsa-api/core/adapters/workflows/list.sh
@@ -1,17 +1,114 @@
 #!/usr/bin/env bash
 # GET /api/fsa/workflows
-# Lists all FSA workflows with their schedule, last run status, and toggle state.
+# Lists all FSA workflows/pipelines with their schedule, last run status, and toggle state.
+# Platform-aware: reads .github/workflows/ on GitHub, .gitlab-ci.yml jobs on GitLab,
+# Gitea Actions on Gitea/Forgejo, and falls back to local file listing on others.
 #
 # Query params:
 #   ?filter=enabled|disabled|all   (default: all)
-#   ?tier=1|2|3|4                  (filter by priority tier)
+#   ?tier=1|2|3|4                  (filter by priority tier, GitHub only)
 #   ?name=<substring>              (filter by name)
+#   ?platform=<platform>           (override detected platform)
 source "$(dirname "${BASH_SOURCE[0]}")/../../lib/fsa-adapter.sh"
 
 FILTER="${QUERY_filter:-all}"
 TIER_FILTER="${QUERY_tier:-}"
 NAME_FILTER="${QUERY_name:-}"
+PLATFORM_OVERRIDE="${QUERY_platform:-}"
 
+# Re-init platform if override requested
+if [[ -n "$PLATFORM_OVERRIDE" ]]; then
+  fsa_platform_init "$PLATFORM_OVERRIDE"
+fi
+
+ACTIVE_PLATFORM="${PA_PLATFORM:-github}"
+
+# ── GitLab: list .gitlab-ci.yml jobs ─────────────────────────────────────────
+if [[ "$ACTIVE_PLATFORM" == "gitlab" ]]; then
+  gitlab_host="${PA_HOST:-https://gitlab.com}"
+  gitlab_token="${GITLAB_TOKEN:-}"
+  group_path="${FSA_GITLAB_GROUP:-openos-project/ops}"
+  repo="${FSA_REPO##*/}"
+  python3 - << GLEOF
+import yaml, json, os, urllib.request
+
+gl_host = '${gitlab_host}'
+token   = '${gitlab_token}'
+group   = '${group_path}'
+repo    = '${repo}'
+name_f  = '${NAME_FILTER}'.lower()
+
+# Fetch .gitlab-ci.yml via API
+encoded = group.replace('/', '%2F')
+try:
+    req = urllib.request.Request(
+        f"{gl_host}/api/v4/projects/{encoded}%2F{repo}/repository/files/.gitlab-ci.yml/raw?ref=main",
+        headers={'PRIVATE-TOKEN': token})
+    with urllib.request.urlopen(req, timeout=10) as r:
+        ci_content = r.read().decode()
+    ci = yaml.safe_load(ci_content) or {}
+except Exception as e:
+    print(json.dumps({'ok': False, 'error': str(e)}))
+    import sys; sys.exit(0)
+
+items = []
+for job_name, job_def in ci.items():
+    if job_name.startswith('.') or not isinstance(job_def, dict):
+        continue
+    if name_f and name_f not in job_name.lower():
+        continue
+    items.append({
+        'name': job_name,
+        'stage': job_def.get('stage', ''),
+        'rules': bool(job_def.get('rules') or job_def.get('only')),
+        'manual': job_def.get('when') == 'manual',
+        'platform': 'gitlab',
+    })
+
+print(json.dumps({'ok': True, 'platform': 'gitlab', 'count': len(items), 'items': items}, indent=2))
+GLEOF
+  exit 0
+fi
+
+# ── Gitea / Forgejo: list Actions workflows ───────────────────────────────────
+if [[ "$ACTIVE_PLATFORM" == "gitea" || "$ACTIVE_PLATFORM" == "forgejo" ]]; then
+  gitea_host="${PA_HOST:-}"
+  gitea_token="${GITEA_TOKEN:-${FORGEJO_TOKEN:-}}"
+  gitea_org="${FSA_ORG:-}"
+  gitea_repo="${FSA_REPO##*/}"
+  python3 - << GTEOF
+import json, urllib.request
+
+host  = '${gitea_host}'
+token = '${gitea_token}'
+org   = '${gitea_org}'
+repo  = '${gitea_repo}'
+name_f = '${NAME_FILTER}'.lower()
+
+try:
+    req = urllib.request.Request(
+        f"{host}/api/v1/repos/{org}/{repo}/actions/workflows",
+        headers={'Authorization': f'token {token}', 'Accept': 'application/json'})
+    with urllib.request.urlopen(req, timeout=10) as r:
+        data = json.loads(r.read())
+    items = []
+    for wf in data.get('workflows', []):
+        if name_f and name_f not in wf.get('name','').lower():
+            continue
+        items.append({
+            'name':  wf.get('name'),
+            'file':  wf.get('path','').split('/')[-1],
+            'state': wf.get('state'),
+            'platform': '${ACTIVE_PLATFORM}',
+        })
+    print(json.dumps({'ok': True, 'platform': '${ACTIVE_PLATFORM}', 'count': len(items), 'items': items}, indent=2))
+except Exception as e:
+    print(json.dumps({'ok': False, 'error': str(e)}))
+GTEOF
+  exit 0
+fi
+
+# ── GitHub (default): existing implementation ─────────────────────────────────
 fsa_quota_check 100 || exit 0
 
 # Fetch last run for each workflow via GraphQL (1 API call)

--- a/fsa-api/core/adapters/workflows/run.sh
+++ b/fsa-api/core/adapters/workflows/run.sh
@@ -1,20 +1,139 @@
 #!/usr/bin/env bash
 # POST /api/fsa/workflows/:name/run
-# Dispatches a workflow_dispatch event for the named workflow.
+# Dispatches a workflow (GitHub Actions), triggers a pipeline (GitLab CI),
+# or runs an Action (Gitea/Forgejo) on the active platform.
 #
-# Path param:  :name  — workflow filename (e.g. sync-forks.yml) or display name
-# Body (JSON): { "inputs": { "key": "value" }, "ref": "main" }
+# Path param:  :name  — workflow filename / job name / pipeline ref
+# Body (JSON): { "inputs": { "key": "value" }, "ref": "main", "platform": "github" }
 #
 # Returns: { "ok": true, "run_url": "...", "workflow": "..." }
 source "$(dirname "${BASH_SOURCE[0]}")/../../lib/fsa-adapter.sh"
 
 WORKFLOW_NAME="${PATH_name:-}"
 REF="${BODY_ref:-main}"
+PLATFORM_OVERRIDE="${BODY_platform:-${QUERY_platform:-}}"
 
 if [[ -z "$WORKFLOW_NAME" ]]; then
   fsa_error "workflow name is required" 400
   exit 0
 fi
+
+# Re-init platform if override requested
+if [[ -n "$PLATFORM_OVERRIDE" ]]; then
+  fsa_platform_init "$PLATFORM_OVERRIDE"
+fi
+
+ACTIVE_PLATFORM="${PA_PLATFORM:-github}"
+
+# ── GitLab: trigger pipeline ──────────────────────────────────────────────────
+if [[ "$ACTIVE_PLATFORM" == "gitlab" ]]; then
+  gitlab_host="${PA_HOST:-https://gitlab.com}"
+  gitlab_token="${GITLAB_TOKEN:-}"
+  group_path="${FSA_GITLAB_GROUP:-openos-project/ops}"
+  repo="${FSA_REPO##*/}"
+  inputs_json="${BODY_inputs:-{}}"
+  python3 - << GLEOF
+import json, urllib.request, urllib.error, sys
+
+gl_host    = '${gitlab_host}'
+token      = '${gitlab_token}'
+group      = '${group_path}'
+repo       = '${repo}'
+ref        = '${REF}'
+inputs_raw = '${inputs_json}'
+
+try:
+    inputs = json.loads(inputs_raw) if inputs_raw else {}
+except Exception:
+    inputs = {}
+
+encoded = group.replace('/', '%2F')
+# Resolve project ID
+try:
+    req = urllib.request.Request(
+        f"{gl_host}/api/v4/projects/{encoded}%2F{repo}",
+        headers={'PRIVATE-TOKEN': token})
+    with urllib.request.urlopen(req, timeout=10) as r:
+        proj = json.loads(r.read())
+    project_id = proj['id']
+except Exception as e:
+    print(json.dumps({'ok': False, 'error': f'project not found: {e}', 'code': 404}))
+    sys.exit(0)
+
+# Trigger pipeline
+body = json.dumps({
+    'ref': ref,
+    'variables': [{'key': k, 'value': str(v)} for k, v in inputs.items()]
+}).encode()
+req = urllib.request.Request(
+    f"{gl_host}/api/v4/projects/{project_id}/pipeline",
+    data=body,
+    headers={'PRIVATE-TOKEN': token, 'Content-Type': 'application/json'},
+    method='POST')
+try:
+    with urllib.request.urlopen(req, timeout=15) as r:
+        resp = json.loads(r.read())
+    print(json.dumps({'ok': True, 'platform': 'gitlab',
+                      'pipeline_id': resp.get('id'),
+                      'pipeline_url': resp.get('web_url', ''),
+                      'ref': ref}))
+except urllib.error.HTTPError as e:
+    err = e.read().decode()
+    print(json.dumps({'ok': False, 'error': err, 'code': e.code}))
+GLEOF
+  exit 0
+fi
+
+# ── Gitea / Forgejo: dispatch workflow ────────────────────────────────────────
+if [[ "$ACTIVE_PLATFORM" == "gitea" || "$ACTIVE_PLATFORM" == "forgejo" ]]; then
+  gitea_host="${PA_HOST:-}"
+  gitea_token="${GITEA_TOKEN:-${FORGEJO_TOKEN:-}}"
+  gitea_org="${FSA_ORG:-}"
+  gitea_repo="${FSA_REPO##*/}"
+  inputs_json="${BODY_inputs:-{}}"
+  wf_file="${WORKFLOW_NAME}"
+  [[ "$wf_file" != *.yml && "$wf_file" != *.yaml ]] && wf_file="${wf_file}.yml"
+  python3 - << GTEOF
+import json, urllib.request, urllib.error, sys
+
+host       = '${gitea_host}'
+token      = '${gitea_token}'
+org        = '${gitea_org}'
+repo       = '${gitea_repo}'
+wf_file    = '${wf_file}'
+ref        = '${REF}'
+inputs_raw = '${inputs_json}'
+
+try:
+    inputs = json.loads(inputs_raw) if inputs_raw else {}
+except Exception:
+    inputs = {}
+
+body = json.dumps({'ref': ref, 'inputs': inputs}).encode()
+req = urllib.request.Request(
+    f"{host}/api/v1/repos/{org}/{repo}/actions/workflows/{wf_file}/dispatches",
+    data=body,
+    headers={'Authorization': f'token {token}', 'Content-Type': 'application/json'},
+    method='POST')
+try:
+    with urllib.request.urlopen(req, timeout=15) as r:
+        print(json.dumps({'ok': True, 'platform': '${ACTIVE_PLATFORM}',
+                          'workflow': wf_file, 'ref': ref}))
+except urllib.error.HTTPError as e:
+    print(json.dumps({'ok': False, 'error': e.read().decode(), 'code': e.code}))
+GTEOF
+  exit 0
+fi
+
+# ── Codeberg: Forgejo-compatible dispatch ─────────────────────────────────────
+if [[ "$ACTIVE_PLATFORM" == "codeberg" ]]; then
+  GITEA_TOKEN="${CODEBERG_TOKEN:-}" \
+  PA_HOST="https://codeberg.org" \
+  ACTIVE_PLATFORM="forgejo" \
+  exec "$0" "$@"
+fi
+
+# ── GitHub (default): existing implementation ─────────────────────────────────
 
 # Resolve filename if display name was given
 resolve_workflow_file() {

--- a/fsa-api/core/lib/fsa-adapter.sh
+++ b/fsa-api/core/lib/fsa-adapter.sh
@@ -22,6 +22,20 @@ FSA_REPO="${FSA_REPO:-${GITHUB_REPOSITORY:-Interested-Deving-1896/fork-sync-all}
 FSA_ORG="${FSA_ORG:-${FSA_REPO%%/*}}"
 GH_API="${GH_API:-https://api.github.com}"
 
+# Point shared.sh toggle system at FSA's toggles file
+FSA_TOGGLES_FILE="${_FSA_ROOT}/fsa-api/config/fsa-toggles.yml"
+UAA_TOGGLES_FILE="$FSA_TOGGLES_FILE"
+
+# Override shared.sh quota_fetch() with GitHub-specific implementation
+quota_fetch() {
+  curl -sf \
+    -H "Authorization: token ${GH_TOKEN}" \
+    -H "Accept: application/vnd.github+json" \
+    "${GH_API}/rate_limit" \
+    | python3 -c "import json,sys; print(json.load(sys.stdin).get('resources',{}).get('core',{}).get('remaining',0))" \
+    2>/dev/null || echo 0
+}
+
 # ── GitHub API helpers ────────────────────────────────────────────────────────
 fsa_api_get() {
   local path="$1"
@@ -69,47 +83,28 @@ fsa_graphql() {
     "${GH_API}/graphql" 2>/dev/null || echo "{}"
 }
 
-# ── Quota check ───────────────────────────────────────────────────────────────
+# ── Quota check — delegates to shared.sh quota_check() ───────────────────────
+# quota_fetch() is overridden above with the GitHub-specific implementation.
+# fsa_quota_remaining / fsa_quota_check are kept as aliases for adapters that
+# use the fsa_ prefix; they delegate to shared.sh's generic implementations.
+
 fsa_quota_remaining() {
-  fsa_api_get "/rate_limit" \
-    | python3 -c "import json,sys; print(json.load(sys.stdin).get('resources',{}).get('core',{}).get('remaining',0))" 2>/dev/null || echo 0
+  quota_fetch
 }
 
 fsa_quota_check() {
-  local min="${1:-200}"
-  local remaining
-  remaining=$(fsa_quota_remaining)
-  if [[ "$remaining" -lt "$min" ]]; then
-    fsa_error "Quota too low: ${remaining} remaining (need ${min})" 429
-    return 1
-  fi
-  return 0
+  quota_check "${1:-200}"
 }
 
-# ── JSON response helpers ─────────────────────────────────────────────────────
-fsa_ok()    { echo "{\"ok\":true,\"data\":${1:-null}}"; }
-fsa_error() { echo "{\"ok\":false,\"error\":\"${1:-error}\",\"code\":${2:-500}}"; }
-fsa_list()  { echo "{\"ok\":true,\"count\":$(echo "$1" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))" 2>/dev/null || echo 0),\"items\":${1:-[]}}"; }
+# ── JSON response helpers — aliases to shared.sh ──────────────────────────────
+# shared.sh provides json_ok / json_error / json_list.
+# fsa_ prefixed aliases are kept for backward compatibility with existing adapters.
+fsa_ok()    { json_ok    "$@"; }
+fsa_error() { json_error "$@"; }
+fsa_list()  { json_list  "$@"; }
 
-# ── Toggle helpers ────────────────────────────────────────────────────────────
-FSA_TOGGLES_FILE="${_FSA_ROOT}/fsa-api/config/fsa-toggles.yml"
-
-fsa_toggle_get() {
-  local name="$1"
-  python3 -c "
-import yaml, sys
-with open('${FSA_TOGGLES_FILE}') as f:
-    cfg = yaml.safe_load(f)
-toggles = cfg.get('toggles', {})
-t = toggles.get('${name}')
-if t is None:
-    print('unknown')
-else:
-    print('enabled' if t.get('enabled', True) else 'disabled')
-" 2>/dev/null || echo "unknown"
-}
-
-fsa_toggle_enabled() {
-  local name="$1"
-  [[ "$(fsa_toggle_get "$name")" == "enabled" ]]
-}
+# ── Toggle helpers — delegates to shared.sh toggle_* ─────────────────────────
+# UAA_TOGGLES_FILE is set above to FSA_TOGGLES_FILE.
+# fsa_toggle_* aliases kept for backward compatibility.
+fsa_toggle_get()     { toggle_get     "$@"; }
+fsa_toggle_enabled() { toggle_enabled "$@"; }

--- a/fsa-api/core/lib/fsa-adapter.sh
+++ b/fsa-api/core/lib/fsa-adapter.sh
@@ -11,10 +11,45 @@
 [[ -n "${_FSA_ADAPTER_LOADED:-}" ]] && return 0
 _FSA_ADAPTER_LOADED=1
 
-# Source UAA adapter base
+# Source UAA adapter base (pulls in log.sh, http.sh, shared.sh)
 _FSA_CORE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 _FSA_ROOT="$(cd "${_FSA_CORE_DIR}/../.." && pwd)"
 source "${_FSA_ROOT}/fsa-api/uaa/lib/adapter.sh" 2>/dev/null || true
+
+# Source platform-adapter.sh for multi-platform support (GitHub, GitLab, Gitea, Forgejo, Codeberg)
+# Provides: pa_init, pa_list_repos, pa_repo_exists, pa_api_get,
+#           pa_clone_url, pa_push_url, pa_create_repo, pa_rate_limit_remaining
+source "${_FSA_ROOT}/scripts/includes/platform-adapter.sh" 2>/dev/null || true
+
+# ── Platform detection ────────────────────────────────────────────────────────
+# FSA_PLATFORM — active platform for this adapter invocation.
+# Defaults to 'github' (the source instance platform).
+# Adapters that operate on a specific deployment set FSA_PLATFORM before sourcing,
+# or call fsa_platform_init explicitly.
+FSA_PLATFORM="${FSA_PLATFORM:-github}"
+FSA_PLATFORM_HOST="${FSA_PLATFORM_HOST:-}"
+FSA_PLATFORM_TOKEN="${FSA_PLATFORM_TOKEN:-}"
+
+# fsa_platform_init [PLATFORM] [HOST]
+# Initialises platform-adapter.sh for the given platform.
+# Selects the correct token secret per platform automatically.
+fsa_platform_init() {
+  local platform="${1:-${FSA_PLATFORM:-github}}"
+  local host="${2:-${FSA_PLATFORM_HOST:-}}"
+  local token
+  case "$platform" in
+    github)   token="${GH_TOKEN:-${SYNC_TOKEN:-}}" ;;
+    gitlab)   token="${GITLAB_TOKEN:-${FSA_PLATFORM_TOKEN:-}}" ;;
+    gitea)    token="${GITEA_TOKEN:-${FSA_PLATFORM_TOKEN:-}}" ;;
+    forgejo)  token="${FORGEJO_TOKEN:-${FSA_PLATFORM_TOKEN:-}}" ;;
+    codeberg) token="${CODEBERG_TOKEN:-${FSA_PLATFORM_TOKEN:-}}" ;;
+    *)        token="${FSA_PLATFORM_TOKEN:-${GH_TOKEN:-}}" ;;
+  esac
+  PLATFORM_TOKEN="$token" pa_init "$platform" "$host" 2>/dev/null || true
+}
+
+# Auto-init for the default platform so existing adapters work unchanged
+fsa_platform_init "${FSA_PLATFORM:-github}" "${FSA_PLATFORM_HOST:-}" 2>/dev/null || true
 
 # ── Token ─────────────────────────────────────────────────────────────────────
 GH_TOKEN="${GH_TOKEN:-${SYNC_TOKEN:-}}"
@@ -26,14 +61,19 @@ GH_API="${GH_API:-https://api.github.com}"
 FSA_TOGGLES_FILE="${_FSA_ROOT}/fsa-api/config/fsa-toggles.yml"
 UAA_TOGGLES_FILE="$FSA_TOGGLES_FILE"
 
-# Override shared.sh quota_fetch() with GitHub-specific implementation
+# Override shared.sh quota_fetch() — uses pa_rate_limit_remaining when platform-adapter
+# is initialised, falls back to direct GitHub API call for backward compatibility.
 quota_fetch() {
-  curl -sf \
-    -H "Authorization: token ${GH_TOKEN}" \
-    -H "Accept: application/vnd.github+json" \
-    "${GH_API}/rate_limit" \
-    | python3 -c "import json,sys; print(json.load(sys.stdin).get('resources',{}).get('core',{}).get('remaining',0))" \
-    2>/dev/null || echo 0
+  if [[ -n "${PA_PLATFORM:-}" ]]; then
+    pa_rate_limit_remaining 2>/dev/null || echo 9999
+  else
+    curl -sf \
+      -H "Authorization: token ${GH_TOKEN}" \
+      -H "Accept: application/vnd.github+json" \
+      "${GH_API}/rate_limit" \
+      | python3 -c "import json,sys; print(json.load(sys.stdin).get('resources',{}).get('core',{}).get('remaining',0))" \
+      2>/dev/null || echo 0
+  fi
 }
 
 # ── GitHub API helpers ────────────────────────────────────────────────────────

--- a/fsa-api/server/fsa-start.sh
+++ b/fsa-api/server/fsa-start.sh
@@ -25,8 +25,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FSA_API_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 UAA_ROOT="$FSA_API_ROOT/uaa"
 
-# Source UAA libs (log + routes)
+# Source UAA libs (log + routes + shared)
 source "$UAA_ROOT/lib/log.sh"
+source "$UAA_ROOT/lib/shared.sh"
 source "$UAA_ROOT/lib/routes.sh"
 
 FSA_PORT="${FSA_PORT:-8090}"
@@ -52,6 +53,9 @@ while [[ $# -gt 0 ]]; do
 done
 
 export FSA_PORT FSA_HOST FSA_LOG FSA_ORG FSA_REPO FSA_API_ROOT UAA_ROOT
+
+# Wire shared.sh toggle system for UAA adapters served by FSA
+export UAA_TOGGLES_FILE="$FSA_API_ROOT/config/fsa-toggles.yml"
 
 # Consumer brand/prefix — read from fsa-consumer.yml if enabled
 if [[ -f "$FSA_CONSUMER_CFG" ]] 2>/dev/null; then

--- a/fsa-api/uaa/lib/adapter.sh
+++ b/fsa-api/uaa/lib/adapter.sh
@@ -17,6 +17,7 @@ REPO_ROOT="${REPO_ROOT:-$(cd "$ADAPTER_DIR/../.." && pwd)}"
 
 source "$REPO_ROOT/lib/log.sh"
 source "$REPO_ROOT/lib/http.sh"
+source "$REPO_ROOT/lib/shared.sh"
 
 # ── Input helpers ─────────────────────────────────────────────────────────────
 

--- a/fsa-api/uaa/lib/shared.sh
+++ b/fsa-api/uaa/lib/shared.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# lib/shared.sh — shared logic between UAA and FSA-API
+#
+# This file is the bidirectional sync point. It contains logic that:
+#   - Originated in FSA-API and was generified for UAA consumers
+#   - Is useful to any UAA adapter regardless of platform (GitHub, GitLab, etc.)
+#
+# FSA-API sources this via fsa-api/uaa/lib/shared.sh (symlinked into UAA).
+# UAA adapters source it directly as lib/shared.sh.
+#
+# What lives here (platform-agnostic):
+#   - Toggle system: read/check feature toggles from a YAML config
+#   - Rate-limit helpers: generic quota check + response (no GitHub coupling)
+#   - JSON response helpers: ok/error/list wrappers (mirrors fsa-adapter.sh)
+#   - Multi-file route merge: merge_routes_files() for multi-manifest servers
+#   - Capability registry: register_capability / list_capabilities
+#
+# What does NOT live here (stays in fsa-adapter.sh):
+#   - GitHub REST/GraphQL API calls (fsa_api_get, fsa_api_post, fsa_graphql)
+#   - FSA-specific quota check against api.github.com/rate_limit
+#   - FSA org/repo env vars (FSA_ORG, FSA_REPO)
+
+[[ -n "${_UAA_SHARED_LOADED:-}" ]] && return 0
+_UAA_SHARED_LOADED=1
+
+# ── Toggle system ─────────────────────────────────────────────────────────────
+# Reads a YAML toggles file of the form:
+#   toggles:
+#     feature_name:
+#       enabled: true
+#       description: "..."
+#
+# UAA_TOGGLES_FILE — path to the toggles YAML (set by server or adapter)
+UAA_TOGGLES_FILE="${UAA_TOGGLES_FILE:-}"
+
+# toggle_get NAME — prints "enabled", "disabled", or "unknown"
+toggle_get() {
+  local name="$1"
+  local file="${UAA_TOGGLES_FILE:-}"
+  [[ -z "$file" || ! -f "$file" ]] && echo "unknown" && return
+  python3 -c "
+import yaml, sys
+with open('${file}') as f:
+    cfg = yaml.safe_load(f) or {}
+t = cfg.get('toggles', {}).get('${name}')
+if t is None:
+    print('unknown')
+else:
+    print('enabled' if t.get('enabled', True) else 'disabled')
+" 2>/dev/null || echo "unknown"
+}
+
+# toggle_enabled NAME — returns 0 if enabled, 1 if disabled/unknown
+toggle_enabled() {
+  [[ "$(toggle_get "$1")" == "enabled" ]]
+}
+
+# toggle_list — prints all toggles as JSON
+toggle_list() {
+  local file="${UAA_TOGGLES_FILE:-}"
+  if [[ -z "$file" || ! -f "$file" ]]; then
+    echo '{"ok":true,"toggles":{}}'
+    return
+  fi
+  python3 -c "
+import yaml, json
+with open('${file}') as f:
+    cfg = yaml.safe_load(f) or {}
+toggles = cfg.get('toggles', {}) or {}
+out = {}
+for name, t in toggles.items():
+    if isinstance(t, dict):
+        out[name] = {'enabled': t.get('enabled', True), 'description': t.get('description', '')}
+    else:
+        out[name] = {'enabled': bool(t), 'description': ''}
+print(json.dumps({'ok': True, 'toggles': out}, indent=2))
+" 2>/dev/null || echo '{"ok":false,"error":"failed to read toggles"}'
+}
+
+# toggle_set NAME true|false — writes toggle state back to the YAML file
+toggle_set() {
+  local name="$1" value="$2"
+  local file="${UAA_TOGGLES_FILE:-}"
+  [[ -z "$file" || ! -f "$file" ]] && return 1
+  python3 -c "
+import yaml, sys
+name, value, path = '${name}', '${value}', '${file}'
+with open(path) as f:
+    cfg = yaml.safe_load(f) or {}
+toggles = cfg.setdefault('toggles', {})
+if name not in toggles:
+    toggles[name] = {}
+if isinstance(toggles[name], dict):
+    toggles[name]['enabled'] = (value.lower() == 'true')
+else:
+    toggles[name] = {'enabled': (value.lower() == 'true')}
+with open(path, 'w') as f:
+    yaml.dump(cfg, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
+print('ok')
+" 2>/dev/null
+}
+
+# ── Generic rate-limit / quota helpers ────────────────────────────────────────
+# These are platform-agnostic. Adapters set UAA_QUOTA_REMAINING before calling
+# quota_check, or override quota_fetch() to query their platform's rate limit.
+
+UAA_QUOTA_REMAINING="${UAA_QUOTA_REMAINING:-}"
+
+# quota_fetch — override this in platform-specific adapters to populate
+# UAA_QUOTA_REMAINING from the platform's rate-limit API.
+# Default: returns 9999 (unlimited — safe for platforms without quota).
+quota_fetch() {
+  echo 9999
+}
+
+# quota_check MIN — exits with fsa_error 429 if remaining < MIN.
+# Reads UAA_QUOTA_REMAINING if set, otherwise calls quota_fetch().
+quota_check() {
+  local min="${1:-100}"
+  local remaining="${UAA_QUOTA_REMAINING:-}"
+  if [[ -z "$remaining" ]]; then
+    remaining=$(quota_fetch 2>/dev/null || echo 9999)
+    UAA_QUOTA_REMAINING="$remaining"
+  fi
+  if [[ "$remaining" -lt "$min" ]]; then
+    json_error "quota too low: ${remaining} remaining (need ${min})" 429
+    return 1
+  fi
+  return 0
+}
+
+# ── JSON response helpers ─────────────────────────────────────────────────────
+# Mirrors fsa-adapter.sh helpers so UAA adapters can use the same API.
+# These write to stdout (the HTTP response body).
+
+json_ok()    { echo "{\"ok\":true,\"data\":${1:-null}}"; }
+json_error() { echo "{\"ok\":false,\"error\":\"${1:-error}\",\"code\":${2:-500}}"; }
+json_list()  {
+  local items="$1"
+  local count
+  count=$(echo "$items" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))" 2>/dev/null || echo 0)
+  echo "{\"ok\":true,\"count\":${count},\"items\":${items}}"
+}
+
+# ── Multi-file route merge ────────────────────────────────────────────────────
+# merge_routes_files FILE1 [FILE2 ...] — merges multiple routes.yml files
+# into a single combined manifest, deduplicating by path+method.
+# Prints the merged YAML to stdout.
+merge_routes_files() {
+  python3 - "$@" << 'PYEOF'
+import yaml, sys, os
+
+files = sys.argv[1:]
+seen = {}   # (path, method) -> route — last writer wins
+ordered = []
+
+for fpath in files:
+    if not os.path.isfile(fpath):
+        print(f"[shared] routes file not found: {fpath}", file=sys.stderr)
+        continue
+    with open(fpath) as f:
+        cfg = yaml.safe_load(f) or {}
+    for route in cfg.get('routes', []):
+        key = (route.get('path', ''), route.get('method', 'GET').upper())
+        if key not in seen:
+            ordered.append(key)
+        seen[key] = route
+
+merged = {'routes': [seen[k] for k in ordered]}
+print(yaml.dump(merged, default_flow_style=False, allow_unicode=True, sort_keys=False), end='')
+PYEOF
+}
+
+# ── Capability registry ───────────────────────────────────────────────────────
+# Lightweight in-memory registry for adapter self-description.
+# Adapters call register_capability at load time; /api/adapters reads it.
+
+declare -A _UAA_CAPABILITIES 2>/dev/null || true
+
+# register_capability NAME DESCRIPTION [VERSION]
+register_capability() {
+  local name="$1" desc="$2" ver="${3:-0.1.0}"
+  _UAA_CAPABILITIES["$name"]=$(python3 -c "
+import json
+print(json.dumps({'name': '$name', 'description': '$desc', 'version': '$ver'}))
+" 2>/dev/null || echo "{\"name\":\"$name\"}")
+}
+
+# list_capabilities — prints all registered capabilities as JSON array
+list_capabilities() {
+  local items="["
+  local first=1
+  for key in "${!_UAA_CAPABILITIES[@]}"; do
+    [[ "$first" == "1" ]] || items+=","
+    items+="${_UAA_CAPABILITIES[$key]}"
+    first=0
+  done
+  items+="]"
+  echo "$items"
+}

--- a/fsa-api/uaa/server/start.sh
+++ b/fsa-api/uaa/server/start.sh
@@ -22,6 +22,8 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # shellcheck source=../lib/log.sh
 source "$REPO_ROOT/lib/log.sh"
+# shellcheck source=../lib/shared.sh
+source "$REPO_ROOT/lib/shared.sh"
 # shellcheck source=../lib/routes.sh
 source "$REPO_ROOT/lib/routes.sh"
 
@@ -46,6 +48,10 @@ while [[ $# -gt 0 ]]; do
 done
 
 export UAA_PORT UAA_HOST UAA_LOG REPO_ROOT
+
+# Wire shared.sh toggle system — point at config/toggles.yml if it exists
+UAA_TOGGLES_FILE="${UAA_TOGGLES_FILE:-$REPO_ROOT/config/toggles.yml}"
+[[ -f "$UAA_TOGGLES_FILE" ]] && export UAA_TOGGLES_FILE || unset UAA_TOGGLES_FILE
 
 info "unified-agnostic-api server starting"
 info "  backend : $UAA_BACKEND"

--- a/scripts/sync-template.sh
+++ b/scripts/sync-template.sh
@@ -244,6 +244,18 @@ EXCLUDED_PATHS=(
   # Never propagate fork-sync-all-only config files to consumers.
   "config/workflow-cost-profiles.yml"
   "config/workflow-sync.yml"
+  "config/fsa-forks.yml"
+  "config/fsa-pin.yml"
+  # Never propagate FSA-specific API layer to consumers — these adapters call
+  # Interested-Deving-1896's GitHub org directly and have no meaning in a
+  # consumer repo. Consumers get fsa-api/uaa/ + fsa-api/server/ + fsa-api/cli/
+  # via template-manifest.yml and scaffold their own fsa-api/consumer/ layer.
+  "fsa-api/core"
+  "fsa-api/config/fsa-routes.yml"
+  "fsa-api/config/fsa-toggles.yml"
+  # fsa-consumer.yml IS propagated — it's the consumer's own config file.
+  # fsa-motto.yml is FSA-specific operational config, not for consumers.
+  "config/fsa-motto.yml"
   # Never propagate the fork-sync-all pytest suite to consumers — these tests
   # validate fork-sync-all's own config/scripts and have no meaning elsewhere.
   "tests"


### PR DESCRIPTION
## What changed

Fixes what consumer repos receive (and don't receive) when fork-sync-all propagates its template via `sync-template.sh`.

### Problem

`fsa-api/core/` was not excluded from `EXCLUDED_PATHS`, meaning consumer repos would receive FSA's GitHub-specific adapters — scripts that call `Interested-Deving-1896`'s org directly via `GH_TOKEN`. Running these in a consumer repo would silently operate against the wrong org.

### Fix

**`scripts/sync-template.sh`** — added to `EXCLUDED_PATHS`:
- `fsa-api/core/` — FSA-specific GitHub adapters
- `fsa-api/config/fsa-routes.yml` — FSA routes (consumers scaffold their own)
- `fsa-api/config/fsa-toggles.yml` — FSA toggles (consumers scaffold their own)
- `config/fsa-forks.yml`, `config/fsa-pin.yml`, `config/fsa-motto.yml` — FSA operational config

**`config/template-manifest.yml`** — `infra-core` and `upstream-sync` profiles now explicitly include the consumer-facing FSA API layer:
- `fsa-api/uaa/` — UAA base (generic, reusable)
- `fsa-api/server/fsa-start.sh` — server that merges UAA + consumer routes
- `fsa-api/cli/fsa.sh` — CLI client
- `fsa-api/scripts/scaffold-consumer.sh` — generates branded consumer layer
- `fsa-api/config/fsa-consumer.yml` — consumer brand/prefix config stub
- `.devcontainer/install-security-tools.sh` — ratchet + dev-machine-guard
- Stub versions of `config/fsa-motto.yml` and `config/fsa-pin.yml`

### Result

Consumer repos receive the UAA base + server + CLI + scaffold tooling. Running `bash fsa-api/scripts/scaffold-consumer.sh "MyOrg" myorg` generates their own branded API layer under `fsa-api/consumer/` with routes served at `/api/myorg/...` alongside the UAA base routes.

## Type

- [x] Bug fix

## Checklist

- [x] Validator passes (`validate-workflow-guards.py`)
- [x] `config/template-manifest.yml` parses cleanly
- [x] No secrets committed