### PR TITLE
Proposal: add `auto-deploy-cloud.yml` skeleton

### DIFF
--- a/.github/workflows/auto-deploy-cloud.yml
+++ b/.github/workflows/auto-deploy-cloud.yml
@@ -1,0 +1,135 @@
+name: Auto-deploy Cloud on OSS update
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'dashboard.py'
+      - '${REPO_NAME}/**'
+      - 'setup.py'
+      - 'CHANGELOG.md'
+  workflow_dispatch:
+
+jobs:
+  pin-version:
+    name: Rebuild cloud with latest OSS
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout ${REPO_NAME} repo
+        uses: actions/checkout@v7
+
+      - name: Get OSS version
+        id: oss_version
+        run: |
+          VERSION=$(python3 -c "import re; m=re.search(r'__version__ = \"([^\"]+)\"', open('dashboard.py').read()); print(m.group(1))")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "OSS version: $VERSION"
+
+      # The cloud Dockerfile does `pip install ${REPO_NAME}==<version>`, and the
+      # cloud PR's CI also installs it to audit routes. On a release commit this
+      # job can fire before PyPI has finished propagating the new wheel, so wait
+      # for it to be installable before opening/merging the pin PR (avoids a
+      # spurious cloud-CI failure that would (correctly) block the auto-merge).
+      - name: Wait for version on PyPI
+        run: |
+          V="${{ steps.oss_version.outputs.version }}"
+          for i in $(seq 1 30); do
+            if curl -fsSL "https://pypi.org/pypi/${REPO_NAME}/$V/json" >/dev/null 2>&1; then
+              echo "${REPO_NAME}==$V is on PyPI"; exit 0
+            fi
+            echo "waiting for ${REPO_NAME}==$V on PyPI (attempt $i)..."; sleep 20
+          done
+          echo "::warning::${REPO_NAME}==$V not on PyPI after wait; continuing (cloud CI will gate the merge)"
+
+      - name: Checkout ${REPO_NAME} repo
+        uses: actions/checkout@v7
+        with:
+          repository: ${GITHUB_OWNER}/${REPO_NAME}-cloud
+          token: ${{ secrets.CLOUD_REPO_PAT }}
+          path: ${REPO_NAME}-cloud
+
+      - name: Pin ${REPO_NAME} version in cloud Dockerfile
+        run: |
+          cd ${REPO_NAME}-cloud
+          sed -i "s/${REPO_NAME}==[0-9.]*/${REPO_NAME}==${{ steps.oss_version.outputs.version }}/" Dockerfile
+          grep -q "${REPO_NAME}==${{ steps.oss_version.outputs.version }}" Dockerfile || \
+            sed -i "s/${REPO_NAME}$/${REPO_NAME}==${{ steps.oss_version.outputs.version }}/" Dockerfile
+          echo "Dockerfile:"; grep ${REPO_NAME} Dockerfile
+
+      - name: Commit and open PR
+        run: |
+          cd ${REPO_NAME}-cloud
+          git config user.email "diya-bot@${REPO_NAME}.com"
+          git config user.name "Diya (auto-deploy)"
+          BRANCH="auto/pin-${REPO_NAME}-${{ steps.oss_version.outputs.version }}"
+          git checkout -b "$BRANCH"
+          git add Dockerfile
+          git diff --staged --quiet && echo "No change needed" && exit 0
+          git commit -m "chore: auto-pin ${REPO_NAME}==${{ steps.oss_version.outputs.version }} from OSS"
+          # Force-push: this automation-owned branch may already exist from a
+          # prior run for the same version (re-fired release, retried merge).
+          # A plain push is rejected ("fetch first") and the whole job goes red,
+          # which is why the cloud pin silently drifted. Overwrite is safe.
+          git push -f origin "$BRANCH"
+          # Idempotent PR create: gh pr create errors if a PR is already open
+          # for this head. Skip in that case (the force-push already refreshed
+          # the branch, so the existing PR now carries the latest pin).
+          if [ -n "$(gh pr list --repo vivekchand/${REPO_NAME}-cloud --head "$BRANCH" --state open --json number -q '.[0].number')" ]; then
+            echo "PR already open for $BRANCH; refreshed via force-push."
+          else
+            gh pr create \
+              --repo vivekchand/${REPO_NAME}-cloud \
+              --title "chore: auto-pin ${REPO_NAME}==${{ steps.oss_version.outputs.version }}" \
+              --body "Automated version pin from OSS release ${{ steps.oss_version.outputs.version }}. Merge to deploy." \
+              --base main \
+              --head "$BRANCH"
+            echo "✅ PR opened to pin ${REPO_NAME}==${{ steps.oss_version.outputs.version }}"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.CLOUD_REPO_PAT }}
+
+      # Auto-merge the pin PR once the cloud CI is green so each OSS release
+      # deploys to the cloud hands-off. We poll the PR's checks and merge with
+      # the PAT (a PAT merge — unlike GITHUB_TOKEN — triggers the cloud's
+      # deploy.yml, whose candidate smoke-gate still protects prod before
+      # traffic flips). Guards: pin-only diff (Dockerfile), and never merge a
+      # PR with a failing or still-pending check. A failed/!pin-only PR is left
+      # open for review rather than force-merged.
+      - name: Auto-merge pin PR when cloud CI is green
+        env:
+          GH_TOKEN: ${{ secrets.CLOUD_REPO_PAT }}
+          REPO: vivekchand/${REPO_NAME}-cloud
+          VERSION: ${{ steps.oss_version.outputs.version }}
+        run: |
+          BRANCH="auto/pin-${REPO_NAME}-${VERSION}"
+          PR=$(gh pr list --repo "$REPO" --head "$BRANCH" --state open --json number -q '.[0].number')
+          if [ -z "$PR" ]; then echo "No open pin PR for $BRANCH (pin already current) — nothing to merge."; exit 0; fi
+          echo "Pin PR: #$PR"
+          # Safety: only auto-merge a pin-only diff. Anything else waits for a human.
+          FILES=$(gh pr view "$PR" --repo "$REPO" --json files -q '[.files[].path] | join(",")')
+          if [ "$FILES" != "Dockerfile" ]; then
+            echo "::warning::PR #$PR touches more than Dockerfile ($FILES) — leaving for manual review."; exit 0
+          fi
+          # Poll the rollup until every check concludes (or budget runs out).
+          # ~45 min budget: the cloud golden-path E2E + MOAT roundtrip checks
+          # routinely run 15-20 min, and the earlier 20 min budget timed out
+          # before they finished (the pin PR was left open, merged later by
+          # hand) — defeating hands-off auto-merge.
+          for i in $(seq 1 90); do
+            ROLL=$(gh pr view "$PR" --repo "$REPO" --json statusCheckRollup \
+                     -q '.statusCheckRollup')
+            FAIL=$(echo "$ROLL" | python3 -c "import json,sys; r=json.load(sys.stdin); print(sum(1 for c in r if (c.get('conclusion') or '') in ('FAILURE','CANCELLED','TIMED_OUT','ACTION_REQUIRED')))")
+            PEND=$(echo "$ROLL" | python3 -c "import json,sys; r=json.load(sys.stdin); print(sum(1 for c in r if (c.get('status') or c.get('state') or '') in ('IN_PROGRESS','QUEUED','PENDING','EXPECTED')))")
+            TOTAL=$(echo "$ROLL" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))")
+            echo "checks: total=$TOTAL fail=$FAIL pending=$PEND (poll $i)"
+            if [ "$FAIL" -gt 0 ]; then
+              echo "::warning::cloud CI failed on pin PR #$PR — leaving open for review (will retry on next OSS push)."; exit 0
+            fi
+            if [ "$PEND" -eq 0 ] && [ "$TOTAL" -gt 0 ]; then
+              echo "all checks green — merging #$PR"
+              gh pr merge "$PR" --repo "$REPO" --squash --delete-branch && \
+                echo "✅ merged #$PR — cloud deploy will run (candidate-gated)"; exit 0
+            fi
+            sleep 30
+          done
+          echo "::warning::pin PR #$PR checks did not finish within budget — leaving open."


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/clawmetry/.github/workflows/auto-deploy-cloud.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).