### PR TITLE
Proposal: add `verify-sources.yml` skeleton

### DIFF
--- a/.github/workflows/verify-sources.yml
+++ b/.github/workflows/verify-sources.yml
@@ -1,0 +1,78 @@
+name: Verify Authoritative Sources
+
+on:
+  pull_request:
+    paths:
+      - '.claude/agents/**/*.md'
+      - 'claude-code-plugin/agents/**/*.md'
+      - '.github/agents/**/*.md'
+      - 'docs/**/*.md'
+      - 'scripts/verify-sources.py'
+      - '.github/agents/SOURCE_REGISTRY.json'
+  schedule:
+    # Run weekly on Monday at 08:00 UTC
+    - cron: '0 8 * * MON'  # TODO: set schedule for your project
+  workflow_dispatch:
+
+jobs:
+  verify-sources:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout ${REPO_NAME}
+        uses: actions/checkout@v6
+      
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+      
+      - name: Install dependencies
+        run: |
+          pip install requests
+      
+      - name: Extract and validate URLs
+        id: validate
+        run: |
+          python scripts/verify-sources.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Report results
+        if: always()
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const results = JSON.parse(fs.readFileSync('source-validation-results.json', 'utf8'));
+            
+            let summary = '## Source Validation Results\n\n';
+            summary += `✅ Valid: ${results.valid}\n`;
+            summary += `⚠️ Redirects: ${results.redirects}\n`;
+            summary += `🚫 Blocked: ${results.blocked || 0}\n`;
+            summary += `❌ Broken: ${results.broken}\n`;
+            summary += `⏭️ Skipped: ${results.skipped}\n\n`;
+            
+            if (results.broken > 0) {
+              summary += '### Broken Links\n';
+              results.broken_links.forEach(link => {
+                summary += `- ${link.file}:${link.line} - ${link.url} (HTTP ${link.status})\n`;
+              });
+              summary += '\nPlease fix these broken links before merging.\n';
+            }
+            
+            if (results.redirects > 0) {
+              summary += '### Redirected Links (Review)\n';
+              results.redirect_links.forEach(link => {
+                summary += `- ${link.file}:${link.line} - ${link.url} → ${link.final_url} (HTTP ${link.status})\n`;
+              });
+              summary += '\nConsider updating these to the final URL.\n';
+            }
+            
+            core.summary.addRaw(summary);
+      
+      - name: Fail if broken links
+        if: failure() && steps.validate.outcome == 'failure'
+        run: |
+          echo "Source validation failed. Check the job logs for details."
+          exit 1


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/accessibility-agents/.github/workflows/verify-sources.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).