### PR TITLE
Proposal: add `test-lxd.yml` skeleton

### DIFF
--- a/.github/workflows/test-lxd.yml
+++ b/.github/workflows/test-lxd.yml
@@ -1,0 +1,101 @@
+name: Test LXD Provision
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lxd-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout ${REPO_NAME}
+        uses: actions/checkout@v4
+
+      - name: Install LXD
+        run: |
+          sudo snap install lxd
+          # Wait for LXD daemon to start
+          echo "Waiting for LXD daemon to start..."
+          sleep 15
+          # Initialize LXD with default settings
+          sudo lxd init --auto
+          # Add runner to lxd group
+          sudo usermod -a -G lxd runner
+          # Fix socket permissions for CI environment
+          sudo chmod 666 /var/snap/lxd/common/lxd/unix.socket
+          # Test basic LXD functionality
+          sudo lxc list
+
+      - name: Launch LXD VM
+        run: |
+          sudo lxc launch ubuntu:24.04 test-vm --vm
+
+      - name: Wait for VM to be ready
+        run: |
+          echo "Waiting for VM to be fully initialized..."
+
+          # Debug: Check VM status
+          echo "=== VM Status ==="
+          sudo lxc list
+          sudo lxc info test-vm
+
+          # We check for basic readiness instead of waiting for cloud-init completion
+          timeout=300
+          elapsed=0
+          while [ $elapsed -lt $timeout ]; do
+            # Debug: Show what we're checking
+            echo "=== Checking VM readiness (attempt $((elapsed/10 + 1))) ==="
+            
+            # Check if VM is running and we can execute commands
+            if sudo lxc list --format=csv | grep -q "test-vm.*RUNNING"; then
+              echo "VM is in RUNNING state"
+              
+              # Try to execute a simple command to verify VM is responsive
+              if sudo lxc exec test-vm -- echo "VM is responsive" 2>/dev/null; then
+                echo "VM is responsive to commands"
+                
+                # Check if basic system is ready (systemd, if available)
+                if sudo lxc exec test-vm -- systemctl is-system-running --wait 2>/dev/null || true; then
+                  echo "VM system is ready!"
+                  break
+                else
+                  echo "VM system not fully ready yet, but responsive"
+                  # For basic VMs, being responsive might be enough
+                  if [ $elapsed -ge 60 ]; then  # After 60 seconds, if responsive, consider ready
+                    echo "VM has been responsive for sufficient time, considering ready"
+                    break
+                  fi
+                fi
+              else
+                echo "VM not responsive to commands yet"
+              fi
+            else
+              echo "VM not in RUNNING state yet"
+            fi
+            
+            echo "Waiting for VM to be ready... ($elapsed/$timeout seconds)"
+            sleep 10
+            elapsed=$((elapsed + 10))
+          done
+
+          if [ $elapsed -ge $timeout ]; then
+            echo "=== TIMEOUT DEBUGGING ==="
+            echo "Final VM status:"
+            sudo lxc list
+            sudo lxc info test-vm
+            echo "Timeout waiting for VM to be ready"
+            exit 1
+          fi
+
+          echo "VM is ready for use!"
+
+      - name: Run command inside VM
+        run: |
+          sudo lxc exec test-vm -- bash -c "echo Hello from LXD VM"
+
+      - name: Stop and delete VM
+        run: |
+          sudo lxc stop test-vm
+          sudo lxc delete test-vm


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/github-actions-virtualization-support/.github/workflows/test-lxd.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).