### PR TITLE
Proposal: add `install-test.yml` skeleton

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -1,0 +1,67 @@
+name: Test Install Script
+on:
+  push:
+    paths: [install.sh, install.ps1, install.cmd]
+  pull_request:
+    paths: [install.sh, install.ps1, install.cmd]
+  workflow_dispatch:
+
+jobs:
+  test-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Run install script
+        run: bash install.sh
+      - name: Verify ${REPO_NAME} binary
+        run: ${REPO_NAME} --version
+
+  test-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Run install script
+        run: bash install.sh
+      - name: Add bin to PATH
+        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - name: Verify ${REPO_NAME} binary
+        run: ${REPO_NAME} --version
+
+  test-windows-ps:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Run PowerShell install
+        shell: pwsh
+        run: .\install.ps1
+      - name: Verify ${REPO_NAME} binary
+        shell: pwsh
+        run: |
+          $env:PATH = "$env:LOCALAPPDATA\${REPO_NAME}\Scripts;$env:PATH"
+          ${REPO_NAME} --version
+
+  test-windows-cmd:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Run CMD install
+        shell: cmd
+        run: install.cmd
+      - name: Verify ${REPO_NAME} binary
+        shell: cmd
+        run: ${REPO_NAME} --version
+
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: ShellCheck
+        run: shellcheck install.sh


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/clawmetry/.github/workflows/install-test.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).