### PR TITLE
Proposal: add `distrobuilder.yml` skeleton

### DIFF
--- a/.github/workflows/distrobuilder.yml
+++ b/.github/workflows/distrobuilder.yml
@@ -1,0 +1,35 @@
+name: Build Incus Image
+run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
+on: [push]
+jobs:
+  Build-Incus-Image:
+    runs-on: ubuntu-latest
+    steps:
+      - run: sudo apt update && sudo apt install -y debootstrap rsync gpg squashfs-tools git
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21.5' 
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Check out distrobuilder code
+        uses: actions/checkout@master
+        with:
+          repository: ${GITHUB_OWNER}/distrobuilder
+          path: distrobuilder
+      - name: Build distrobuilder
+        run: cd distrobuilder && make
+      - name: Add distrobuilder to path  
+        run: echo "/home/runner/go/bin" >> $GITHUB_PATH
+      - name: Build Incus Image
+        run: |
+          cd ${{ github.workspace }}
+          pwd
+          sudo ./build.sh
+      - name: List files in the repository
+        run: |
+          ls ${{ github.workspace }}
+      - run: echo "🍏 This job's status is ${{ job.status }}."
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ubuntucloud
+          path: ${{ github.workspace }}/ubuntucloud/ 


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/incus-gha/.github/workflows/distrobuilder.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).