### PR TITLE
Proposal: add `test-multipass.yml` skeleton

### DIFF
--- a/.github/workflows/test-multipass.yml
+++ b/.github/workflows/test-multipass.yml
@@ -1,0 +1,35 @@
+name: Test Multipass Provision
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  multipass-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout ${REPO_NAME}
+        uses: actions/checkout@v4
+
+      - name: Install Multipass
+        run: |
+          sudo snap install multipass --classic
+          sudo snap wait system seed.loaded
+          sleep 5
+
+      - name: Launch Multipass VM
+        run: |
+          sudo multipass launch 24.04 -n test-vm
+          sleep 10
+
+      - name: Run command inside VM
+        run: |
+          sudo multipass exec test-vm -- bash -c "echo Hello from Multipass VM"
+
+      - name: Stop and delete VM
+        run: |
+          sudo multipass stop test-vm
+          sudo multipass delete test-vm
+          sudo multipass purge


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/github-actions-virtualization-support/.github/workflows/test-multipass.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).