### PR TITLE
Proposal: add `mdl_style.rb` skeleton

### DIFF
--- a/.github/workflows/mdl_style.rb
+++ b/.github/workflows/mdl_style.rb
@@ -1,0 +1,11 @@
+# Include all rules
+all
+
+# Exclude the rules that refers to the line length
+exclude_tag :line_length
+
+# Allow inline HTML
+exclude_tag :html
+
+# Allow having multiple headers with the same content (for CHANGELOG.md)
+exclude_rule 'MD024'


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/cachy-update/.github/workflows/mdl_style.rb`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).