### PR TITLE
Proposal: add `merge-conflicts.yml` skeleton

### DIFF
--- a/.github/workflows/merge-conflicts.yml
+++ b/.github/workflows/merge-conflicts.yml
@@ -1,0 +1,30 @@
+name: Merge Conflicts
+
+# Reject unresolved Git merge-conflict markers committed into tracked files.
+#
+# This lives in its own workflow ON PURPOSE: ci.yml sets
+# `on.pull_request.paths-ignore: ['**/*.md', ...]`, so a Markdown/CHANGELOG-only
+# PR skips that workflow entirely. The conflict markers this guard exists to
+# catch landed in CHANGELOG.md, so the check must run with no `paths-ignore`.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  merge-conflicts:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - name: Reject unresolved merge-conflict markers
+        run: |
+          if git grep -nI -E '^(<{7}|>{7}|\|{7})( |$)' -- .; then
+            echo "::error::Unresolved Git merge-conflict markers found in tracked files (see matches above)."
+            exit 1
+          fi
+          echo "No merge-conflict markers found."


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/headroom/.github/workflows/merge-conflicts.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).