### PR TITLE
Proposal: add `aur-release.yml` skeleton

### DIFF
--- a/.github/workflows/aur-release.yml
+++ b/.github/workflows/aur-release.yml
@@ -1,0 +1,31 @@
+name: Release to aur
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+jobs:
+  aur_publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Prepare AUR package
+      run: |
+        version=""
+        if [ hash git &>/dev/null ]; then
+          version=$(git describe --abbrev=0 --tags | sed 's/^v//g')
+        fi
+        if [ -z "${version}" ]; then
+          version=$(cat ${REPO_NAME}/version.py | grep version | sed 's/^.*= .\(.*\).$/\1/g')
+        fi
+        [ -z "${version}" ] && exit 1
+        sed -i "s/^pkgver=.*$/pkgver=${version}/g" packages/arch-${REPO_NAME}/PKGBUILD
+        cat packages/arch-${REPO_NAME}/PKGBUILD
+    - name: Publish to aur
+      uses: KSXGitHub/github-actions-deploy-aur@v4.1.2
+      with:
+        pkgname: ${REPO_NAME}
+        pkgbuild: ./packages/arch-${REPO_NAME}/PKGBUILD
+        commit_username: ${{ secrets.AUR_USERNAME }}
+        commit_email: ${{ secrets.AUR_EMAIL }}
+        ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+        commit_message: "bump version"


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/dotdrop/.github/workflows/aur-release.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).