### PR TITLE
Proposal: add `server-ci.yml` skeleton

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -1,0 +1,162 @@
+name: Server CI
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - 'feature/**'
+      - 'hotfix/**'
+    paths:
+      - 'unified-image-server/server/**'
+  pull_request:
+    paths:
+      - 'unified-image-server/server/**'
+
+defaults:
+  run:
+    working-directory: unified-image-server/server
+
+jobs:
+  deps:
+    name: Dependencies
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:3.19
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.1
+        with:
+          access_token: ${{ github.token }}
+
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install OS Deps
+        run: |
+          apk update && apk add --update tar build-base libsodium-dev \
+            elixir nodejs npm git erlang-dialyzer
+
+      - name: Retrieve Cached Dependencies
+        uses: actions/cache@v5
+        id: mix-cache
+        with:
+          path: |
+            unified-image-server/server/deps
+            unified-image-server/server/_build
+            unified-image-server/server/priv/plts
+          key: ${{ runner.os }}-polar-${{ hashFiles('unified-image-server/server/mix.lock') }}
+
+      - name: Install Dependencies
+        if: steps.mix-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p priv/plts
+          mix local.rebar --force
+          mix local.hex --force
+          mix deps.get
+          mix deps.compile
+          MIX_ENV=test mix deps.compile
+          mix dialyzer --plt
+
+  static_code_analysis:
+    name: Static Code Analysis
+    needs: deps
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:3.19
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.1
+        with:
+          access_token: ${{ github.token }}
+
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install Dependencies
+        run: |
+          apk update && apk add --update tar build-base libsodium-dev \
+            elixir nodejs npm git erlang-dialyzer
+          mix local.rebar --force
+          mix local.hex --force
+          mix deps.get  # Ensure all dependencies are fetched including ecto_sql
+
+      - name: Retrieve Cached Dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            unified-image-server/server/deps
+            unified-image-server/server/_build
+            unified-image-server/server/priv/plts
+          key: ${{ runner.os }}-polar-${{ hashFiles('unified-image-server/server/mix.lock') }}
+
+      - name: Check Code Format
+        run: mix format --check-formatted
+
+      - name: Run Dialyzer
+        run: mix dialyzer --no-check --halt-exit-status
+
+  test:
+    name: Unit Tests
+    needs: deps
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:3.19
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.1
+        with:
+          access_token: ${{ github.token }}
+
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install Dependencies
+        run: |
+          apk update && apk add --update tar build-base libsodium-dev \
+            elixir nodejs npm git erlang-dialyzer
+          mix local.rebar --force
+          mix local.hex --force
+
+      - name: Retrieve Cached Dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            unified-image-server/server/deps
+            unified-image-server/server/_build
+            unified-image-server/server/priv/plts
+          key: ${{ runner.os }}-polar-${{ hashFiles('unified-image-server/server/mix.lock') }}
+
+      - name: Run Tests
+        run: mix test --trace --slowest 10
+        env:
+          POSTGRES_HOST: postgres
+          POSTGRES_USERNAME: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_PORT: ${{ job.services.postgres.ports[5432] }}
+          DEFAULT_CDN_HOST: some.domain.com
+          POLAR_CLOAK_KEY: ${{ secrets.POLAR_CLOAK_KEY }}
+          # Storage adapter: use local filesystem in CI — no S3 credentials needed
+          STORAGE_ADAPTER: local
+          STORAGE_BASE_PATH: /tmp/polar-test-storage


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/incus-image-server/.github/workflows/server-ci.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).