### PR TITLE
Proposal: add `ci.yml` skeleton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,613 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+jobs:
+  # ── Fast syntax check (runs in ~10s, blocks everything else) ─────────────────────
+  lint:
+    name: Syntax & Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.9"
+      - name: Check Python syntax (all .py files, Python 3.9 compatible)
+        run: |
+          python3 -c "
+          import ast, glob, sys
+          errors = 0
+          for f in ['dashboard.py'] + glob.glob('${REPO_NAME}/**/*.py', recursive=True):
+              try:
+                  ast.parse(open(f).read(), filename=f)
+              except SyntaxError as e:
+                  print(f'❌ {f}:{e.lineno}: {e.msg}')
+                  errors += 1
+          if errors:
+              sys.exit(1)
+          print(f'✅ Syntax OK ({len(glob.glob(\"${REPO_NAME}/**/*.py\", recursive=True)) + 1} files)')
+          "
+      - name: Install ruff (fast linter)
+        run: pip install ruff
+      - name: Lint (warnings only, don't fail)
+        run: ruff check dashboard.py --select E,W --ignore E501,W503 || true
+
+      # v0.12.165 shipped ${REPO_NAME}/static/js/app.js with a missing `}`
+      # (PR #753). Browsers threw "Unexpected end of input" and the whole
+      # dashboard JS bundle died, stranding every user on the boot
+      # overlay. `node --check` catches this in <1s. Required gate.
+      - name: Setup Node (for JS syntax check)
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+      - name: Check JS syntax (all ${REPO_NAME}/static/js/*.js)
+        run: |
+          set -e
+          for f in ${REPO_NAME}/static/js/*.js; do
+            node --check "$f" || { echo "❌ JS PARSE FAILED: $f"; exit 1; }
+          done
+          echo "✅ JS Syntax OK"
+
+  # ── API tests across all 3 platforms ─────────────────────────────────────────────
+  api-tests:
+    name: API Tests (${{ matrix.os }})
+    needs: lint
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.9", "3.11"]
+        exclude:
+          # Only test py3.9 on Linux to keep matrix manageable
+          - os: macos-latest
+            python-version: "3.9"
+          - os: windows-latest
+            python-version: "3.9"
+
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: pip install flask pytest requests waitress
+
+      - name: Start server (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          OPENCLAW_GATEWAY_TOKEN=ci-test-token python3 dashboard.py --port 8900 --no-debug &
+          for i in $(seq 1 30); do
+            curl -sf -H "Authorization: Bearer ci-test-token" http://localhost:8900/api/health && echo "Ready" && break
+            sleep 1
+          done
+        shell: bash
+
+      - name: Start server (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          $env:OPENCLAW_GATEWAY_TOKEN = "ci-test-token"
+          $env:PYTHONIOENCODING = "utf-8"
+          $env:PYTHONUTF8 = "1"
+          Start-Process python -ArgumentList "-u -X utf8 dashboard.py --port 8900 --no-debug" -NoNewWindow -RedirectStandardOutput "server_out.txt" -RedirectStandardError "server_err.txt"
+          $ready = $false
+          for ($i = 0; $i -lt 30; $i++) {
+            try {
+              $r = Invoke-WebRequest -Uri "http://localhost:8900/api/health" -Headers @{"Authorization"="Bearer ci-test-token"} -UseBasicParsing -ErrorAction Stop
+              if ($r.StatusCode -eq 200) { $ready = $true; break }
+            } catch {}
+            Start-Sleep 1
+          }
+          if (-not $ready) {
+            Write-Host "=== server_out.txt ==="
+            if (Test-Path server_out.txt) { Get-Content server_out.txt }
+            Write-Host "=== server_err.txt ==="
+            if (Test-Path server_err.txt) { Get-Content server_err.txt }
+            Write-Error "Server failed to start"; exit 1
+          }
+        shell: pwsh
+
+      - name: Run API tests
+        env:
+          CLAWMETRY_URL: http://localhost:8900
+          CLAWMETRY_TOKEN: ci-test-token
+        run: python3 -m pytest tests/test_api.py -v --tb=short
+
+  # ── MOAT verifier (hermetic, hard-fail) ────────────────────────────────────────────────────
+  # Issue #1491 / PRD #1133 invariant #3: "A regression in either direction
+  # is caught BEFORE merge." These files exercise the
+  # OpenClaw → DuckDB → API surface contract end-to-end, plus the lint
+  # guards that pin the chokepoint patterns (no-direct-get_store,
+  # v3-shape silent-zero refs #1582). No live server, no gateway, no
+  # network — drives sync/local_store helpers + Flask test client.
+  # Runtime ~10s locally, ~15-20s on CI. HARD-FAIL: no continue-on-error.
+  moat-tests:
+    name: MOAT Verifier (72 tests)
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install dependencies
+        run: pip install flask waitress cryptography duckdb pytest requests psutil
+      - name: Run MOAT verifier suite
+        run: |
+          # Phase 4 open-core move (#2335) deleted the 9 paid runtime
+          # adapter test files from public OSS; the live impls + their
+          # tests now live in ${REPO_NAME}-pro. The MOAT verifier in OSS
+          # covers Free runtimes (OpenClaw + NeMo) + cross-cutting
+          # invariants only. Pro adapter coverage runs in ${REPO_NAME}-pro
+          # CI.
+          python3 -m pytest \
+            tests/test_moat_send_message_e2e.py \
+            tests/test_moat_event_shape_manifest_guard.py \
+            tests/test_moat_regression_1129.py \
+            tests/test_e2e_real_openclaw_pipeline.py \
+            tests/test_duckdb_fastpath_v3_invariants.py \
+            tests/test_moat_cloud_roundtrip_e2e.py \
+            tests/test_channel_event_chokepoint.py \
+            tests/test_no_direct_get_store_in_routes.py \
+            tests/test_moat_bug_class_v3_event_shape_gate.py \
+            tests/test_local_query_api.py \
+            tests/test_local_query_dispatch_edge_cases.py \
+            tests/test_query_contract_drift.py \
+            tests/test_query_contract_goldens.py \
+            tests/test_local_store_concurrent_flush_1590.py \
+            tests/test_moat_perf_benchmark.py \
+            tests/test_runtime_detection_snapshot.py \
+            tests/test_family_runtime_ingest.py \
+            tests/test_phase4_adapter_move.py \
+            tests/test_openclaw_detection_real.py \
+            -q
+
+  # ── Entitlement API test suite (~2700 hermetic tests) ─────────────────────
+  # Covers every helper in ${REPO_NAME}/entitlements.py and every endpoint
+  # under routes/entitlement.py via Flask test client. No live server, no
+  # gateway, no network. Runtime ~60s. HARD-FAIL: no continue-on-error.
+  entitlement-tests:
+    name: Entitlement API tests
+    needs: lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install dependencies
+        run: pip install flask waitress cryptography duckdb pytest requests psutil
+      - name: Run entitlement test suite
+        run: |
+          python3 -m pytest \
+            tests/test_entitlement*.py \
+            tests/test_entitlements*.py \
+            tests/test_required_tier_canonical.py \
+            tests/test_tier_catalog.py \
+            tests/test_tier_cli.py \
+            -q
+
+  # ── Compression / cache-safety eval (Tier-1, deterministic) ──────────────
+  # Issue #2844 (epic #2837): port Headroom's eval rigor so we can claim
+  # "compression-safe" with proof. This Tier-1 gate is pure-Python and spends
+  # ZERO API budget — it proves CCR payload compression is byte-for-byte
+  # lossless (needle-retention / UUID-retrieval / anomaly-preservation) and
+  # that the cache-risk + compression-potential metrics persist only aggregates,
+  # never the raw secrets they scan. Higher LLM-judge tiers (Tier-2/3) are
+  # gated behind an API key and run out-of-band, not on the PR budget.
+  compression-safety:
+    name: Compression Safety Eval (Tier-1)
+    needs: lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install dependencies
+        run: pip install flask waitress cryptography duckdb pytest requests psutil
+      - name: Run compression/cache-safety eval suite
+        run: python3 -m pytest tests/test_compression_safety_eval.py -q
+
+  # ── MOAT keystone (DuckDB-first invariant, 13-endpoint bar) ──────────────
+  # Implements `docs/MOAT_BAR.md` Section 5 acceptance criterion #1:
+  # `keystone_e2e.py --no-drive` exits 0 on every PR. The keystone is the
+  # canonical 13-endpoint verifier (PR #1672) that asserts every
+  # UI-backing API surface returns non-zero, correctly shaped data
+  # against live DuckDB rows.
+  #
+  # Why this gate exists: PR #1682 found a silent-zero bug in
+  # `/api/component/tool/exec` AFTER it shipped to main because the
+  # keystone was only being hand-run by Principal A. Wiring it as a
+  # required CI check stops that class of regression at the PR boundary.
+  #
+  # Boot pattern mirrors the existing `api-tests` job: dashboard on 8900
+  # with a deterministic gateway token, then a minimal local_query
+  # server (writes ~/.${REPO_NAME}/local_query.json which the keystone
+  # discovers). `--no-drive` skips the real openclaw turn (LLM budget)
+  # and instead verifies every probe against whatever rows the daemon's
+  # startup bootstrap landed. Drive mode runs nightly via
+  # `.github/workflows/moat-keystone-drive-nightly.yml`.
+  moat-keystone:
+    name: MOAT Keystone (13-endpoint bar)
+    needs: lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install flask waitress cryptography duckdb requests psutil
+
+      - name: "Guard: keystone harness file present"
+        # Until PR #1672 merges, the keystone script lives only on the
+        # feat/moat-keystone-e2e-verifier branch. Once that PR lands on
+        # main, this guard becomes a no-op pass and the job becomes a
+        # hard gate. Until then, this surfaces an explicit warning rather
+        # than a confusing "file not found" failure.
+        run: |
+          if [ ! -f scripts/accuracy_harness/keystone_e2e.py ]; then
+            echo "::warning::scripts/accuracy_harness/keystone_e2e.py not present on this commit. Merge PR #1672 first to activate the keystone gate."
+            echo "KEYSTONE_PRESENT=0" >> "$GITHUB_ENV"
+          else
+            echo "KEYSTONE_PRESENT=1" >> "$GITHUB_ENV"
+          fi
+
+      - name: Start dashboard
+        if: env.KEYSTONE_PRESENT == '1'
+        run: |
+          OPENCLAW_GATEWAY_TOKEN=ci-test-token python3 dashboard.py --port 8900 --no-debug \
+            > /tmp/dashboard.log 2>&1 &
+          for i in $(seq 1 30); do
+            curl -sf -H "Authorization: Bearer ci-test-token" http://localhost:8900/api/health && echo "Dashboard ready" && break
+            sleep 1
+          done
+
+      - name: Start local_server (DuckDB query proxy for keystone)
+        if: env.KEYSTONE_PRESENT == '1'
+        # The full sync daemon needs a configured node (${REPO_NAME} connect)
+        # which CI doesn't have. The keystone only depends on the
+        # `local_query` HTTP proxy (writes ~/.${REPO_NAME}/local_query.json);
+        # we boot just that piece in a background process. This matches
+        # the in-process startup the real daemon does at sync.py:8452.
+        run: |
+          nohup python3 -c "
+          import os, time, json, pathlib
+          from ${REPO_NAME} import local_server
+          port = local_server.start()
+          assert port, 'local_server failed to start'
+          # Re-stamp pid so discover_daemon() resolves to a live process.
+          disc = pathlib.Path.home() / '.${REPO_NAME}' / 'local_query.json'
+          d = json.loads(disc.read_text())
+          d['pid'] = os.getpid()
+          disc.write_text(json.dumps(d))
+          while True: time.sleep(60)
+          " > /tmp/local_server.log 2>&1 &
+          for i in $(seq 1 10); do
+            [ -f "$HOME/.${REPO_NAME}/local_query.json" ] && echo "local_query.json present" && break
+            sleep 1
+          done
+
+      - name: Run keystone verifier (--no-drive)
+        if: env.KEYSTONE_PRESENT == '1'
+        env:
+          CLAWMETRY_URL: http://localhost:8900
+        run: make moat-check
+
+      - name: Dashboard log tail (on failure)
+        if: failure() && env.KEYSTONE_PRESENT == '1'
+        run: |
+          echo "── dashboard.log tail ──"
+          tail -200 /tmp/dashboard.log || true
+          echo "── local_server.log tail ──"
+          tail -200 /tmp/local_server.log || true
+
+  # ── E2E Playwright tests — critical subset (hard-gate, blocks merge) ────
+  # Per issue #1528: the prior `e2e-tests` job carried `continue-on-error: true`
+  # which silently masked Playwright regressions. We split the suite into:
+  #   1. `e2e-critical` (this job) — TestTabsLoad: page-load + tab-nav smoke
+  #      tests that have been stable. Hard-fails on regression.
+  #      TestAllTabsPostAuth: C5 auth-overlay gate (issue #1646, #2146).
+  #   2. `e2e-nightly`  (.github/workflows/e2e-nightly.yml) — the broader
+  #      TestFlowDiagram suite, which depends on SVG rendering of live data
+  #      and is still flaky. Runs on schedule, not per-PR.
+  # If you add a new e2e test, default it to nightly until it has a clean
+  # run history; promote to critical once it has been green for ~1 week.
+  e2e-critical:
+    name: E2E Browser Tests (critical subset)
+    needs: lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        # duckdb is in requirements.txt and used by the dashboard's local
+        # event store; without it the server crashes on import and the
+        # health check silently times out.
+        run: pip install flask pytest pytest-playwright requests duckdb
+      - name: Install Playwright browsers
+        run: python3 -m playwright install chromium --with-deps
+      - name: Start server
+        run: |
+          OPENCLAW_GATEWAY_TOKEN=ci-test-token python3 dashboard.py --port 8900 --no-debug &
+          ok=0
+          for i in $(seq 1 30); do
+            curl -sf -H "Authorization: Bearer ci-test-token" http://localhost:8900/api/health \
+              && echo "Dashboard ready after ${i}s" && ok=1 && break
+            sleep 1
+          done
+          if [ "$ok" != "1" ]; then
+            echo "::error::Dashboard failed to start on port 8900. Check for import errors or port conflicts."
+            exit 1
+          fi
+      - name: Probe gateway-token auth (C5 gate)
+        # Explicit pre-flight: verify /api/auth/check accepts the token
+        # BEFORE Playwright runs. Without this a token mismatch produces
+        # 19 identical overlay-visible assertion failures instead of one
+        # actionable message. Routes/meta.py:api_auth_check compares the
+        # bearer token directly to OPENCLAW_GATEWAY_TOKEN (no gateway
+        # process needed), so this probe is purely env-var correctness.
+        run: |
+          resp=$(curl -sf -H "Authorization: Bearer ci-test-token" \
+            "http://localhost:8900/api/auth/check" 2>/dev/null || echo '{"valid":false}')
+          valid=$(echo "$resp" | python3 -c \
+            "import sys,json; d=json.load(sys.stdin); print(d.get('valid',False))" \
+            2>/dev/null || echo "False")
+          if [ "$valid" != "True" ]; then
+            echo "::error::/api/auth/check returned valid!=true (C5 gate). Response: $resp"
+            echo "::error::Token plumbing broken: OPENCLAW_GATEWAY_TOKEN=ci-test-token not accepted."
+            exit 1
+          fi
+          echo "C5 auth probe OK: /api/auth/check returned valid=true"
+      - name: Run E2E tests (critical subset only -- hard gate)
+        env:
+          CLAWMETRY_URL: http://localhost:8900
+          CLAWMETRY_TOKEN: ci-test-token
+        run: |
+          python3 -m pytest \
+            tests/test_e2e.py::TestTabsLoad \
+            tests/test_e2e_oss_all_tabs.py::TestAllTabsPostAuth \
+            -v --tb=short
+
+  # ── pip install smoke test across platforms ─────────────────────────────────────────
+  pip-install:
+    name: pip install (${{ matrix.os }})
+    needs: lint
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Install from source
+        run: pip install flask .
+      - name: Smoke test - help works
+        run: python3 -c "import dashboard" || python3 dashboard.py --version 2>/dev/null || echo 'import OK'
+        continue-on-error: true
+      - name: Smoke test - syntax valid
+        run: python3 -c "import dashboard; print('✅ Import OK')"
+        continue-on-error: true  # May fail if dashboard has top-level side effects
+
+  # ── Wheel-install verification: routes/, helpers/, static/, templates/ ────
+  # This catches packaging regressions that source-checkout tests miss.
+  # If static/js/app.js doesn't ship in the wheel, the dashboard's frontend
+  # 404s for everyone who `pip install ${REPO_NAME}` — which is how cloud
+  # consumes the package too. This job proves the wheel contains what it
+  # needs to run end-to-end, in a fresh venv isolated from the source tree.
+  wheel-install:
+    name: Wheel install & asset presence
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Build wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build --wheel
+      - name: Install wheel in isolated venv
+        run: |
+          python -m venv /tmp/vwheel
+          /tmp/vwheel/bin/pip install --upgrade pip
+          /tmp/vwheel/bin/pip install dist/${REPO_NAME}-*.whl flask waitress cryptography pytest requests
+      - name: Verify runtime assets shipped in wheel
+        run: |
+          /tmp/vwheel/bin/python -c "
+          import ${REPO_NAME}, pathlib
+          root = pathlib.Path(${REPO_NAME}.__file__).parent
+          for p in ('static/js/app.js',
+                    'static/img/logo.svg',
+                    'templates/tabs/flow.html'):
+              assert (root/p).exists(), f'missing in wheel: {p}'
+          import dashboard  # ensures top-level module + routes/ + helpers/ all import
+          from routes.sessions import bp_sessions
+          from helpers.gateway import _gw_ws_rpc
+          print('wheel ships all runtime assets; dashboard imports clean')
+          "
+      - name: Start dashboard from installed wheel & hit /static/js/app.js
+        run: |
+          mkdir -p /tmp/wheel-run && cd /tmp/wheel-run
+          OPENCLAW_GATEWAY_TOKEN=ci-test-token /tmp/vwheel/bin/python -c "import dashboard; dashboard.main()" --port 8955 --no-debug &
+          for i in $(seq 1 30); do
+            curl -sf -H "Authorization: Bearer ci-test-token" http://localhost:8955/api/health && echo "Ready" && break
+            sleep 1
+          done
+          STATUS=$(curl -sS -o /dev/null -w "%{http_code}" http://localhost:8955/static/js/app.js)
+          if [ "$STATUS" != "200" ]; then
+            echo "❌ /static/js/app.js returned HTTP $STATUS — wheel is broken"
+            exit 1
+          fi
+          echo "✅ /static/js/app.js served from installed wheel"
+
+  # ── Eval suite gate (Phase 2 evals, refs #1619 / PR #1626) ──────────────
+  # Runs ClawMetry's own golden suite (tests/data/golden_ci.yaml) through
+  # the `${REPO_NAME} eval` CLI on every PR. Catches regressions in:
+  #   * eval_suite_runner.py YAML parsing / runner loop
+  #   * eval_runner.py judge plumbing (rubric, _call_judge, parse_score)
+  #   * cli.py `eval` subcommand wiring (flags, exit codes, error msgs)
+  #
+  # The "agent" in CI is the canned tests/eval_ci_mock_agent.py — no
+  # external LLM call from the agent side, only the judge (Haiku) hits
+  # the network. Cost ceiling: 4 tests × 1 judge call ≈ $0.005 per PR.
+  #
+  # Graceful-skip: when CI_ANTHROPIC_API_KEY is not set (e.g. forks,
+  # community PRs) the job emits an explicit "SKIPPED" warning and exits
+  # 0. The gate hard-fails only when the secret IS set AND any test
+  # fails. This keeps green-checks-only test runs unblocked while still
+  # gating the merge for maintainer-owned PRs.
+  #
+  # To disable the gate temporarily (e.g. during a known-broken judge
+  # provider outage), set the repo variable `CLAWMETRY_EVALS_GATE` to
+  # "off" — the job short-circuits with a SKIPPED warning. Re-enable by
+  # unsetting the variable or setting it to anything other than "off".
+  eval-suite:
+    name: Eval Suite Gate (Phase 2 evals)
+    needs: lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install ClawMetry (editable) + eval deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e . pyyaml httpx
+      - name: Check kill-switch
+        id: gate
+        run: |
+          if [ "${{ vars.CLAWMETRY_EVALS_GATE }}" = "off" ]; then
+            echo "::warning::eval gate SKIPPED — CLAWMETRY_EVALS_GATE repo var set to 'off'"
+            echo "skip=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=0" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Check for CI_ANTHROPIC_API_KEY
+        if: steps.gate.outputs.skip != '1'
+        id: keycheck
+        env:
+          CI_ANTHROPIC_API_KEY: ${{ secrets.CI_ANTHROPIC_API_KEY }}
+        run: |
+          if [ -z "$CI_ANTHROPIC_API_KEY" ]; then
+            echo "::warning::eval gate SKIPPED — needs CI_ANTHROPIC_API_KEY repo secret. Set one at Settings → Secrets → Actions to enable the PR quality gate."
+            echo "skip=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=0" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Run golden_ci suite (hard gate)
+        if: steps.gate.outputs.skip != '1' && steps.keycheck.outputs.skip != '1'
+        env:
+          # Judge call uses the CI-scoped key, namespaced so it can't
+          # collide with the developer's local ANTHROPIC_API_KEY and so
+          # rotating one doesn't disturb the other.
+          ANTHROPIC_API_KEY: ${{ secrets.CI_ANTHROPIC_API_KEY }}
+          # Point the runner at the deterministic mock agent — no real
+          # agent process needed for the gate.
+          CLAWMETRY_EVALS_AGENT_CMD: "python3 tests/eval_ci_mock_agent.py"
+          GITHUB_SHA: ${{ github.sha }}
+        run: |
+          # --no-persist: CI has no daemon / DuckDB, so suppress the
+          # local_store write warning. The CLI still exits 1 on any
+          # failure, which fails the job and blocks the merge.
+          ${REPO_NAME} eval --suite tests/data/golden_ci.yaml --no-persist
+      - name: Upload eval result JSON on failure
+        if: failure() && steps.gate.outputs.skip != '1' && steps.keycheck.outputs.skip != '1'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.CI_ANTHROPIC_API_KEY }}
+          CLAWMETRY_EVALS_AGENT_CMD: "python3 tests/eval_ci_mock_agent.py"
+          GITHUB_SHA: ${{ github.sha }}
+        run: |
+          ${REPO_NAME} eval --suite tests/data/golden_ci.yaml --no-persist --json > eval-result.json || true
+      - uses: actions/upload-artifact@v7
+        if: failure() && steps.gate.outputs.skip != '1' && steps.keycheck.outputs.skip != '1'
+        with:
+          name: ${REPO_NAME}-ci-eval-result
+          path: eval-result.json
+          if-no-files-found: warn
+          retention-days: 7
+
+  # ── Live OpenClaw E2E ──────────────────────────────────────────────────────
+  # Closes #1544. Boots a real openclaw gateway, sends a real message
+  # through `openclaw agent --local`, drives the daemon's
+  # sync_sessions_recent over the on-disk JSONL, and asserts every
+  # relevant API endpoint returns the real data tagged
+  # _source: 'local_store'.
+  #
+  # Depends on the .github/actions/setup-openclaw composite action (PR
+  # #1545). When that PR lands on main this job goes green the next push;
+  # in the meantime CI runs on Linux only and skips cleanly on macOS /
+  # Windows (no openclaw binary preinstalled, test module skips
+  # gracefully).
+  #
+  # Per #1544 budget: <90s wall-clock. Total job timeout 10 min covers
+  # the cold-cache npm install (~30s) + Python deps (~30s) + the test.
+  live-openclaw-e2e:
+    name: Live OpenClaw E2E (real gateway + real send-message)
+    needs: lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # NON-BLOCKING for now. OpenClaw harness setup in CI is an open
+    # follow-up (see PR #1549 debug-team thread + comment from author).
+    # Synthetic MOAT verifier (#1527) + cloud roundtrip E2E (#917) +
+    # browser golden-path (#918) cover the regression class this would
+    # add defense-in-depth for. Flip to required after local-dev OpenClaw
+    # setup pattern is documented.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Setup OpenClaw
+        # Composite action from PR #1545 — installs `openclaw` via
+        # `npm install -g`, caches per-runner, exposes on PATH.
+        uses: ./.github/actions/setup-openclaw
+        with:
+          version: latest
+          gateway-token: moat-live-e2e-token
+      - name: Install Python deps
+        run: pip install flask pytest waitress duckdb cryptography requests
+      - name: Run live OpenClaw E2E
+        env:
+          # User-provided key (private repo secret) so OpenClaw can make a
+          # real LLM round-trip and write the session row the test asserts
+          # on. Rotate via console.anthropic.com if leaked.
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        # test_e2e_real_openclaw_pipeline now drives a REAL turn (it used to
+        # seed synthetic JSONL), so it belongs here — the only job with the
+        # openclaw binary + a key. Elsewhere it skips gracefully.
+        run: python3 -m pytest tests/test_moat_live_openclaw_e2e.py tests/test_e2e_real_openclaw_pipeline.py -v --tb=short
+      - name: Upload gateway logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: moat-live-e2e-logs
+          path: |
+            /tmp/pytest-of-*/pytest-current/**/gateway.log
+          if-no-files-found: warn
+          retention-days: 7


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/clawmetry/.github/workflows/ci.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).