### PR TITLE
Proposal: add `daily.yml` skeleton

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,0 +1,56 @@
+name: Daily
+on:
+  schedule:
+  - cron: "0 0 * * *"  # TODO: set schedule for your project
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  api-tests:
+    name: IncusOS API tests
+    strategy:
+      fail-fast: false
+    timeout-minutes: 600
+    runs-on:
+      - self-hosted
+      - cpu-24
+      - mem-48G
+      - disk-250G
+      - arch-amd64
+      - image-debian-13
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Install dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          sudo apt-get install --yes \
+            linux-headers-$(uname -r)
+          sudo --preserve-env=DEBIAN_FRONTEND apt-get install --yes \
+            dosfstools \
+            gdisk \
+            genisoimage \
+            mtools \
+            zfsutils-linux
+
+      - name: Setup Incus
+        run: |
+          curl https://pkgs.zabbly.com/get/incus-daily | sudo sh
+          sudo chmod 666 /var/lib/incus/unix.socket
+          echo "initializing incus with zfs backend and 200MB loop device"
+          incus admin init --auto --storage-backend=zfs --storage-create-loop=200
+          echo "setting zfs sync to disabled for better performance in CI environment"
+          zfs set sync=disabled default
+
+      - name: Run API tests
+        run: |
+          ${REPO_NAME}d/tests/api-tests.py


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/incus-os/.github/workflows/daily.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).