### PR TITLE
Proposal: add `stale.yml` skeleton

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,60 @@
+name: Stale Triage
+
+on:
+  schedule:
+    # Daily weekday pass during US morning hours.
+    - cron: '17 15 * * 1-5'  # TODO: set schedule for your project
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: stale-triage
+  cancel-in-progress: false
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Ensure stale label exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create "status: stale" \
+            --repo "${{ github.repository }}" \
+            --color "ededed" \
+            --description "No recent activity; may be closed if it stays inactive" \
+            --force
+
+      - uses: actions/stale@v10
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          operations-per-run: 200
+          remove-stale-when-updated: true
+          exempt-all-milestones: true
+          exempt-issue-labels: pinned,security,good first issue,help wanted,needs reproduction
+          exempt-pr-labels: pinned,security,dependencies,release,do not merge
+
+          stale-issue-label: "status: stale"
+          days-before-issue-stale: 60
+          days-before-issue-close: 14
+          stale-issue-message: >
+            This issue has had no recent activity and is being marked stale.
+            Please comment with new context if it is still relevant.
+          close-issue-message: >
+            Closing this issue due to continued inactivity. It can be reopened
+            if there is new information or a clear next step.
+
+          stale-pr-label: "status: stale"
+          days-before-pr-stale: 30
+          days-before-pr-close: 14
+          stale-pr-message: >
+            This pull request has had no recent activity and is being marked
+            stale. Please rebase, resolve conflicts, or comment if it is still
+            actively being worked.
+          close-pr-message: >
+            Closing this pull request due to continued inactivity. It can be
+            reopened when it is ready for review again.


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/headroom/.github/workflows/stale.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).