### PR TITLE
Proposal: add `release.yml` skeleton

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Download all artifacts
+      uses: actions/download-artifact@v3
+      with:
+        path: artifacts
+    
+    - name: List downloaded artifacts
+      run: |
+        find artifacts -type f -name "*.exe" -o -name "*.deb" -o -name "*.rpm" | sort
+    
+    - name: Create release assets
+      run: |
+        mkdir -p release-assets
+        
+        # Copy Windows EXE
+        if [ -d "artifacts/windows-package" ]; then
+          cp artifacts/windows-package/*.exe release-assets/ 2>/dev/null || true
+          cp -r artifacts/windows-package/package release-assets/windows-package 2>/dev/null || true
+        fi
+        
+        # Copy DEB packages
+        if [ -d "artifacts/debian-package" ]; then
+          cp artifacts/debian-package/*.deb release-assets/ 2>/dev/null || true
+        fi
+        
+        # Copy RPM packages
+        if [ -d "artifacts/rpm-package" ]; then
+          cp artifacts/rpm-package/*.rpm release-assets/ 2>/dev/null || true
+        fi
+        
+        # Create source distribution
+        python setup.py sdist
+        cp dist/*.tar.gz release-assets/
+        
+        ls -la release-assets/
+    
+    - name: Upload to Release
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./release-assets/
+        asset_name: ${REPO_NAME}-${{ github.event.release.tag_name }}
+        asset_content_type: application/zip 


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/git-repo-manager/.github/workflows/release.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).