### PR TITLE
Proposal: add `test.yml` skeleton

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,65 @@
+name: Test
+on:
+  pull_request:
+  push: { branches: master }
+
+jobs:
+  test:
+    name: Ruby ${{ matrix.ruby }}
+
+    runs-on: ubuntu-latest
+
+    env: 
+      # For consistent sort order
+      LC_ALL: en_US.UTF-8 
+
+    strategy:
+      matrix: { ruby: ['3.2', '3.3', '3.4', '4.0'] }
+
+    steps:
+    - name: Checkout ${REPO_NAME}
+      uses: actions/checkout@v4
+
+    - name: Install OS dependencies
+      run: sudo apt-get -y install mandoc
+
+    # Rush needed for easy installation of stuff
+    - name: Install rush
+      run: curl -Ls http://get.dannyb.co/rush/setup | bash
+
+    - name: Connect rush repo
+      run: rush clone dannyben --shallow --default
+
+    - name: Install pandoc
+      run: rush get pandoc
+
+    - name: Install shfmt
+      run: rush get shfmt
+
+    # libyaml needed for Ruby's YAML library
+    - name: Install OS dependencies
+      run: sudo apt-get -y install libyaml-dev
+
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with: 
+        ruby-version: '${{ matrix.ruby }}'
+        bundler-cache: true
+
+    - name: Run tests
+      run: bundle exec rspec
+
+  docker:
+    name: Docker smoke test
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout ${REPO_NAME}
+      uses: actions/checkout@v4
+
+    - name: Build the image
+      run: docker compose build bash
+
+    - name: Test pandoc presence
+      run: docker compose run pandoc-test


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/bashly/.github/workflows/test.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).