### PR TITLE
chore(vouch): sync CODEOWNERS + org members into VOUCHED.td

### DIFF
--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -18,6 +18,3 @@
 #   All other paths → unvouched authors: warn label only, maintainer decides
 #   Denounced authors → always auto-closed regardless of paths touched
 
-# ── Org owner and bots (always trusted) ───────────────────────────────────────
-github:Interested-Deving-1896
-


### PR DESCRIPTION
Weekly sync of CODEOWNERS entries and org members into `.github/VOUCHED.td`.

Auto-generated by `vouch-sync-codeowners.yml`. Safe to merge.

---

### Backlog audit disposition (2026-08-21)

Closed as a superseded generated regression. This patch is byte-equivalent to the other open Vouch snapshots and removes the Tier 1 maintainer from `.github/VOUCHED.td`. The registry is the trust single source of truth; [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607) removes the destructive second-generation pass, validates that Tier 1 is retained, and consolidates future updates into one stable PR.