### PR TITLE
Proposal: add `browserstack.yml` skeleton

### DIFF
--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -1,0 +1,65 @@
+name: BrowserStack
+
+on:
+  workflow_dispatch:  # Manual trigger only
+  push:
+    branches: [main]  # Run on merge to main
+  pull_request:
+    branches: [main]
+    types: [labeled]  # Trigger by adding label 'browserstack'
+
+jobs:
+  cross-browser:
+    name: Cross-Browser Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install flask pytest pytest-playwright requests browserstack-sdk
+
+      - name: Install Playwright browsers
+        run: python3 -m playwright install chromium
+
+      - name: Start ClawMetry server
+        run: |
+          OPENCLAW_GATEWAY_TOKEN=ci-test-token python3 dashboard.py --port 8900 --no-debug &
+          for i in $(seq 1 30); do
+            curl -sf -H "Authorization: Bearer ci-test-token" http://localhost:8900/api/health && echo "Server ready" && break
+            sleep 1
+          done
+
+      - name: Set up BrowserStack env
+        uses: browserstack/github-actions/setup-env@master
+        with:
+          username: ${{ secrets.BROWSERSTACK_USERNAME }}
+          access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+
+      - name: Start BrowserStack Local Tunnel
+        uses: browserstack/github-actions/setup-local@master
+        with:
+          local-testing: start
+          local-identifier: ${REPO_NAME}-${{ github.run_id }}
+
+      - name: Run tests via BrowserStack SDK
+        env:
+          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+          BROWSERSTACK_LOCAL_IDENTIFIER: ${REPO_NAME}-${{ github.run_id }}
+          CLAWMETRY_URL: http://localhost:8900
+          CLAWMETRY_TOKEN: ci-test-token
+        run: |
+          BUILD_NUMBER=${{ github.run_number }} browserstack-sdk python3 -m pytest tests/test_e2e_browserstack.py -v --tb=short
+
+      - name: Stop BrowserStack Local Tunnel
+        if: always()
+        uses: browserstack/github-actions/setup-local@master
+        with:
+          local-testing: stop
+          local-identifier: ${REPO_NAME}-${{ github.run_id }}


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/clawmetry/.github/workflows/browserstack.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).