### PR TITLE
Proposal: add `release.yml` skeleton

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify tag matches version
+        run: |
+          VERSION=$(grep '^# Version:' fixfolder.sh | head -1 | awk '{print $3}')
+          TAG=${GITHUB_REF#refs/tags/}
+          if [ "v$VERSION" != "$TAG" ]; then
+            echo "Tag $TAG does not match version $VERSION in fixfolder.sh"
+            exit 1
+          fi
+
+      - name: Package release
+        run: |
+          mkdir -p dist
+          cp fixfolder.sh dist/fixfolder
+          cp install.sh dist/
+          cp LICENSE dist/
+          tar -czf dist/smart-file-organizer-${{ github.ref_name }}.tar.gz \
+            -C dist fixfolder install.sh LICENSE
+          echo "SHA256:" > dist/checksums.txt
+          sha256sum dist/*.tar.gz >> dist/checksums.txt
+
+      - name: Generate release notes
+        id: notes
+        run: |
+          if [ -f CHANGELOG.md ]; then
+            awk '/^## /{if(capture) exit; capture=1; next} capture' CHANGELOG.md > /tmp/release-notes.md
+          else
+            echo "Release ${{ github.ref_name }}" > /tmp/release-notes.md
+          fi
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: /tmp/release-notes.md
+          files: |
+            dist/smart-file-organizer-${{ github.ref_name }}.tar.gz
+            dist/checksums.txt


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/Smart-File-Organizer/.github/workflows/release.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).