### PR TITLE
Proposal: add `ci-integrity-guards.yml` skeleton

### DIFF
--- a/.github/workflows/ci-integrity-guards.yml
+++ b/.github/workflows/ci-integrity-guards.yml
@@ -1,0 +1,64 @@
+name: CI Integrity Guards
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - '.github/schemas/**'
+      - '.vscode/settings.json'
+      - 'templates/*config*.json'
+      - 'scripts/validate-workflow-invariants.mjs'
+      - 'scripts/validate-config-integrity.mjs'
+      - 'scripts/validate-doc-version-pins.mjs'
+      - 'scripts/release-readiness-check.mjs'
+      - 'scripts/validate-codex-plugin.js'
+      - 'scripts/codex-accessibility-dispatch-smoke.mjs'
+      - 'codex-plugin/**'
+      - 'action/README.md'
+      - 'CHANGELOG.md'
+      - 'plugin.yaml'
+      - 'RELEASE-*.md'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/schemas/**'
+      - '.vscode/settings.json'
+      - 'templates/*config*.json'
+      - 'scripts/validate-workflow-invariants.mjs'
+      - 'scripts/validate-config-integrity.mjs'
+      - 'scripts/validate-doc-version-pins.mjs'
+      - 'scripts/release-readiness-check.mjs'
+      - 'scripts/validate-codex-plugin.js'
+      - 'scripts/codex-accessibility-dispatch-smoke.mjs'
+      - 'codex-plugin/**'
+      - 'action/README.md'
+      - 'CHANGELOG.md'
+      - 'plugin.yaml'
+      - 'RELEASE-*.md'
+  workflow_dispatch:
+
+jobs:
+  guard-rails:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout ${REPO_NAME}
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Validate workflow invariants
+        run: node scripts/validate-workflow-invariants.mjs
+
+      - name: Validate config integrity
+        run: node scripts/validate-config-integrity.mjs
+
+      - name: Validate documentation version pins
+        run: node scripts/validate-doc-version-pins.mjs
+
+      - name: Run aggregated release readiness check
+        run: node scripts/release-readiness-check.mjs


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/accessibility-agents/.github/workflows/ci-integrity-guards.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).