### PR TITLE
Proposal: add `release.yml` skeleton

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,89 @@
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release, like v1.0.0. Must increment current versions"
+        required: true
+      releaseNotes:
+        description: "Any notes for this release"
+        required: false
+        default: ""
+      prerelease:
+        description: "Is this a prerelease"
+        required: false
+        default: false
+        type: boolean
+jobs:
+  update-dockerfile:
+    if: github.repository_owner == '${GITHUB_OWNER}'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.THIS_PAT }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Docker metadata
+        uses: docker/metadata-action@v4
+        id: meta
+        with:
+          images: |
+            ${{ github.repository }}
+          tags: |
+            type=raw,value=${{ inputs.version }}
+            # minimal (short sha)
+            type=sha,prefix=
+            # full length sha
+            type=sha,format=long,prefix=
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: Docker/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          # https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#registry-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Update Action Dockerfile with Jinja
+        id: update_action-dockerfile
+        uses: cuchi/jinja2-action@v1.2.0
+        with:
+          template: Docker/ActionDockerfile.j2
+          output_file: Dockerfile
+          strict: true
+          variables: |
+            image_version=${{ inputs.version }}
+      - name: Commit Dockerfile changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "ci: update actions dockerfile for release"
+          file_pattern: Dockerfile
+          tagging_message: ${{ inputs.version }}
+  release:
+    runs-on: ubuntu-latest
+    needs: update-dockerfile
+    steps:
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.THIS_PAT }}
+        with:
+          tag_name: ${{ inputs.version }}
+          release_name: ${{ inputs.version }}
+          body: ${{ inputs.releaseNotes }}
+          draft: false
+          prerelease: ${{ inputs.prerelease }}


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/gha-repo-manager/.github/workflows/release.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).