### PR TITLE
Proposal: add `CI.yml` skeleton

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,36 @@
+name: CI
+on: pull_request
+
+jobs:
+  Test:
+    runs-on:
+      - self-hosted
+      - CI-CD
+
+    steps:
+      - name: Clone ${REPO_NAME}
+        uses: actions/checkout@v7
+
+      - name: Run actionlint
+        run: actionlint -ignore 'label "CI-CD" is unknown' .github/workflows/CI.yml
+
+      - name: Run codespell
+        run: codespell --skip="README-fr.md,./doc/man/fr,./po" --enable-colors
+
+      - name: Run mdl
+        run: mdl --style .github/workflows/mdl_style.rb .
+
+      - name: Run shellcheck
+        run: find . -name '*.sh' -exec shellcheck --color=always {} +
+
+      - name: Run pylint
+        run: find . -name '*.py' -exec pylint -d E0611,E0401,C0103,C0301,R0902,R0912,R0915,R0914 --output-format=colorized {} +
+
+      - name: Run make clean
+        run: make clean
+
+      - name: Run make
+        run: make
+
+      - name: Run make test
+        run: make test


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/cachy-update/.github/workflows/CI.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).