### PR TITLE
Proposal: add `skills-cli-readiness.yml` skeleton

### DIFF
--- a/.github/workflows/skills-cli-readiness.yml
+++ b/.github/workflows/skills-cli-readiness.yml
@@ -1,0 +1,57 @@
+name: Skills CLI Readiness
+
+on:
+  pull_request:
+    paths:
+      - '.github/skills/**'
+      - 'scripts/validate-agents.js'
+      - 'scripts/generate-skills-manifest.js'
+      - 'scripts/generate-skills-sbom.js'
+      - 'scripts/sign-skills-manifest.js'
+      - 'scripts/check-skills-artifacts.js'
+      - '.github/workflows/skills-cli-readiness.yml'
+  workflow_dispatch:
+
+jobs:
+  cli-readiness:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout ${REPO_NAME}
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Validate agents and skills (Phase 3 checks)
+        run: node scripts/validate-agents.js --strict --validate-wcag --validate-urls --skip-url-checks
+
+      - name: Check skill description quality
+        run: node scripts/check-skill-description-quality.js
+
+      - name: Validate Codex plugin surface
+        run: node scripts/validate-codex-plugin.js
+
+      - name: Generate manifest, SBOM, and signature payload
+        env:
+          GH_SKILLS_SIGNING_KEY: ${{ secrets.GH_SKILLS_SIGNING_KEY }}
+          REQUIRE_SIGNING: 'false'
+        run: |
+          node scripts/generate-skills-manifest.js
+          node scripts/generate-skills-sbom.js
+          node scripts/sign-skills-manifest.js
+
+      - name: Verify generated artifacts
+        run: node scripts/check-skills-artifacts.js
+
+      - name: Upload CLI readiness artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: skills-cli-readiness
+          path: |
+            artifacts/skills-manifest.json
+            artifacts/skills-manifest.sig.json
+            artifacts/skills-sbom.cdx.json
+          if-no-files-found: error


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/accessibility-agents/.github/workflows/skills-cli-readiness.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).