### PR TITLE
Proposal: add `sync-docs-site.yml` skeleton

### DIFF
--- a/.github/workflows/sync-docs-site.yml
+++ b/.github/workflows/sync-docs-site.yml
@@ -1,0 +1,186 @@
+name: Sync Documentation to Site
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'README.md'
+      - 'CONTRIBUTING.md'
+      - 'CODE_OF_CONDUCT.md'
+      - 'ROADMAP.md'
+      - 'SECURITY.md'
+
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout ${REPO_NAME}
+        uses: actions/checkout@v6
+
+      - name: Build docs manifest
+        run: |
+          echo '{ "generated": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'", "sections": [' > manifest.json
+
+          # Getting Started
+          echo '{"name":"Getting Started","id":"getting-started","items":[' >> manifest.json
+          first=true
+          for f in docs/getting-started.md docs/configuration.md docs/architecture.md; do
+            if [ -f "$f" ]; then
+              title=$(head -5 "$f" | grep -m1 '^#' | sed 's/^#\+ //')
+              [ -z "$title" ] && title=$(basename "$f" .md | sed 's/-/ /g')
+              $first || echo ',' >> manifest.json
+              echo "{\"path\":\"$f\",\"title\":\"$title\"}" >> manifest.json
+              first=false
+            fi
+          done
+          echo ']},' >> manifest.json
+
+          # Agents
+          echo '{"name":"Agents","id":"agents","items":[' >> manifest.json
+          first=true
+          for f in docs/agents/README.md $(find docs/agents -name '*.md' ! -name 'README.md' | sort); do
+            if [ -f "$f" ]; then
+              title=$(head -5 "$f" | grep -m1 '^#' | sed 's/^#\+ //')
+              [ -z "$title" ] && title=$(basename "$f" .md | sed 's/-/ /g')
+              $first || echo ',' >> manifest.json
+              echo "{\"path\":\"$f\",\"title\":\"$title\"}" >> manifest.json
+              first=false
+            fi
+          done
+          echo ']},' >> manifest.json
+
+          # Skills
+          echo '{"name":"Skills","id":"skills","items":[' >> manifest.json
+          first=true
+          for f in $(find docs/skills -name '*.md' | sort); do
+            if [ -f "$f" ]; then
+              title=$(head -5 "$f" | grep -m1 '^#' | sed 's/^#\+ //')
+              [ -z "$title" ] && title=$(basename "$f" .md | sed 's/-/ /g')
+              $first || echo ',' >> manifest.json
+              echo "{\"path\":\"$f\",\"title\":\"$title\"}" >> manifest.json
+              first=false
+            fi
+          done
+          echo ']},' >> manifest.json
+
+          # Tools
+          echo '{"name":"Tools","id":"tools","items":[' >> manifest.json
+          first=true
+          for f in $(find docs/tools -name '*.md' | sort); do
+            if [ -f "$f" ]; then
+              title=$(head -5 "$f" | grep -m1 '^#' | sed 's/^#\+ //')
+              [ -z "$title" ] && title=$(basename "$f" .md | sed 's/-/ /g')
+              $first || echo ',' >> manifest.json
+              echo "{\"path\":\"$f\",\"title\":\"$title\"}" >> manifest.json
+              first=false
+            fi
+          done
+          echo ']},' >> manifest.json
+
+          # Scanning
+          echo '{"name":"Scanning","id":"scanning","items":[' >> manifest.json
+          first=true
+          for f in $(find docs/scanning -name '*.md' | sort); do
+            if [ -f "$f" ]; then
+              title=$(head -5 "$f" | grep -m1 '^#' | sed 's/^#\+ //')
+              [ -z "$title" ] && title=$(basename "$f" .md | sed 's/-/ /g')
+              $first || echo ',' >> manifest.json
+              echo "{\"path\":\"$f\",\"title\":\"$title\"}" >> manifest.json
+              first=false
+            fi
+          done
+          echo ']},' >> manifest.json
+
+          # Prompts: Web
+          echo '{"name":"Prompts: Web","id":"prompts-web","items":[' >> manifest.json
+          first=true
+          for f in $(find docs/prompts/web -name '*.md' | sort); do
+            if [ -f "$f" ]; then
+              title=$(head -5 "$f" | grep -m1 '^#' | sed 's/^#\+ //')
+              [ -z "$title" ] && title=$(basename "$f" .md | sed 's/-/ /g')
+              $first || echo ',' >> manifest.json
+              echo "{\"path\":\"$f\",\"title\":\"$title\"}" >> manifest.json
+              first=false
+            fi
+          done
+          echo ']},' >> manifest.json
+
+          # Prompts: Documents
+          echo '{"name":"Prompts: Documents","id":"prompts-docs","items":[' >> manifest.json
+          first=true
+          for f in $(find docs/prompts/documents -name '*.md' | sort); do
+            if [ -f "$f" ]; then
+              title=$(head -5 "$f" | grep -m1 '^#' | sed 's/^#\+ //')
+              [ -z "$title" ] && title=$(basename "$f" .md | sed 's/-/ /g')
+              $first || echo ',' >> manifest.json
+              echo "{\"path\":\"$f\",\"title\":\"$title\"}" >> manifest.json
+              first=false
+            fi
+          done
+          echo ']},' >> manifest.json
+
+          # Prompts: GitHub
+          echo '{"name":"Prompts: GitHub","id":"prompts-github","items":[' >> manifest.json
+          first=true
+          for f in $(find docs/prompts/github -name '*.md' | sort); do
+            if [ -f "$f" ]; then
+              title=$(head -5 "$f" | grep -m1 '^#' | sed 's/^#\+ //')
+              [ -z "$title" ] && title=$(basename "$f" .md | sed 's/-/ /g')
+              $first || echo ',' >> manifest.json
+              echo "{\"path\":\"$f\",\"title\":\"$title\"}" >> manifest.json
+              first=false
+            fi
+          done
+          echo ']},' >> manifest.json
+
+          # Advanced
+          echo '{"name":"Advanced","id":"advanced","items":[' >> manifest.json
+          first=true
+          for f in $(find docs/advanced -name '*.md' | sort); do
+            if [ -f "$f" ]; then
+              title=$(head -5 "$f" | grep -m1 '^#' | sed 's/^#\+ //')
+              [ -z "$title" ] && title=$(basename "$f" .md | sed 's/-/ /g')
+              $first || echo ',' >> manifest.json
+              echo "{\"path\":\"$f\",\"title\":\"$title\"}" >> manifest.json
+              first=false
+            fi
+          done
+          echo ']},' >> manifest.json
+
+          # Project root files
+          echo '{"name":"Project","id":"project","items":[' >> manifest.json
+          first=true
+          for f in README.md CONTRIBUTING.md CODE_OF_CONDUCT.md ROADMAP.md SECURITY.md; do
+            if [ -f "$f" ]; then
+              title=$(head -5 "$f" | grep -m1 '^#' | sed 's/^#\+ //')
+              [ -z "$title" ] && title=$(basename "$f" .md)
+              $first || echo ',' >> manifest.json
+              echo "{\"path\":\"$f\",\"title\":\"$title\"}" >> manifest.json
+              first=false
+            fi
+          done
+          echo ']}' >> manifest.json
+
+          echo ']}' >> manifest.json
+
+          # Validate JSON
+          python3 -m json.tool manifest.json > /dev/null
+
+      - name: Create pull request with manifest
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ github.token }}
+          commit-message: "chore: update docs manifest [skip ci]"
+          title: "chore: update docs manifest"
+          body: |
+            Automated update of `manifest.json` from docs/ changes.
+            This PR is auto-generated by the Sync Documentation to Site workflow.
+          branch: chore/update-manifest
+          delete-branch: true


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/accessibility-agents/.github/workflows/sync-docs-site.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).