### PR TITLE
Proposal: add `skills-release-readiness.yml` skeleton

### DIFF
--- a/.github/workflows/skills-release-readiness.yml
+++ b/.github/workflows/skills-release-readiness.yml
@@ -1,0 +1,63 @@
+name: Skills Release Readiness
+
+on:
+  pull_request:
+    paths:
+      - '.github/skills/**'
+      - 'codex-plugin/**'
+      - '.github/workflows/skills-release-readiness.yml'
+      - '.github/workflows/skills-cli-readiness.yml'
+      - '.github/workflows/skills-supply-chain.yml'
+      - 'scripts/validate-agents.js'
+      - 'scripts/validate-codex-plugin.js'
+      - 'scripts/codex-accessibility-dispatch-smoke.mjs'
+      - 'scripts/generate-skills-manifest.js'
+      - 'scripts/generate-skills-sbom.js'
+      - 'scripts/sign-skills-manifest.js'
+      - 'scripts/check-skills-artifacts.js'
+      - 'scripts/check-release-consistency.js'
+  workflow_dispatch:
+
+jobs:
+  release-readiness:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout ${REPO_NAME}
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Phase 3 validation checks
+        run: node scripts/validate-agents.js --strict --validate-wcag --validate-urls --skip-url-checks
+
+      - name: Description quality gate
+        run: node scripts/check-skill-description-quality.js
+
+      - name: Validate Codex plugin surface
+        run: node scripts/validate-codex-plugin.js
+
+      - name: Validate Codex accessibility dispatch contract
+        run: node scripts/codex-accessibility-dispatch-smoke.mjs
+
+      - name: Generate release artifacts
+        env:
+          GH_SKILLS_SIGNING_KEY: ${{ secrets.GH_SKILLS_SIGNING_KEY }}
+          REQUIRE_SIGNING: ${{ secrets.GH_SKILLS_SIGNING_KEY && matrix.os == 'ubuntu-latest' && 'true' || 'false' }}
+        run: |
+          node scripts/generate-skills-manifest.js
+          node scripts/generate-skills-sbom.js
+          node scripts/sign-skills-manifest.js
+
+      - name: Verify artifacts exist
+        run: node scripts/check-skills-artifacts.js
+
+      - name: Verify release consistency
+        run: node scripts/check-release-consistency.js


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/accessibility-agents/.github/workflows/skills-release-readiness.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).