### PR TITLE
Proposal: add `action-integration.yml` skeleton

### DIFF
--- a/.github/workflows/action-integration.yml
+++ b/.github/workflows/action-integration.yml
@@ -1,0 +1,33 @@
+# Tests athe github action on each push
+name: Action Integration Test
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+jobs:
+  action-integration-testing:
+    name: Action Integration Testing
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Update action.yml to use dockerfile
+        uses: rmeneely/update-yaml@v1
+        with:
+          infile: action.yml
+          varlist: "runs.image=Dockerfile"
+      - name: cat action.yml
+        run: cat action.yml
+      - name: Test action
+        id: test-action
+        # test with the local checkout of the action
+        uses: ./
+        with:
+          token: ${{ secrets.THIS_PAT || github.token }}
+          action: "check"
+      - name: Check outputs
+        run: |
+          test "${{ steps.test-action.outputs.result }}" == "Check passed"


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/gha-repo-manager/.github/workflows/action-integration.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).