### PR TITLE
Proposal: add `chromiumos-stage3-build.yml` skeleton

### DIFF
--- a/.github/workflows/chromiumos-stage3-build.yml
+++ b/.github/workflows/chromiumos-stage3-build.yml
@@ -1,0 +1,76 @@
+```yaml
+name: Build ChromiumOS Stage3
+
+on:
+  schedule:
+    # Weekly on Sunday 02:00 UTC — picks up new ChromiumOS release branches
+    - cron: '0 2 * * 0'  # TODO: set schedule for your project
+  workflow_dispatch:
+    inputs:
+      board:
+        description: 'Board to build (leave empty to build all container-suitable boards)'
+        required: false
+        default: ''
+
+jobs:
+  # Determine which boards to build. Container-suitable boards are built by
+  # default (reven, arm64-generic). Hardware-specific boards require manual
+  # dispatch with an explicit board name.
+  matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      boards: ${{ steps.set.outputs.boards }}
+    steps:
+      - id: set
+        run: |
+          if [ -n "${{ github.event.inputs.board }}" ]; then
+            echo "boards=[\"${{ github.event.inputs.board }}\"]" >> "$GITHUB_OUTPUT"
+          else
+            echo 'boards=["reven","arm64-generic"]' >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    needs: matrix
+    runs-on: ${{ matrix.board == 'reven' && 'ubuntu-latest' || 'ubuntu-latest' }}
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        board: ${{ fromJson(needs.matrix.outputs.boards) }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install qemu-user-static (arm64 boards)
+        if: ${{ matrix.board != 'reven' }}
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y qemu-user-static
+
+      - name: Build stage3
+        working-directory: unified-image-server/chromiumos-stage3
+        run: |
+          script=$(cat << 'EOF'
+          #!/bin/bash
+          # Your build script content here
+          # Ensure to replace {board} with the actual board variable
+          if [ -n "${extra_pkgs}" ]; then
+            emerge-${{ matrix.board }} ${extra_pkgs}
+          fi
+          EOF
+          )
+          echo "$script" | sudo tee /build/${{ matrix.board }}/init
+          sudo ./build.sh --board "${{ matrix.board }}" --jobs 4 --output .
+        timeout-minutes: 480
+
+      - name: Upload release artifact
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ env.CHROMIUMOS_SHORT_VERSION }}-${{ github.run_id }}
+          name: ChromiumOS Stage3 ${{ env.CHROMIUMOS_SHORT_VERSION }}
+          files: unified-image-server/chromiumos-stage3/chromiumos-stage3-${{ matrix.board }}-*.tar.xz
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/incus-image-server/.github/workflows/chromiumos-stage3-build.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).