### PR TITLE
Proposal: add `ai-bom-scan.yml` skeleton

### DIFF
--- a/.github/workflows/ai-bom-scan.yml
+++ b/.github/workflows/ai-bom-scan.yml
@@ -1,0 +1,137 @@
+name: AI-BOM Scan (PR)
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  ${REPO_NAME}:
+    runs-on: ubuntu-latest
+
+    env:
+      AIBOM_JSON: aibom.json
+      SUMMARY_JSON: aibom-summary.json
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # Use the official AI-BOM GitHub Action (faster than pip install)
+      - name: Run AI-BOM scan (AIBOM JSON)
+        id: scan
+        uses: trusera/${REPO_NAME}@v3
+        continue-on-error: true
+        with:
+          path: "."
+          format: "aibom"
+          output: "${{ env.AIBOM_JSON }}"
+          # Policy gate: critical only (this repo itself contains AI components by design)
+          fail-on: "critical"
+
+      # Python only for building summary + PR comment
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Build summary (pass/fail + counts)
+        run: |
+          python - <<'PY'
+          import json, os
+
+          aibom_path = os.environ["AIBOM_JSON"]
+          out_path = os.environ["SUMMARY_JSON"]
+          scan_status = os.environ.get("SCAN_STATUS", "PASS")
+
+          components = []
+
+          try:
+            with open(aibom_path, "r", encoding="utf-8") as f:
+              data = json.load(f)
+
+            # Best-effort component extraction across likely schemas
+            if isinstance(data, dict):
+              components = data.get("components") or data.get("aiComponents") or []
+              if not isinstance(components, list):
+                components = []
+              if not components and isinstance(data.get("results"), dict):
+                components = data["results"].get("components") or data["results"].get("aiComponents") or []
+                if not isinstance(components, list):
+                  components = []
+
+          except (FileNotFoundError, json.JSONDecodeError, ValueError):
+            # Scan step may fail before producing output or produce invalid JSON.
+            components = []
+
+          summary = {
+            "status": scan_status,
+            "components_found": len(components),
+            "policy_gate": "fail-on: critical",
+            "artifact_generated": os.path.exists(aibom_path),
+          }
+
+          with open(out_path, "w", encoding="utf-8") as f:
+            json.dump(summary, f, indent=2)
+
+          print(json.dumps(summary, indent=2))
+          PY
+        env:
+          SCAN_STATUS: ${{ steps.scan.outcome == 'success' && 'PASS' || 'FAIL' }}
+
+      - name: Upload AIBOM JSON artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: ${REPO_NAME}-results
+          path: |
+            ${{ env.AIBOM_JSON }}
+            ${{ env.SUMMARY_JSON }}
+          if-no-files-found: warn
+
+      - name: Create PR comment body
+        id: comment
+        run: |
+          python - <<'PY'
+          import json, os
+
+          with open(os.environ["SUMMARY_JSON"], "r", encoding="utf-8") as f:
+            s = json.load(f)
+
+          status = s["status"]
+          emoji = "✅" if status == "PASS" else "❌"
+
+          if s.get("artifact_generated"):
+            artifact_note = f"Artifact uploaded: `{os.environ['AIBOM_JSON']}`"
+          else:
+            artifact_note = "Artifact not generated (scan may have failed before producing output)."
+
+          body = f"""### {emoji} AI-BOM Scan Result: **{status}**
+
+          - **Components found:** {s["components_found"]}
+          - **Policy gate:** {s["policy_gate"]}
+
+          {artifact_note}
+          """
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as f:
+            f.write("body<<EOF\n")
+            f.write(body)
+            f.write("\nEOF\n")
+          PY
+
+      - name: Post PR comment
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: ${{ steps.comment.outputs.body }}
+          edit-mode: replace
+
+      # Enforce failure after comment + artifacts (so reviewers still see output)
+      - name: Fail if policy gate failed
+        if: steps.scan.outcome != 'success'
+        run: |
+          echo "AI-BOM policy gate failed (fail-on: high)."
+          exit 1
+          


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/ai-bom/.github/workflows/ai-bom-scan.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).