### PR TITLE
Proposal: add `c6-health.yml` skeleton

### DIFF
--- a/.github/workflows/c6-health.yml
+++ b/.github/workflows/c6-health.yml
@@ -1,0 +1,138 @@
+name: C6 daily health check (branch-protection audit)
+
+on:
+  schedule:
+    - cron: '0 9 * * *'  # TODO: set schedule for your project
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  discussions: write  # Added permission to allow posting comments
+
+jobs:
+  c6-health:
+    name: C6 required-status-checks audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Audit branch protection and notify tracking issue
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python3 - <<'PYEOF'
+          import json
+          import os
+          import sys
+          import urllib.error
+          import urllib.request
+          from datetime import datetime, timezone
+
+          TOKEN = os.environ["GITHUB_TOKEN"]
+          OWNER = "vivekchand"
+          TRACKING_ISSUE = 2146
+          MARKER = "<!-- c6-health-check -->"
+
+          HEADERS = {
+              "Authorization": f"token {TOKEN}",
+              "Accept": "application/vnd.github.v3+json",
+              "User-Agent": "${REPO_NAME}-c6-health/1.0",
+          }
+
+          LOCAL_CHECKS = [
+              "OSS golden path (wheel + OpenClaw + 9 tabs)",
+              "Cross-repo handoff (C4)",
+          ]
+
+          def api_get(path):
+              req = urllib.request.Request(
+                  f"https://api.github.com{path}", headers=HEADERS
+              )
+              try:
+                  with urllib.request.urlopen(req) as r:
+                      return json.loads(r.read()), None
+              except urllib.error.HTTPError as exc:
+                  return None, exc.code
+
+          def post_comment(body):
+              url = (
+                  f"https://api.github.com/repos/{OWNER}/${REPO_NAME}"
+                  f"/issues/{TRACKING_ISSUE}/comments"
+              )
+              data = json.dumps({"body": body}).encode()
+              hdrs = {**HEADERS, "Content-Type": "application/json"}
+              req = urllib.request.Request(
+                  url, data=data, headers=hdrs, method="POST"
+              )
+              with urllib.request.urlopen(req) as r:
+                  return json.loads(r.read())
+
+          data, err = api_get(f"/repos/{OWNER}/${REPO_NAME}/branches/main")
+          if not err and data:
+              prot = (data.get("protection") or {}).get("required_status_checks") or {}
+              existing = set(prot.get("contexts", []))
+          else:
+              existing = set()
+
+          missing = [c for c in LOCAL_CHECKS if c not in existing]
+
+          today_utc = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+          comments, _ = api_get(
+              f"/repos/{OWNER}/${REPO_NAME}/issues/{TRACKING_ISSUE}"
+              "/comments?per_page=20&sort=updated&direction=desc"
+          )
+          for c in comments or []:
+              author = (c.get("user") or {}).get("login", "")
+              posted = (c.get("created_at") or "")[:10]
+              body_text = c.get("body", "")
+              if (
+                  author == "github-actions[bot]"
+                  and posted == today_utc
+                  and MARKER in body_text
+              ):
+                  print(f"Health check already posted today ({today_utc}). Skipping.")
+                  sys.exit(1 if missing else 0)
+
+          if missing:
+              checks_block = "".join(f"  - `{c}`\n" for c in missing)
+              body = (
+                  f"{MARKER}\n"
+                  f"**C6 health check {today_utc}:"
+                  f" {len(missing)}/2 required checks not yet configured on ${REPO_NAME}/main.**\n\n"
+                  f"Missing:\n{checks_block}\n"
+                  "**Close C6 now (browser only, no local setup):**\n"
+                  "1. [Actions > Apply required E2E status checks (C6 -- one-shot)"
+                  " > Run workflow](https://github.com/vivekchand/${REPO_NAME}/actions"
+                  "/workflows/apply-required-checks.yml)\n"
+                  "2. `confirm` = `APPLY`, `pat_token` = fine-grained PAT\n"
+                  "   (Administration read+write on ${REPO_NAME}, ${REPO_NAME}-cloud,"
+                  " ${REPO_NAME}-landing)\n"
+                  "3. Click Run workflow\n\n"
+                  "Or locally: `bash scripts/close-c6.sh` (30s, uses existing gh CLI session).\n\n"
+                  "Also verify cloud and landing manually:\n"
+                  "  - https://github.com/vivekchand/${REPO_NAME}-cloud/settings/branches\n"
+                  "  - https://github.com/vivekchand/${REPO_NAME}-landing/settings/branches\n\n"
+                  "C1/C2/C3/C4/C5/C7 have been green for 7+ days."
+                  " C6 is the sole remaining blocker."
+              )
+          else:
+              body = (
+                  f"{MARKER}\n"
+                  f"**C6 health check {today_utc}:"
+                  " ${REPO_NAME} required checks confirmed GREEN.**\n\n"
+                  "${REPO_NAME}/main has both checks required:\n"
+                  "  - `OSS golden path (wheel + OpenClaw + 9 tabs)`\n"
+                  "  - `Cross-repo handoff (C4)`\n\n"
+                  "Please verify cloud and landing manually:\n"
+                  "  - https://github.com/vivekchand/${REPO_NAME}-cloud/settings/branches"
+                  " (expect: `Cloud golden-path browser E2E`)\n"
+                  "  - https://github.com/vivekchand/${REPO_NAME}-landing/settings/branches"
+                  " (expect: `Landing golden path (C3)`)\n\n"
+                  "Once all 3 repos are confirmed, C6 is GREEN and the 7-day"
+                  " countdown can begin."
+              )
+
+          result = post_comment(body)
+          print(f"Posted: {result['html_url']}")
+          sys.exit(1 if missing else 0)
+          PYEOF


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/clawmetry/.github/workflows/c6-health.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).