### PR TITLE
Proposal: add `wrap-native-e2e.yml` skeleton

### DIFF
--- a/.github/workflows/wrap-native-e2e.yml
+++ b/.github/workflows/wrap-native-e2e.yml
@@ -1,0 +1,73 @@
+name: Wrap Native E2E
+
+# Cross-platform smoke tests for the hidden ``${REPO_NAME} wrap ... --prepare-only``
+# flows. These reuse the existing pytest bridge cases so we exercise the real
+# CLI on linux / macos without depending on agent binaries or long-lived proxy
+# processes. Windows will be added once the upstream CRT conflict is resolved
+# (see matrix comment below).
+#
+# This complements the Docker-native wrap e2e by catching host-specific issues
+# such as home-directory layout and filesystem quirks in prepare-only config
+# injection.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "${REPO_NAME}/cli/**"
+      - "${REPO_NAME}/providers/**"
+      - "${REPO_NAME}/rtk/**"
+      - "tests/test_cli/test_wrap_bridge.py"
+      - ".github/actions/${REPO_NAME}-e2e-setup/**"
+      - ".github/workflows/wrap-native-e2e.yml"
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  wrap-native:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        # Windows is excluded today: upstream `esaxx-rs` (transitively from
+        # `tokenizers`) and `ort-sys` (onnxruntime via `fastembed`) link
+        # with conflicting MSVC C runtime libraries (/MT vs /MD), so the
+        # Rust extension cannot build for `win_amd64` until the upstream
+        # CRT conflict is resolved. Re-add `windows-latest` once the wheel
+        # builds cleanly there. Match init-native-e2e.yml so this workflow
+        # doesn't fail during setup before the wrap smoke tests run.
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup
+        uses: ./.github/actions/${REPO_NAME}-e2e-setup
+        with:
+          install-mode: deps-only-proxy
+          python-version: "3.11"
+
+      - name: Install pytest
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --retries 10 --timeout 60 pytest pytest-cov
+
+      - name: Run wrap native bridge tests
+        shell: bash
+        run: |
+          pytest tests/test_cli/test_wrap_bridge.py --cov=${REPO_NAME} --cov-report=xml:coverage-wrap-native.xml --cov-report=term-missing -q
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage-wrap-native.xml
+          flags: wrap-native
+          name: wrap-native-${{ matrix.os }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/headroom/.github/workflows/wrap-native-e2e.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).