### PR TITLE
Proposal: add `ci.yml` skeleton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,154 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PYTHON_VERSION: "3.12"
+  NODE_VERSION: "22"
+  OMOIOS_ENV: test
+
+jobs:
+  lint:
+    name: Lint & Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install dependencies
+        working-directory: backend
+        run: uv sync --group test
+
+      - name: Install linters
+        run: uv tool install ruff@0.9.7
+
+      - name: Ruff lint check
+        working-directory: backend
+        run: ruff check . --statistics
+
+      - name: Ruff format check
+        working-directory: backend
+        run: |
+          ruff format --check . || {
+            echo ""
+            echo "::error::Files need formatting. Run 'uv run ruff format backend/' locally and commit."
+            exit 1
+          }
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7
+        ports:
+          - 16379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install dependencies
+        working-directory: backend
+        run: uv sync --group test
+
+      - name: Run unit tests
+        working-directory: backend
+        env:
+          DATABASE_URL: postgresql+psycopg://postgres:postgres@localhost:15432/omoi_os_test
+          REDIS_URL: redis://localhost:16379
+        run: >-
+          uv run pytest tests/unit/ -x -v
+          --ignore=tests/unit/workers/
+          --ignore=tests/unit/services/test_ownership_validation.py
+          --ignore=tests/unit/services/test_synthesis_service.py
+          --ignore=tests/unit/test_artifact_service.py
+          --ignore=tests/unit/test_credential_encryption.py
+          --ignore=tests/unit/test_environment_credentials_column.py
+          --ignore=tests/unit/test_feature_flags.py
+          --ignore=tests/unit/test_webhook_service.py
+          --ignore=tests/unit/test_credential_broker.py
+          --ignore=tests/unit/test_workspace_isolation.py
+          --ignore=tests/unit/test_environment_service.py
+          --ignore=tests/unit/services/test_session_event_envelope.py
+          -k "not database and not db and not migration"
+
+  frontend:
+    name: Frontend Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check & Build
+        working-directory: frontend
+        run: pnpm build
+
+  secrets-scan:
+    name: Secret Detection
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install detect-secrets
+        run: pip install detect-secrets
+
+      - name: Scan for new secrets (against baseline)
+        run: |
+          # Save the current results (minus timestamp) for comparison
+          python3 -c "import json; d=json.load(open('.secrets.baseline')); d.pop('generated_at',None); json.dump(d,open('/tmp/before.json','w'),sort_keys=True)"
+          # Update baseline with any new findings
+          detect-secrets scan --baseline .secrets.baseline
+          # Compare results (minus timestamp)
+          python3 -c "import json; d=json.load(open('.secrets.baseline')); d.pop('generated_at',None); json.dump(d,open('/tmp/after.json','w'),sort_keys=True)"
+          if diff -q /tmp/before.json /tmp/after.json > /dev/null 2>&1; then
+            echo "No new secrets detected."
+          else
+            echo "::error::New potential secrets found! Run 'detect-secrets scan --baseline .secrets.baseline' locally, audit them, and commit the updated baseline."
+            diff /tmp/before.json /tmp/after.json || true
+            exit 1
+          fi


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/OmoiOS/.github/workflows/ci.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).