### PR TITLE
Proposal: add `release.yml` skeleton

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,146 @@
+name: Release
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+  issues: write
+  id-token: write
+  attestations: write
+
+jobs:
+  version:
+    name: Format version
+    runs-on: ubuntu-latest
+    outputs:
+      display: ${{ steps.version.outputs.display }}
+      full: ${{ steps.version.outputs.full }}
+    steps:
+      - name: Format version
+        id: version
+        run: |
+          raw="${GITHUB_REF_NAME#v}"
+          IFS='.' read -r major minor patch <<< "$raw"
+          echo "full=${major}.${minor}.${patch}" >> $GITHUB_OUTPUT
+          if [ "${patch}" = "0" ]; then
+            echo "display=${major}.${minor}" >> $GITHUB_OUTPUT
+          else
+            echo "display=${major}.${minor}.${patch}" >> $GITHUB_OUTPUT
+          fi
+
+  build-msi:
+    name: Build Windows installer
+    runs-on: windows-latest
+    needs: version
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: stable
+
+      # Pinned to v5, the last release before WiX v6/v7 moved to the Open
+      # Source Maintenance Fee license requiring EULA acceptance.
+      - name: Install WiX
+        shell: pwsh
+        run: |
+          dotnet tool install --global wix --version 5.0.2
+          echo "$env:USERPROFILE\.dotnet\tools" | Out-File -FilePath $env:GITHUB_PATH -Append
+
+      - name: Add WiX extensions
+        shell: pwsh
+        run: wix extension add -g WixToolset.UI.wixext/5.0.2
+
+      - name: Build installers
+        shell: bash
+        env:
+          VERSION: ${{ needs.version.outputs.full }}
+        run: bash .github/packaging/windows/build.sh
+
+      - name: Upload installers
+        uses: actions/upload-artifact@v7
+        with:
+          name: installers-windows
+          path: installers/*.msi
+          if-no-files-found: error
+
+  build-pkg:
+    name: Build macOS installer
+    runs-on: macos-latest
+    needs: version
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: stable
+
+      - name: Build installer
+        env:
+          VERSION: ${{ needs.version.outputs.full }}
+        run: bash .github/packaging/macos/build.sh
+
+      - name: Upload installer
+        uses: actions/upload-artifact@v7
+        with:
+          name: installers-macos
+          path: installers/*.pkg
+          if-no-files-found: error
+
+  goreleaser:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [version, build-msi, build-pkg]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: stable
+
+      - name: Install syft
+        uses: anchore/sbom-action/download-syft@v0
+
+      - name: Download installers
+        uses: actions/download-artifact@v8
+        with:
+          pattern: installers-*
+          path: installers
+          merge-multiple: true
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INCUS_VERSION: ${{ needs.version.outputs.display }}
+
+      - name: Handle attestation
+        uses: actions/attest@v4
+        with:
+          subject-checksums: ./dist/checksums.txt
+
+      - name: Handle installer attestation
+        uses: actions/attest@v4
+        with:
+          subject-path: |
+            installers/*.msi
+            installers/*.pkg


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/incus/.github/workflows/release.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).