### PR TITLE
Proposal: add `release-please.yml` skeleton

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,49 @@
+name: Release Please
+
+# What this does
+# ----------------
+# release-please watches `main` for conventional-commit traffic and
+# maintains a single "Release vX.Y.Z" PR that aggregates everything
+# released since the last tag. Merging that PR is what triggers an
+# actual PyPI / npm / GitHub-Release publish (via release.yml, which
+# fires on the published-release event the bot emits at merge time).
+#
+# This replaces the prior "every push to main is a release" pattern
+# that burned PyPI's per-project storage quota by uploading a fresh
+# wheel matrix (~200 MB) for each merged `fix:` / `feat:` PR.
+#
+# Day-to-day:
+#   - Merge a `fix:` PR into main      -> bot updates the release PR
+#   - Merge a `feat:` PR into main     -> bot bumps minor in release PR
+#   - Merge `ci:` / `docs:` / `chore:` -> no PR change (hidden)
+#   - Ready to ship                    -> merge the release PR
+#                                       (bot tags + emits release event;
+#                                        release.yml does the actual builds + publishes)
+#
+# Config lives in `.release-please-config.json`; current versions
+# tracked in `.release-please-manifest.json`.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  # Serialize bot runs on main so two pushes don't race the
+  # release-PR update. We never cancel mid-flight — losing a manifest
+  # write would mean the next push computes the wrong base version.
+  group: release-please-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config-file: .release-please-config.json
+          manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/headroom/.github/workflows/release-please.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).