### PR TITLE
Proposal: add `auth-bootstrap-guard.yml` skeleton

### DIFF
--- a/.github/workflows/auth-bootstrap-guard.yml
+++ b/.github/workflows/auth-bootstrap-guard.yml
@@ -1,0 +1,94 @@
+name: Auth Bootstrap Guard
+
+on:
+  pull_request:
+    paths:
+      - "${REPO_NAME}/static/js/*.js"
+      - ".github/workflows/auth-bootstrap-guard.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  auth-bootstrap-guard:
+    name: Auth bootstrap no-reload smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+
+      - name: Check auth-bootstrap.js syntax
+        run: node --check ${REPO_NAME}/static/js/auth-bootstrap.js
+
+      - name: Guard bootstrap IIFE does not reload
+        run: |
+          awk '1; /^\}\)\(\);$/ { exit }' ${REPO_NAME}/static/js/auth-bootstrap.js | grep -v '^[[:space:]]*//' | \
+            node -e "const fs=require('fs'); const s=fs.readFileSync(0,'utf8'); if (/location\\.reload\\s*\\(/.test(s) || /window\\.location\\.reload\\s*\\(/.test(s)) { console.error('auth bootstrap IIFE must not call location.reload()'); process.exit(1); }"
+
+      - name: Install runtime deps
+        run: |
+          pip install flask requests waitress cryptography
+          npm install playwright
+          npx playwright install --with-deps chromium
+
+      - name: Start dashboard
+        run: |
+          OPENCLAW_GATEWAY_TOKEN=ci-test-token python3 dashboard.py --host 127.0.0.1 --port 8900 --no-debug > /tmp/${REPO_NAME}.log 2>&1 &
+          for i in $(seq 1 30); do
+            curl -sf -H "Authorization: Bearer ci-test-token" http://127.0.0.1:8900/api/health && exit 0
+            sleep 1
+          done
+          cat /tmp/${REPO_NAME}.log
+          exit 1
+
+      - name: Smoke test zero-click bootstrap does not reload
+        run: |
+          node <<'NODE'
+          const { chromium } = require('playwright');
+
+          (async () => {
+            const browser = await chromium.launch();
+            const page = await browser.newPage();
+
+            await page.goto('http://127.0.0.1:8900/', {
+              waitUntil: 'load',
+              timeout: 10000,
+            });
+
+            await page.waitForTimeout(2000);
+
+            const result = await page.evaluate(() => ({
+              readyState: document.readyState,
+              navType: performance.getEntriesByType('navigation')[0]?.type,
+              token: localStorage.getItem('${REPO_NAME}-token'),
+            }));
+
+            await browser.close();
+
+            if (result.readyState !== 'complete') {
+              throw new Error(`document.readyState was ${result.readyState}, expected complete`);
+            }
+
+            if (result.navType === 'reload') {
+              throw new Error('page reloaded during bootstrap');
+            }
+
+            if (result.token !== 'ci-test-token') {
+              throw new Error(`bootstrap token was not stored correctly: ${result.token}`);
+            }
+
+            console.log('auth bootstrap smoke passed');
+          })().catch((err) => {
+            console.error(err);
+            process.exit(1);
+          });
+          NODE


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/clawmetry/.github/workflows/auth-bootstrap-guard.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).