### PR TITLE
Proposal: add `static-analysis.yml` skeleton

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,90 @@
+name: Static Analysis
+on:
+  pull_request:
+  push: { branches: master }
+
+jobs:
+  static_analysis:
+    name: Run shellcheck and shfmt
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout ${REPO_NAME}
+      uses: actions/checkout@v4
+
+    # Rush needed for easy installation of latest shfmt
+    - name: Install rush
+      run: curl -Ls http://get.dannyb.co/rush/setup | bash
+
+    - name: Connect rush repo
+      run: rush clone dannyben --shallow --default
+
+    - name: Install shfmt
+      run: rush get shfmt
+
+    # libyaml needed for Ruby's YAML library
+    - name: Install OS dependencies
+      run: sudo apt-get -y install libyaml-dev
+
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with: 
+        ruby-version: '3.4'
+        bundler-cache: true
+
+    - name: Generate all examples and fixtures
+      run: bundle exec run examples regen
+
+    - name: Run shellcheck and shfmt tests
+      run: bundle exec run static
+
+  json_schema:
+    name: Validate JSON schemas
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout ${REPO_NAME}
+      uses: actions/checkout@v4
+
+    # Rush needed for easy installation of check-jsonschema
+    - name: Install rush
+      run: curl -Ls http://get.dannyb.co/rush/setup | bash
+
+    - name: Connect rush repo
+      run: rush clone dannyben --shallow --default
+
+    - name: Install check-jsonschema
+      run: rush get check-jsonschema
+
+    # libyaml needed for Ruby's YAML library
+    - name: Install OS dependencies
+      run: sudo apt-get -y install libyaml-dev
+
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with: 
+        ruby-version: '3.4'
+        bundler-cache: true
+
+    - name: Generate all subjects
+      run: bundle exec run examples regen
+
+    - name: Run schema tests
+      run: bundle exec run schema all
+
+  codespell:
+    name: Spell check
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout ${REPO_NAME}
+      uses: actions/checkout@v4
+
+    - name: Install OS dependencies
+      run: sudo apt-get -y install codespell
+
+    - name: Run codespell
+      run: codespell


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/bashly/.github/workflows/static-analysis.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).