### PR TITLE
Proposal: add `cross-repo-handoff.yml` skeleton

### DIFF
--- a/.github/workflows/cross-repo-handoff.yml
+++ b/.github/workflows/cross-repo-handoff.yml
@@ -1,0 +1,114 @@
+name: Cross-repo handoff (C4)
+
+# C4 gate: landing signup -> cloud boot -> daemon pair -> first sync event lands.
+# Hard gate: no continue-on-error. Budget: 10 min.
+# Tracking: vivekchand/${REPO_NAME}#1646 (C4)
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: cross-repo-handoff-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cross-repo-handoff:
+    name: Cross-repo handoff (C4)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout ${REPO_NAME} (OSS)
+        uses: actions/checkout@v7
+        with:
+          path: oss
+
+      # CLOUD_REPO_PAT is NOT exposed to pull_request runs from a fork (GitHub
+      # withholds repo secrets from fork PRs to prevent exfiltration). Without it
+      # the private ${REPO_NAME}-cloud checkout below cannot authenticate, so this
+      # cross-repo test can only run on same-repo PRs and on push to main. Detect
+      # that here and skip the cloud-dependent steps (job still goes green) so a
+      # fork contributor's PR is not blocked by an inaccessible private repo.
+      - name: Detect cloud-repo access
+        id: access
+        env:
+          CLOUD_REPO_PAT: ${{ secrets.CLOUD_REPO_PAT }}
+        run: |
+          if [ -n "$CLOUD_REPO_PAT" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=C4 skipped (fork PR)::CLOUD_REPO_PAT is not available to PRs from forks, so the private ${REPO_NAME}-cloud repo cannot be checked out. The cross-repo handoff test is skipped on this run; it still runs on same-repo PRs and on push to main."
+          fi
+
+      # Cloud repo provides run_cloud.py stub + DaemonSim wire-format simulator.
+      - name: Checkout ${REPO_NAME}-cloud
+        if: steps.access.outputs.available == 'true'
+        uses: actions/checkout@v7
+        with:
+          repository: ${GITHUB_OWNER}/${REPO_NAME}-cloud
+          token: ${{ secrets.CLOUD_REPO_PAT }}
+          path: cloud
+
+      - name: Patch run_cloud.py throttle stub (node_id kwarg compat)
+        if: steps.access.outputs.available == 'true'
+        run: |
+          python - <<'EOF'
+          import pathlib
+          p = pathlib.Path("cloud/tests/e2e_browser/run_cloud.py")
+          if not p.exists():
+              print("run_cloud.py not found — skipping patch")
+              exit(0)
+          t = p.read_text()
+          t = t.replace(
+              "def _throttle_patched(token):",
+              "def _throttle_patched(token, node_id=None):"
+          ).replace(
+              "return _orig_throttle(token)",
+              "return _orig_throttle(token, node_id=node_id)"
+          )
+          p.write_text(t)
+          print("patched _throttle_patched: added node_id kwarg")
+          EOF
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install deps
+        if: steps.access.outputs.available == 'true'
+        run: |
+          python -m pip install --upgrade pip
+          # Install only what the test needs (avoids duckdb version-pin in requirements.txt)
+          pip install flask pytest requests cryptography
+          # Cloud deps (psycopg2 is never called -- DB is monkey-patched --
+          # but it must be importable for 'import db' to succeed)
+          pip install psycopg2-binary
+          pip install -r cloud/requirements.txt || true
+          pip install waitress
+
+      - name: Run C4 cross-repo handoff
+        if: steps.access.outputs.available == 'true'
+        env:
+          CLAWMETRY_E2E_STUB_AUTH: "1"
+        run: |
+          cd "${{ github.workspace }}"
+          python -m pytest oss/tests/test_e2e_cross_repo_handoff.py \
+            -v --tb=short
+
+      - name: Dump server logs on failure
+        if: failure()
+        run: |
+          echo "=== cloud server log ==="
+          cat /tmp/c4-cloud.log 2>/dev/null | tail -200 || true
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: c4-handoff-logs
+          path: /tmp/c4-cloud.log
+          if-no-files-found: warn
+          retention-days: 7


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/clawmetry/.github/workflows/cross-repo-handoff.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).