### PR TITLE
Proposal: add `prune.yaml` skeleton

### DIFF
--- a/.github/workflows/prune.yaml
+++ b/.github/workflows/prune.yaml
@@ -1,0 +1,22 @@
+name: Prune Old Container Images
+on:
+  schedule:
+    - cron: '36 10 * * *'  # TODO: set schedule for your project
+  push:
+    branches:
+      - latest
+jobs:
+  prune-container-registry:
+    runs-on: ubuntu-latest
+    environment: prune
+    steps:
+      - name: Prune
+        uses: vlaurin/action-ghcr-prune@v0.6.0
+        with:
+          token: ${{ secrets.THE_TOKEN }}
+          user: cmspam
+          container: ${REPO_NAME}
+          dry-run: false # Dry-run first, then change to `false`
+          keep-younger-than: 0 # days
+          keep-last: 0
+          prune-untagged: true


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/incus-docker/.github/workflows/prune.yaml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).