### PR TITLE
Proposal: add `oss-golden-path.yml` skeleton

### DIFF
--- a/.github/workflows/oss-golden-path.yml
+++ b/.github/workflows/oss-golden-path.yml
@@ -1,0 +1,205 @@
+name: OSS Golden Path (C1)
+
+# C1 gate: wheel install + real OpenClaw + synthetic session + 9 tabs render
+# without auth errors. Hard gate on every PR, no continue-on-error.
+# Budget: 8 minutes wall-clock (raised from 5; Playwright chromium download
+# ~100 MB takes up to 4.5 min on a cold runner -- cache hit drops it to ~30 s).
+# Tracking: vivekchand/${REPO_NAME}#1646 (C1)
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: oss-golden-path-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  oss-golden-path:
+    name: OSS golden path (wheel + OpenClaw + 9 tabs)
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      # Cache the ~100 MB Playwright chromium binary so the download step
+      # takes seconds rather than minutes on warm runners.
+      - name: Cache Playwright browsers
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}-${{ hashFiles('setup.py', 'requirements.txt') }}
+          restore-keys: |
+            playwright-chromium-${{ runner.os }}-
+
+      # Step 1 -- build the wheel from source and install into an isolated venv.
+      # This proves the wheel ships all runtime assets (same surface as the
+      # wheel-install job in ci.yml) AND that the installed package can drive
+      # the full E2E flow.
+      - name: Build wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build --wheel
+
+      - name: Install wheel in isolated venv
+        run: |
+          python -m venv /tmp/oss-golden
+          /tmp/oss-golden/bin/pip install --upgrade pip
+          /tmp/oss-golden/bin/pip install \
+            dist/${REPO_NAME}-*.whl \
+            flask waitress cryptography duckdb requests \
+            pytest pytest-playwright
+
+      # Step 2 -- boot real OpenClaw gateway.
+      # setup-openclaw installs the npm package, puts openclaw on PATH, and
+      # exports OPENCLAW_GATEWAY_TOKEN for all subsequent steps.
+      # continue-on-error: true because the C1 auth check does not require
+      # a running gateway -- it compares the token directly against env.
+      - name: Setup OpenClaw
+        continue-on-error: true
+        uses: ./.github/actions/setup-openclaw
+        with:
+          version: latest
+          gateway-token: ci-golden-token
+
+      # Guarantee the token is in GITHUB_ENV even when Setup OpenClaw
+      # fails above. Without this, OPENCLAW_GATEWAY_TOKEN is never set
+      # and the dashboard fails /api/auth/check (login overlay on every tab).
+      - name: Export gateway token (CI auth fallback)
+        run: echo "OPENCLAW_GATEWAY_TOKEN=ci-golden-token" >> "$GITHUB_ENV"
+
+      - name: Start OpenClaw gateway
+        continue-on-error: true
+        run: |
+          mkdir -p /tmp/openclaw-logs
+          nohup openclaw gateway --port 18789 --allow-unconfigured \
+            > /tmp/openclaw-logs/gateway.log 2>&1 &
+          echo "OPENCLAW_GATEWAY_PID=$!" >> "$GITHUB_ENV"
+          for i in $(seq 1 30); do
+            code=$(curl -s -o /dev/null -w "%{http_code}" \
+              -H "Authorization: Bearer ci-golden-token" \
+              "http://127.0.0.1:18789/v1/models" 2>/dev/null || echo "000")
+            case "$code" in 2*|401|403) echo "gateway up ($code after ${i}s)"; break;; esac
+            sleep 1
+          done
+
+      # Step 3 -- seed a synthetic OpenClaw session JSONL.
+      # Mirrors the real event shape the daemon ingests (same keys used by
+      # test_moat_send_message_e2e.py). Seeded BEFORE the dashboard starts
+      # so the startup sync picks it up immediately.
+      - name: Seed synthetic OpenClaw session
+        shell: python
+        run: |
+          import json, datetime, pathlib
+          home = pathlib.Path.home() / ".openclaw" / "agents" / "main" / "sessions"
+          home.mkdir(parents=True, exist_ok=True)
+          sid = "aaaaaaaa-0001-0001-0001-000000000001"
+          now = datetime.datetime.now(datetime.timezone.utc)
+          def ts(s):
+              return (now - datetime.timedelta(seconds=s)).isoformat().replace("+00:00", "Z")
+          events = [
+              {
+                  "id": "ev-start", "type": "session_start",
+                  "timestamp": ts(600), "workspace": "ws-golden",
+                  "title": "Golden Path E2E",
+              },
+              {
+                  "id": "ev-user", "type": "message",
+                  "timestamp": ts(550), "workspace": "ws-golden",
+                  "role": "user", "content": "Golden Path E2E",
+              },
+              {
+                  "id": "ev-tool", "type": "tool_call",
+                  "timestamp": ts(500), "workspace": "ws-golden",
+                  "tool": "Bash", "args": {"cmd": "echo hello"}, "result": "hello",
+                  "cost_usd": 0.001, "tokens": 42, "model": "claude-opus-4-7",
+              },
+              {
+                  "id": "ev-msg", "type": "message",
+                  "timestamp": ts(400), "workspace": "ws-golden",
+                  "role": "assistant", "text": "Done.",
+                  "cost_usd": 0.002, "tokens": 50, "model": "claude-opus-4-7",
+              },
+          ]
+          f = home / f"{sid}.jsonl"
+          f.write_text("\n".join(json.dumps(e) for e in events))
+          print(f"Seeded {len(events)} events to {f}")
+
+      # Step 4 -- start the dashboard from the installed wheel (NOT from the
+      # source checkout). This is the key C1 invariant: the installed package
+      # must serve all tabs correctly, not just the in-repo version.
+      - name: Start dashboard from installed wheel
+        run: |
+          OPENCLAW_GATEWAY_TOKEN=ci-golden-token \
+          /tmp/oss-golden/bin/python -c "import dashboard; dashboard.main()" \
+            --port 8920 --no-debug \
+            > /tmp/oss-golden-dashboard.log 2>&1 &
+          echo "DASHBOARD_PID=$!" >> "$GITHUB_ENV"
+          for i in $(seq 1 30); do
+            curl -sf -H "Authorization: Bearer ci-golden-token" \
+              http://localhost:8920/api/health && echo "Dashboard ready after ${i}s" && break
+            sleep 1
+          done
+
+      # Step 5 -- wait for the daemon sync thread to ingest the seeded JSONL.
+      # The dashboard starts a background sync loop on boot that watches
+      # ~/.openclaw/agents/main/sessions/. We poll /api/sessions up to 30s.
+      - name: Wait for session sync
+        run: |
+          for i in $(seq 1 30); do
+            count=$(
+              curl -s -H "Authorization: Bearer ci-golden-token" \
+                http://localhost:8920/api/sessions \
+                | python3 -c "import sys,json; d=json.load(sys.stdin); print(len(d.get('sessions', [])))" \
+                2>/dev/null || echo 0
+            )
+            if [ "${count:-0}" -ge 1 ]; then
+              echo "Session sync complete: $count session(s) in DuckDB"
+              break
+            fi
+            sleep 1
+          done
+
+      # Step 6 -- Playwright tab sweep across all 9 C1 tabs.
+      - name: Install Playwright browsers
+        run: /tmp/oss-golden/bin/python -m playwright install chromium --with-deps
+
+      - name: Run OSS golden path test
+        env:
+          CLAWMETRY_URL: http://localhost:8920
+          CLAWMETRY_TOKEN: ci-golden-token
+        run: |
+          /tmp/oss-golden/bin/python -m pytest \
+            tests/test_e2e_oss_golden_path.py \
+            -v --tb=short
+
+      - name: Dashboard and gateway logs on failure
+        if: failure()
+        run: |
+          echo "==== dashboard log ===="
+          tail -150 /tmp/oss-golden-dashboard.log || true
+          echo "==== openclaw gateway log ===="
+          tail -100 /tmp/openclaw-logs/gateway.log || true
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: c1-golden-path-logs
+          path: |
+            /tmp/oss-golden-dashboard.log
+            /tmp/openclaw-logs/
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Tear down
+        if: always()
+        run: |
+          kill "$OPENCLAW_GATEWAY_PID" 2>/dev/null || true
+          kill "$DASHBOARD_PID" 2>/dev/null || true


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/clawmetry/.github/workflows/oss-golden-path.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).