### PR TITLE
Proposal: add `sync-wiki.yml` skeleton

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -1,0 +1,106 @@
+name: Sync Docs to Wiki
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+
+jobs:
+  sync-wiki:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout ${REPO_NAME}
+        uses: actions/checkout@v6
+
+      - name: Checkout ${REPO_NAME}
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ github.repository }}.wiki
+          path: wiki
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sync ${REPO_NAME} to wiki
+        run: |
+          cd wiki
+
+          # Map docs/ files to wiki page names
+          declare -A FILE_MAP
+          FILE_MAP["docs/getting-started.md"]="Getting-Started.md"
+          FILE_MAP["docs/architecture.md"]="Architecture.md"
+          FILE_MAP["docs/configuration.md"]="Configuration.md"
+          FILE_MAP["docs/agents/README.md"]="Agents-Overview.md"
+          FILE_MAP["docs/agents/accessibility-lead.md"]="Agent:-Accessibility-Lead.md"
+          FILE_MAP["docs/agents/web-accessibility-wizard.md"]="Agent:-Web-Accessibility-Wizard.md"
+          FILE_MAP["docs/agents/document-accessibility-wizard.md"]="Agent:-Document-Accessibility-Wizard.md"
+          FILE_MAP["docs/agents/alt-text-headings.md"]="Agent:-Alt-Text-and-Headings.md"
+          FILE_MAP["docs/agents/aria-specialist.md"]="Agent:-ARIA-Specialist.md"
+          FILE_MAP["docs/agents/contrast-master.md"]="Agent:-Contrast-Master.md"
+          FILE_MAP["docs/agents/forms-specialist.md"]="Agent:-Forms-Specialist.md"
+          FILE_MAP["docs/agents/keyboard-navigator.md"]="Agent:-Keyboard-Navigator.md"
+          FILE_MAP["docs/agents/link-checker.md"]="Agent:-Link-Checker.md"
+          FILE_MAP["docs/agents/live-region-controller.md"]="Agent:-Live-Region-Controller.md"
+          FILE_MAP["docs/agents/modal-specialist.md"]="Agent:-Modal-Specialist.md"
+          FILE_MAP["docs/agents/tables-data-specialist.md"]="Agent:-Tables-Data-Specialist.md"
+          FILE_MAP["docs/agents/testing-coach.md"]="Agent:-Testing-Coach.md"
+          FILE_MAP["docs/agents/wcag-guide.md"]="Agent:-WCAG-Guide.md"
+          FILE_MAP["docs/agents/word-accessibility.md"]="Agent:-Word-Accessibility.md"
+          FILE_MAP["docs/agents/excel-accessibility.md"]="Agent:-Excel-Accessibility.md"
+          FILE_MAP["docs/agents/powerpoint-accessibility.md"]="Agent:-PowerPoint-Accessibility.md"
+          FILE_MAP["docs/agents/pdf-accessibility.md"]="Agent:-PDF-Accessibility.md"
+          FILE_MAP["docs/agents/office-scan-config.md"]="Agent:-Office-Scan-Config.md"
+          FILE_MAP["docs/agents/pdf-scan-config.md"]="Agent:-PDF-Scan-Config.md"
+          FILE_MAP["docs/scanning/office-scanning.md"]="Office-Scanning.md"
+          FILE_MAP["docs/scanning/pdf-scanning.md"]="PDF-Scanning.md"
+          FILE_MAP["docs/scanning/scan-configuration.md"]="Scan-Configuration.md"
+          FILE_MAP["docs/scanning/custom-prompts.md"]="Custom-Prompts.md"
+          FILE_MAP["docs/tools/mcp-tools.md"]="MCP-Tools.md"
+          FILE_MAP["docs/tools/axe-core-integration.md"]="Axe-Core-Integration.md"
+          FILE_MAP["docs/tools/vpat-generation.md"]="VPAT-Generation.md"
+          FILE_MAP["docs/advanced/advanced-scanning-patterns.md"]="Advanced-Scanning-Patterns.md"
+          FILE_MAP["docs/advanced/cross-platform-handoff.md"]="Cross-Platform-Handoff.md"
+          FILE_MAP["docs/advanced/platform-references.md"]="Platform-References.md"
+          FILE_MAP["docs/advanced/plugin-packaging.md"]="Plugin-Packaging.md"
+
+          CHANGED=false
+
+          for src in "${!FILE_MAP[@]}"; do
+            dest="${FILE_MAP[$src]}"
+            src_path="../$src"
+            if [ -f "$src_path" ]; then
+              if [ ! -f "$dest" ] || ! diff -q "$src_path" "$dest" > /dev/null 2>&1; then
+                cp "$src_path" "$dest"
+                echo "Updated: $dest"
+                CHANGED=true
+              fi
+            fi
+          done
+
+          # Also pick up any new docs not in the map
+          for f in $(find ../docs -name "*.md" -type f); do
+            rel="${f#../}"
+            if [[ -z "${FILE_MAP[$rel]}" ]]; then
+              basename=$(basename "$f" .md)
+              wiki_name=$(echo "$basename" | sed 's/ /-/g; s/^./\U&/; s/-./\U&/g')
+              wiki_name="${wiki_name}.md"
+              if [ ! -f "$wiki_name" ]; then
+                cp "$f" "$wiki_name"
+                echo "Added new page: $wiki_name"
+                CHANGED=true
+              fi
+            fi
+          done
+
+          if [ "$CHANGED" = true ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add -A
+            git commit -m "Sync docs from repo (automated)"
+            git push
+            echo "Wiki updated."
+          else
+            echo "Wiki already up to date."
+          fi


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/accessibility-agents/.github/workflows/sync-wiki.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).