### PR TITLE
Proposal: add `api-latency-smoke.yml` skeleton

### DIFF
--- a/.github/workflows/api-latency-smoke.yml
+++ b/.github/workflows/api-latency-smoke.yml
@@ -1,0 +1,128 @@
+name: API Latency Smoke
+
+# Issue #1241 — catches "fast in CI, broken in real two-process install"
+# regressions like PR #1235 (3 endpoints were 7-15s under the sync-daemon
+# + dashboard contention). Single-process CI never sees DuckDB lock fights.
+
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+  schedule:
+    - cron: "0 6 * * *"   # nightly PyPI-release run  # TODO: set schedule for your project
+  workflow_dispatch:
+
+concurrency:
+  group: api-latency-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: ${{ matrix.source == 'pypi' && 'PyPI nightly' || 'PR build' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        # PR + push runs the local-wheel slice only. Nightly schedule
+        # additionally exercises the published PyPI release.
+        source: ${{ github.event_name == 'schedule' && fromJSON('["wheel", "pypi"]') || fromJSON('["wheel"]') }}
+    env:
+      CLAWMETRY_TOKEN: ci-smoke-token
+      OPENCLAW_GATEWAY_TOKEN: ci-smoke-token
+      CLAWMETRY_LOCAL_STORE_PATH: ${{ github.workspace }}/.smoke/${REPO_NAME}.duckdb
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Build wheel
+        if: matrix.source == 'wheel'
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build --wheel
+
+      - name: Install into isolated venv
+        run: |
+          python -m venv /tmp/vsmoke
+          /tmp/vsmoke/bin/pip install --upgrade pip
+          if [ "${{ matrix.source }}" = "pypi" ]; then
+            /tmp/vsmoke/bin/pip install --no-cache-dir ${REPO_NAME} flask waitress cryptography duckdb requests
+          else
+            /tmp/vsmoke/bin/pip install dist/${REPO_NAME}-*.whl flask waitress cryptography duckdb requests
+          fi
+
+      - name: Write minimal daemon config
+        # The sync-daemon entry point refuses to start without an api_key,
+        # so we drop a fake one. Ingest URL points at a closed port so
+        # network POSTs fail-fast and don't hold up the loop — we only
+        # care about the daemon's local_query HTTP server here.
+        run: |
+          mkdir -p "$HOME/.${REPO_NAME}" .smoke
+          cat > "$HOME/.${REPO_NAME}/config.json" <<EOF
+          {
+            "node_id": "smoke-ci-node",
+            "api_key": "smoke-ci-fake",
+            "encryption_key": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+            "ingest_url": "http://127.0.0.1:9"
+          }
+          EOF
+          chmod 600 "$HOME/.${REPO_NAME}/config.json"
+
+      - name: Seed realistic-shape DuckDB fixture (1k events / 200 hb / 50 mem / 5 sess)
+        run: /tmp/vsmoke/bin/python scripts/seed_smoke_duckdb.py
+
+      - name: Start sync daemon (writer) + dashboard (reader)
+        # Daemon owns the DuckDB lock and publishes its local-query port to
+        # ~/.${REPO_NAME}/local_query.json. Dashboard proxies through that for
+        # /api/local/* reads. Both running = the contention shape we test.
+        #
+        # Failures here are SETUP FLAKES, not perf regressions — emit a
+        # distinct `[setup-flake]` annotation so devs (and downstream
+        # automation) can tell "re-run the workflow" from "fix your code".
+        env:
+          CLAWMETRY_INGEST_URL: http://127.0.0.1:9
+        run: |
+          nohup /tmp/vsmoke/bin/python -m ${REPO_NAME} sync --foreground \
+            > .smoke/daemon.log 2>&1 &
+          echo $! > .smoke/daemon.pid
+          for i in $(seq 1 30); do
+            [ -f "$HOME/.${REPO_NAME}/local_query.json" ] && { echo "daemon up after ${i}s"; break; }
+            sleep 1
+          done
+          if [ ! -f "$HOME/.${REPO_NAME}/local_query.json" ]; then
+            echo "::error::[setup-flake] Gate setup failed: daemon did not publish local_query.json within 30s (this is NOT a regression). Re-run the workflow."
+            tail -100 .smoke/daemon.log; exit 2
+          fi
+          nohup /tmp/vsmoke/bin/${REPO_NAME} --port 8900 --no-debug \
+            > .smoke/dashboard.log 2>&1 &
+          echo $! > .smoke/dashboard.pid
+          for i in $(seq 1 30); do
+            curl -sf -H "Authorization: Bearer $CLAWMETRY_TOKEN" \
+              http://localhost:8900/api/health > /dev/null && \
+              { echo "dashboard up after ${i}s"; break; }
+            sleep 1
+          done
+          curl -sf -H "Authorization: Bearer $CLAWMETRY_TOKEN" \
+            http://localhost:8900/api/health > /dev/null || {
+            echo "::error::[setup-flake] Gate setup failed: dashboard /api/health never returned 200 within 30s (this is NOT a regression). Re-run the workflow."
+            tail -100 .smoke/dashboard.log; exit 2; }
+
+      - name: Probe endpoints + assert p50/p95 budgets
+        env:
+          CLAWMETRY_URL: http://localhost:8900
+        run: /tmp/vsmoke/bin/python scripts/api_latency_probe.py
+
+      - name: Tail logs on failure
+        if: failure()
+        run: |
+          echo "── daemon.log ──"; tail -200 .smoke/daemon.log || true
+          echo "── dashboard.log ──"; tail -200 .smoke/dashboard.log || true
+
+      - name: Stop background processes
+        if: always()
+        run: |
+          for f in .smoke/dashboard.pid .smoke/daemon.pid; do
+            [ -f "$f" ] && kill "$(cat "$f")" 2>/dev/null || true
+          done


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/clawmetry/.github/workflows/api-latency-smoke.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).