### PR TITLE
Proposal: add `repair-smoke-test.yml` skeleton

### DIFF
--- a/.github/workflows/repair-smoke-test.yml
+++ b/.github/workflows/repair-smoke-test.yml
@@ -1,0 +1,141 @@
+name: Repair Script Smoke Test
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/repair-install.ps1'
+      - 'scripts/repair-install.sh'
+      - 'scripts/Installer.Common.ps1'
+      - 'scripts/installer-common.sh'
+      - '.github/workflows/repair-smoke-test.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'scripts/repair-install.ps1'
+      - 'scripts/repair-install.sh'
+      - 'scripts/Installer.Common.ps1'
+      - 'scripts/installer-common.sh'
+      - '.github/workflows/repair-smoke-test.yml'
+  workflow_dispatch:
+
+jobs:
+  powershell-repair-smoke:
+    name: PowerShell repair script smoke test
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Write minimal install summary fixture
+        shell: powershell
+        run: |
+          $fixture = @{
+            schemaVersion    = '1.0'
+            operation        = 'install'
+            scope            = 'project'
+            targetDir        = $env:RUNNER_TEMP
+            installed        = $true
+            destinations     = @{
+              claude    = @{ agentsDir = Join-Path $env:RUNNER_TEMP '.claude\agents' }
+              copilot   = @{}
+              copilotCli = @{}
+              codex     = @{}
+              gemini    = @{}
+              mcp       = @{ serverDir = Join-Path $env:RUNNER_TEMP 'mcp-server' }
+            }
+            notes            = @()
+            issues           = @()
+            issueCount       = 0
+            lastRepairRun    = $null
+            version          = '4.6.0'
+            elapsedSeconds   = 0
+          } | ConvertTo-Json -Depth 10
+
+          $fixturePath = Join-Path $env:RUNNER_TEMP 'smoke-test-summary.json'
+          Set-Content -Path $fixturePath -Value $fixture -Encoding utf8
+          Write-Host "Written fixture to: $fixturePath"
+
+          # Create the stub destination directories so validate does not flag them as missing
+          $claudeDir = Join-Path $env:RUNNER_TEMP '.claude\agents'
+          $mcpDir    = Join-Path $env:RUNNER_TEMP 'mcp-server'
+          New-Item -ItemType Directory -Path $claudeDir -Force | Out-Null
+          New-Item -ItemType Directory -Path $mcpDir    -Force | Out-Null
+
+      - name: Run repair script in validate-only mode
+        shell: powershell
+        run: |
+          $fixturePath = Join-Path $env:RUNNER_TEMP 'smoke-test-summary.json'
+          $result = & pwsh -NoProfile -ExecutionPolicy Bypass -File scripts\repair-install.ps1 `
+            -SummaryPath $fixturePath
+          $exitCode = $LASTEXITCODE
+          Write-Host "Repair script exited with code: $exitCode"
+          if ($exitCode -ne 0) { throw "Repair script (validate-only) exited with non-zero code $exitCode" }
+
+      - name: Run repair script with -Repair flag
+        shell: powershell
+        run: |
+          $fixturePath = Join-Path $env:RUNNER_TEMP 'smoke-test-summary.json'
+          & pwsh -NoProfile -ExecutionPolicy Bypass -File scripts\repair-install.ps1 `
+            -SummaryPath $fixturePath `
+            -Repair
+          $exitCode = $LASTEXITCODE
+          Write-Host "Repair script (-Repair) exited with code: $exitCode"
+          if ($exitCode -ne 0) { throw "Repair script (-Repair) exited with non-zero code $exitCode" }
+
+      - name: Confirm repair summary was written
+        shell: powershell
+        run: |
+          $repairPath = Join-Path (Get-Location).Path '.a11y-agent-team-repair-summary.json'
+          if (-not (Test-Path $repairPath)) { throw "Repair summary file was not written: $repairPath" }
+          $repairData = Get-Content $repairPath -Raw | ConvertFrom-Json
+          Write-Host "Repair summary operation: $($repairData.operation)"
+          if ($repairData.operation -ne 'repair-install') { throw "Expected repair summary operation='repair-install', got '$($repairData.operation)'" }
+          Write-Host "Smoke test passed."
+
+  shell-repair-smoke:
+    name: Shell repair script smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Write minimal install summary fixture
+        run: |
+          FIXTURE_DIR="$RUNNER_TEMP"
+          CLAUDE_DIR="$FIXTURE_DIR/.claude/agents"
+          MCP_DIR="$FIXTURE_DIR/mcp-server"
+          mkdir -p "$CLAUDE_DIR" "$MCP_DIR"
+
+          OUT="$FIXTURE_DIR/smoke-test-summary.json"
+          python3 -c "import json, os; d=os.environ['RUNNER_TEMP']; json.dump({'schemaVersion':'1.0','operation':'install','scope':'project','targetDir':d,'installed':True,'destinations':{'claude':{'agentsDir':os.path.join(d,'.claude','agents')},'copilot':{},'copilotCli':{},'codex':{},'gemini':{},'mcp':{'serverDir':os.path.join(d,'mcp-server')}},'notes':[],'issues':[],'issueCount':0,'lastRepairRun':None,'version':'4.6.0','elapsedSeconds':0}, open(os.path.join(d,'smoke-test-summary.json'),'w'), indent=2)"
+          echo "Written fixture to: $OUT"
+
+      - name: Run repair script in validate-only mode
+        run: |
+          FIXTURE="$RUNNER_TEMP/smoke-test-summary.json"
+          bash scripts/repair-install.sh --summary="$FIXTURE" --validate-only
+          echo "Repair script (validate-only) exit code: $?"
+
+      - name: Run repair script with repair enabled
+        run: |
+          FIXTURE="$RUNNER_TEMP/smoke-test-summary.json"
+          bash scripts/repair-install.sh --summary="$FIXTURE"
+          echo "Repair script (repair) exit code: $?"
+
+      - name: Confirm repair summary was written
+        run: |
+          REPAIR_PATH="$(pwd)/.a11y-agent-team-repair-summary.json"
+          if [ ! -f "$REPAIR_PATH" ]; then
+            echo "ERROR: Repair summary file was not written: $REPAIR_PATH"
+            exit 1
+          fi
+          OPERATION=$(python3 -c "import json,sys; d=json.load(open('$REPAIR_PATH')); print(d.get('operation',''))")
+          if [ "$OPERATION" != "repair-install" ]; then
+            echo "ERROR: Expected operation='repair-install', got '$OPERATION'"
+            exit 1
+          fi
+          echo "Smoke test passed."


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/accessibility-agents/.github/workflows/repair-smoke-test.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).