### PR TITLE
Proposal: add `test.yml` skeleton

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,245 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches: [main, develop, issue-*]
+  workflow_dispatch:
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install
+        run: yarn install
+
+      - name: Test
+        run: yarn test-unit
+
+  e2e-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install
+        run: yarn install
+
+      - name: Build
+        run: yarn build
+
+      - name: Test
+        run: yarn test-e2e
+
+  integration-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up git committer identity
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Install dependencies and build
+        run: yarn install && yarn build && yarn package
+
+      - name: Create a temp git dir
+        run: |
+          mkdir ${{ runner.temp }}/temp_git_dir
+          cd ${{ runner.temp }}/temp_git_dir
+          git config --global init.defaultBranch main
+          git init
+          git status
+
+      - name: Create new job
+        id: create-job
+        uses: ./
+        with:
+          git_repo_dir: ${{ runner.temp }}/temp_git_dir
+          queue_name: 'library update - library-aaa'
+          action: 'create-job'
+          job_payload: '{"field": "value", "state": "pending"}'
+
+      - name: Debug
+        run: |
+          cd ${{ runner.temp }}/temp_git_dir
+          git log --show-signature
+
+      - name: Mark job as started
+        id: start-job
+        if: ${{ steps.create-job.outputs.job_created == 'true' }}
+        uses: ./
+        with:
+          git_repo_dir: ${{ runner.temp }}/temp_git_dir
+          queue_name: 'library update - library-aaa'
+          action: 'start-job'
+          job_payload: '{"field": "value", "state": "started"}'
+
+      - name: Debug
+        run: |
+          cd ${{ runner.temp }}/temp_git_dir
+          git log --show-signature
+
+      - name: Mutual exclusion code
+        if: ${{ steps.create-job.outputs.job_created == 'true' }}
+        run: echo "Running the job that requires mutual exclusion"
+
+      - name: Get next job
+        id: get-next-job
+        if: ${{ steps.create-job.outputs.job_created == 'true' }}
+        uses: ./
+        with:
+          git_repo_dir: ${{ runner.temp }}/temp_git_dir
+          queue_name: 'library update - library-aaa'
+          action: 'next-job'
+
+      - name: Debug
+        run: |
+          cd ${{ runner.temp }}/temp_git_dir
+          git log --show-signature
+
+      - name: Mark job as finished
+        id: finish-job
+        if: ${{ steps.create-job.outputs.job_created == 'true' }}
+        uses: ./
+        with:
+          git_repo_dir: ${{ runner.temp }}/temp_git_dir
+          queue_name: 'library update - library-aaa'
+          action: 'finish-job'
+          job_payload: '{"field": "value", "state": "finished"}'
+
+      - name: Debug
+        run: |
+          cd ${{ runner.temp }}/temp_git_dir
+          git log --show-signature
+
+      - name: Show new commits
+        run: |
+          cd ${{ runner.temp }}/temp_git_dir
+          git show --pretty="fuller" --show-signature ${{ steps.create-job.outputs.job_commit }}
+          git show --pretty="fuller" --show-signature ${{ steps.start-job.outputs.job_commit }}
+          git show --pretty="fuller" --show-signature ${{ steps.finish-job.outputs.job_commit }}
+
+      - name: Upload test git dir
+        uses: actions/upload-artifact@v3
+        with:
+          name: Integration test git dir
+          path: ${{ runner.temp }}/temp_git_dir
+
+  integration-tests-with-commit-signature:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Git config
+        run: |
+          # Import test GPG key
+          # secretlint-disable
+          {
+            # nosemgrep
+            echo -e "-----BEGIN PGP PRIVATE KEY BLOCK-----\n"
+            cat __tests__/fixtures/test-key-committer.pgp
+            echo -e "\n-----END PGP PRIVATE KEY BLOCK-----\n"
+          } | gpg --import --batch --yes -
+          # secretlint-enable
+          # Set Git config
+          git config --global user.name 'A Committer'
+          git config --global user.email 'committer@example.com'
+          git config --global user.signingkey 'BD98B3F42545FF93EFF55F7F3F39AA1432CA6AD7'
+          git config --global commit.gpgsign true
+
+      - name: Install dependencies and build
+        run: yarn install && yarn build && yarn package
+
+      - name: Create a temp git dir
+        run: |
+          mkdir ${{ runner.temp }}/temp_git_dir
+          cd ${{ runner.temp }}/temp_git_dir
+          git config --global init.defaultBranch main
+          git init
+          git status
+
+      - name: Create new job
+        id: create-job
+        uses: ./
+        with:
+          git_repo_dir: ${{ runner.temp }}/temp_git_dir
+          queue_name: 'library update - library-aaa'
+          action: 'create-job'
+          job_payload: '{"field": "value", "state": "pending"}'
+
+      - name: Debug
+        run: |
+          cd ${{ runner.temp }}/temp_git_dir
+          git log --show-signature
+
+      - name: Mark job as started
+        id: start-job
+        if: ${{ steps.create-job.outputs.job_created == 'true' }}
+        uses: ./
+        with:
+          git_repo_dir: ${{ runner.temp }}/temp_git_dir
+          queue_name: 'library update - library-aaa'
+          action: 'start-job'
+          job_payload: '{"field": "value", "state": "started"}'
+
+      - name: Debug
+        run: |
+          cd ${{ runner.temp }}/temp_git_dir
+          git log --show-signature
+
+      - name: Mutual exclusion code
+        if: ${{ steps.create-job.outputs.job_created == 'true' }}
+        run: echo "Running the job that requires mutual exclusion"
+
+      - name: Get next job
+        id: get-next-job
+        if: ${{ steps.create-job.outputs.job_created == 'true' }}
+        uses: ./
+        with:
+          git_repo_dir: ${{ runner.temp }}/temp_git_dir
+          queue_name: 'library update - library-aaa'
+          action: 'next-job'
+
+      - name: Debug
+        run: |
+          cd ${{ runner.temp }}/temp_git_dir
+          git log --show-signature
+
+      - name: Mark job as finished
+        id: finish-job
+        if: ${{ steps.create-job.outputs.job_created == 'true' }}
+        uses: ./
+        with:
+          git_repo_dir: ${{ runner.temp }}/temp_git_dir
+          queue_name: 'library update - library-aaa'
+          action: 'finish-job'
+          job_payload: '{"field": "value", "state": "finished"}'
+
+      - name: Debug
+        run: |
+          cd ${{ runner.temp }}/temp_git_dir
+          git log --show-signature
+
+      - name: Show new commits
+        run: |
+          cd ${{ runner.temp }}/temp_git_dir
+          git show --pretty="fuller" --show-signature ${{ steps.create-job.outputs.job_commit }}
+          git show --pretty="fuller" --show-signature ${{ steps.start-job.outputs.job_commit }}
+          git show --pretty="fuller" --show-signature ${{ steps.finish-job.outputs.job_commit }}
+
+      - name: Upload test git dir
+        uses: actions/upload-artifact@v3
+        with:
+          name: Integration test git dir
+          path: ${{ runner.temp }}/temp_git_dir


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/git-queue/.github/workflows/test.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).