### PR TITLE
Proposal: add `api-docs.yaml` skeleton

### DIFF
--- a/.github/workflows/api-docs.yaml
+++ b/.github/workflows/api-docs.yaml
@@ -1,0 +1,23 @@
+name: API Docs Freshness
+
+on: [pull_request]
+
+jobs:
+  check-swagger:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - name: Install swag
+        run: go install github.com/swaggo/swag/cmd/swag@latest
+      - name: Regenerate docs
+        run: swag init -g cmd/api/main.go -o api/docs --parseDependency --parseInternal
+      - name: Verify no drift
+        run: |
+          if [ -n "$(git status --porcelain api/docs)" ]; then
+            echo "::error::API docs are stale. Run 'make docs' and commit the result."
+            git diff api/docs
+            exit 1
+          fi


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/api-base/.github/workflows/api-docs.yaml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).