### PR TITLE
Proposal: add `build-haproxy-images.yml` skeleton

### DIFF
--- a/.github/workflows/build-haproxy-images.yml
+++ b/.github/workflows/build-haproxy-images.yml
@@ -1,0 +1,51 @@
+name: Build Haproxy Images
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    permissions:
+      contents: write   # for release
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        # amd64 images
+        - { type: container, base: ubuntu, arch: amd64 }
+        - { type: container, base: debian, arch: amd64 }
+        # arm64 images
+        - { type: container, base: ubuntu, arch: arm64 }
+        - { type: container, base: debian, arch: arm64 }
+    runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Prepare runner
+        run: |
+          ./hack/scripts/ci/setup-github-actions.sh
+
+      - name: Setup infrastructure
+        run: |
+          ./hack/scripts/ci/setup-incus.sh
+
+      - name: Build image
+        run: |
+          go run ./cmd/exp/image-builder haproxy --v=4 \
+            --base-image=${{ matrix.base }} \
+            --output=haproxy-${{ matrix.base }}-${{ matrix.arch }}.tar.gz
+
+      - name: Release image
+        uses: softprops/action-gh-release@v3
+        with:
+          name: Kubeadm images
+          tag_name: kubeadm-images
+          files: |
+            haproxy-${{ matrix.base }}-${{ matrix.arch }}.tar.gz
+          make_latest: "false"


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/cluster-api-provider-incus/.github/workflows/build-haproxy-images.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).