### PR TITLE
Proposal: add `ci-skip.yml` skeleton

### DIFF
--- a/.github/workflows/ci-skip.yml
+++ b/.github/workflows/ci-skip.yml
@@ -1,0 +1,24 @@
+name: CI
+
+# Companion to ci.yml. When a pull request only touches documentation or other
+# path-ignored files, ci.yml is skipped entirely and its required "Shellcheck"
+# check never reports — which blocks the PR from merging. This workflow runs on
+# exactly those ignored paths and emits a passing check with the same job name,
+# so the required status is always satisfied without a manual bypass.
+
+on:
+  pull_request:
+    paths:
+      - '**.md'
+      - 'LICENSE'
+      - '.github/FUNDING.yml'
+
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: No shell scripts changed
+        run: echo "Documentation-only change; no shell scripts to lint."


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/github-api-scripts1/.github/workflows/ci-skip.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).