### PR TITLE
Proposal: add `commits.yml` skeleton

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -1,0 +1,69 @@
+name: Commits
+on:
+  - pull_request
+
+permissions:
+  contents: read
+
+jobs:
+  dco-check:
+    permissions:
+      pull-requests: read  # for tim-actions/get-pr-commits to get list of commits from the PR
+    name: Signed-off-by (DCO)
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Check that all commits are signed-off
+      uses: KineticCafe/actions-dco@v3.1.0
+
+  llm-commit-policy:
+    permissions:
+      contents: none
+    name: LLM commit policy
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v7
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+
+    - name: Check LLM commit policy
+      run: |
+        set -eu
+
+        # Inspired by https://github.com/yaml/go-yaml/pull/340
+        agents="(aider|anthropic|claude|codex|copilot|devin|gemini|grok|openai)"
+
+        commits=$(git rev-list ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }})
+        for commit in $commits; do
+            if git log -n 1 "$commit" | tr '[:upper:]' '[:lower:]' | grep -qE "(author|assisted-by|co-authored-by|signed-off-by):.*$agents"; then
+                echo "Error: The following commit appears to violate this repo's LLM/AI contribution policy:"
+                echo ""
+                git log -n 1 "$commit"
+
+                exit 1
+            fi
+        done
+
+  target-branch:
+    permissions:
+      contents: none
+    name: Branch target
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Check branch target
+      env:
+        TARGET: ${{ github.event.pull_request.base.ref }}
+        TITLE: ${{ github.event.pull_request.title }}
+      run: |
+        set -eux
+        TARGET_FROM_PR_TITLE="$(echo "${TITLE}" | sed -n 's/.*(\(stable-[0-9]\.[0-9]\))$/\1/p')"
+        if [ -z "${TARGET_FROM_PR_TITLE}" ]; then
+          TARGET_FROM_PR_TITLE="main"
+        else
+          echo "Branch target overridden from PR title"
+        fi
+        [ "${TARGET}" = "${TARGET_FROM_PR_TITLE}" ] && exit 0
+
+        echo "Invalid branch target: ${TARGET} != ${TARGET_FROM_PR_TITLE}"
+        exit 1


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/incus/.github/workflows/commits.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).