### PR TITLE
Proposal: add `release-consistency-guard.yml` skeleton

### DIFF
--- a/.github/workflows/release-consistency-guard.yml
+++ b/.github/workflows/release-consistency-guard.yml
@@ -1,0 +1,105 @@
+name: Release Consistency Guard
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "plugin.yaml"
+      - "gemini-extension.json"
+      - "mcp-server/package.json"
+      - "manifest.json"
+      - "CHANGELOG.md"
+      - "RELEASE-*.md"
+  pull_request:
+    branches: [main]
+    paths:
+      - "plugin.yaml"
+      - "gemini-extension.json"
+      - "mcp-server/package.json"
+      - "manifest.json"
+      - "CHANGELOG.md"
+      - "RELEASE-*.md"
+  workflow_dispatch:
+
+jobs:
+  version-consistency:
+    name: Version Consistency Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Extract and compare versions
+        run: |
+          set -euo pipefail
+
+          # Extract versions from each manifest
+          PLUGIN_VER=$(grep -E '^version:' plugin.yaml | head -1 | sed 's/version:[[:space:]]*//' | tr -d '"' | tr -d "'")
+          GEMINI_VER=$(node -pe "require('./gemini-extension.json').version" 2>/dev/null || echo "missing")
+          MCP_VER=$(node -pe "require('./mcp-server/package.json').version" 2>/dev/null || echo "missing")
+          MANIFEST_VER=$(node -pe "require('./manifest.json').version" 2>/dev/null || echo "missing")
+
+          echo "plugin.yaml version:           $PLUGIN_VER"
+          echo "gemini-extension.json version:  $GEMINI_VER"
+          echo "mcp-server/package.json version: $MCP_VER"
+          echo "manifest.json version:           $MANIFEST_VER"
+
+          FAIL=0
+          if [ "$PLUGIN_VER" != "$GEMINI_VER" ]; then
+            echo "::error file=gemini-extension.json::Version mismatch: plugin.yaml=$PLUGIN_VER, gemini-extension.json=$GEMINI_VER"
+            FAIL=1
+          fi
+          if [ "$PLUGIN_VER" != "$MCP_VER" ]; then
+            echo "::error file=mcp-server/package.json::Version mismatch: plugin.yaml=$PLUGIN_VER, mcp-server/package.json=$MCP_VER"
+            FAIL=1
+          fi
+          if [ "$PLUGIN_VER" != "$MANIFEST_VER" ]; then
+            echo "::error file=manifest.json::Version mismatch: plugin.yaml=$PLUGIN_VER, manifest.json=$MANIFEST_VER"
+            FAIL=1
+          fi
+
+          if [ "$FAIL" -eq 1 ]; then
+            echo ""
+            echo "Version mismatch detected. All manifest files must agree on a single version."
+            echo "Update the mismatched file(s) so all four match before merging."
+            exit 1
+          fi
+          echo "All manifest versions agree: $PLUGIN_VER"
+
+      - name: Verify CHANGELOG has entry for current version
+        run: |
+          set -euo pipefail
+          PLUGIN_VER=$(grep -E '^version:' plugin.yaml | head -1 | sed 's/version:[[:space:]]*//' | tr -d '"' | tr -d "'")
+          if grep -qF "[$PLUGIN_VER]" CHANGELOG.md; then
+            echo "CHANGELOG.md contains entry for [$PLUGIN_VER]"
+          else
+            echo "::error file=CHANGELOG.md::No CHANGELOG entry found for version [$PLUGIN_VER]. Add a [${PLUGIN_VER}] section before releasing."
+            exit 1
+          fi
+
+      - name: Verify release notes file and structure
+        run: |
+          set -euo pipefail
+          PLUGIN_VER=$(grep -E '^version:' plugin.yaml | head -1 | sed 's/version:[[:space:]]*//' | tr -d '"' | tr -d "'")
+          RELEASE_FILE="RELEASE-${PLUGIN_VER}.md"
+
+          if [ ! -f "$RELEASE_FILE" ]; then
+            echo "::error file=$RELEASE_FILE::Missing release notes file for version ${PLUGIN_VER}. Create $RELEASE_FILE before releasing."
+            exit 1
+          fi
+
+          if ! grep -qE '^## Overview' "$RELEASE_FILE"; then
+            echo "::error file=$RELEASE_FILE::Release notes must include a '## Overview' section."
+            exit 1
+          fi
+
+          if ! grep -qE '^## Highlights' "$RELEASE_FILE"; then
+            echo "::error file=$RELEASE_FILE::Release notes must include a '## Highlights' section."
+            exit 1
+          fi
+
+          if ! grep -qE '^## Full Changelog' "$RELEASE_FILE"; then
+            echo "::error file=$RELEASE_FILE::Release notes must include a '## Full Changelog' section."
+            exit 1
+          fi
+
+          echo "$RELEASE_FILE exists and includes required release sections."


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/accessibility-agents/.github/workflows/release-consistency-guard.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).