### PR TITLE
Proposal: add `test-action.yml` skeleton

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -1,0 +1,199 @@
+name: Test GitHub Action
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "src/action.ts"
+      - "action.yml"
+      - "dist/**"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/test-action.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "action.yml"
+      - "dist/**"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/test-action.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Test the action against the vulnerable examples directory
+  test-vulnerable:
+    name: Scan vulnerable examples
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+      - name: Build action
+        run: npm run build
+
+      - name: Run AgentShield on vulnerable examples
+        id: scan
+        uses: ./
+        with:
+          path: "examples/vulnerable"
+          min-severity: "low"
+          fail-on-findings: "false"
+
+      - name: Verify outputs are set
+        env:
+          SCAN_SCORE: ${{ steps.scan.outputs.score }}
+          SCAN_GRADE: ${{ steps.scan.outputs.grade }}
+          SCAN_TOTAL: ${{ steps.scan.outputs.total-findings }}
+          SCAN_CRITICAL: ${{ steps.scan.outputs.critical-count }}
+        run: |
+          echo "Score: $SCAN_SCORE"
+          echo "Grade: $SCAN_GRADE"
+          echo "Total findings: $SCAN_TOTAL"
+          echo "Critical count: $SCAN_CRITICAL"
+
+          if [ -z "$SCAN_SCORE" ]; then
+            echo "ERROR: score output is empty"
+            exit 1
+          fi
+
+          if [ -z "$SCAN_GRADE" ]; then
+            echo "ERROR: grade output is empty"
+            exit 1
+          fi
+
+          echo "All outputs verified successfully"
+
+  # Test the action on a clean directory (should pass with high score)
+  test-clean:
+    name: Scan clean directory
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+      - name: Build action
+        run: npm run build
+
+      - name: Create clean temp directory
+        run: mkdir -p /tmp/clean-scan
+
+      - name: Run AgentShield on clean directory
+        id: scan
+        uses: ./
+        with:
+          path: "/tmp/clean-scan"
+          min-severity: "medium"
+          fail-on-findings: "true"
+
+      - name: Verify clean scan passes
+        env:
+          SCAN_SCORE: ${{ steps.scan.outputs.score }}
+          SCAN_GRADE: ${{ steps.scan.outputs.grade }}
+        run: |
+          echo "Score: $SCAN_SCORE"
+          echo "Grade: $SCAN_GRADE"
+          echo "Expected high score on clean directory"
+
+  # Test with different severity levels
+  test-severity-filter:
+    name: Test severity filtering
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+      - name: Build action
+        run: npm run build
+
+      - name: Scan with critical-only filter
+        id: critical-only
+        uses: ./
+        with:
+          path: "."
+          min-severity: "critical"
+          fail-on-findings: "false"
+
+      - name: Scan with info filter (all findings)
+        id: all-findings
+        uses: ./
+        with:
+          path: "."
+          min-severity: "info"
+          fail-on-findings: "false"
+
+      - name: Verify filtering works
+        env:
+          CRITICAL_COUNT: ${{ steps.critical-only.outputs.total-findings }}
+          ALL_COUNT: ${{ steps.all-findings.outputs.total-findings }}
+        run: |
+          echo "Critical-only findings: $CRITICAL_COUNT"
+          echo "All findings: $ALL_COUNT"
+          echo "Severity filtering verified"
+
+  # Test that fail-on-findings works
+  test-fail-on-findings:
+    name: Test fail-on-findings
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+      - name: Build action
+        run: npm run build
+
+      - name: Run scan expecting failure (should fail if findings exist)
+        id: should-fail
+        uses: ./
+        with:
+          path: "examples/vulnerable"
+          min-severity: "critical"
+          fail-on-findings: "true"
+        continue-on-error: true
+
+      - name: Verify action behavior
+        env:
+          OUTCOME: ${{ steps.should-fail.outcome }}
+        run: |
+          if [ "$OUTCOME" = "failure" ]; then
+            echo "Action correctly failed on findings - PASS"
+          else
+            echo "Action did not fail"
+            echo "Outcome was: $OUTCOME"
+            echo "(This is OK if no critical findings exist in examples/vulnerable)"
+          fi


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/agentshield/.github/workflows/test-action.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).