### PR TITLE
Proposal: add `delete_test_reports.yml` skeleton

### DIFF
--- a/.github/workflows/delete_test_reports.yml
+++ b/.github/workflows/delete_test_reports.yml
@@ -1,0 +1,53 @@
+name: Delete playwright test reports
+on:
+    pull_request_target:
+        types:
+            - closed
+
+jobs:
+    delete_reports:
+        name: Delete Playwright Test Reports for PR ${{ github.event.number }}
+        runs-on: ubuntu-latest
+        env:
+            # Folder on gh-pages branch that contains all test reports for a PR
+            PR_REPORTS_DIR: reports/pr-${{ github.event.number }}
+        steps:
+            - uses: actions/checkout@main
+              with:
+                ref: gh-pages
+                token: ${{ secrets.GITHUB_TOKEN }}
+            - name: Set Git User
+              run: |
+                git config --global user.email "github-action@example.com"
+                git config --global user.name "GitHub Action"
+            - name: Check for workflow reports
+              id: has-reports
+              run: |
+                if [ -z "$(ls -A $PR_REPORTS_DIR)" ]; then
+                    echo "PR_REPORTS_EXISTS=false" >> $GITHUB_OUTPUT
+                else
+                    echo "PR_REPORTS_EXISTS=true" >> $GITHUB_OUTPUT
+                fi
+            - name: Delete reports from repo for PR ${{ github.event.number }}
+              if: ${{ steps.has-reports.outputs.PR_REPORTS_EXISTS == 'true' }}
+              timeout-minutes: 3
+              run: |
+                rm -rf reports/pr-${{ github.event.number }}
+                git add .
+                git commit -m "workflow: remove all reports for PR #${{ github.event.number }}"
+                
+                # In case if another action job pushed to gh-pages while we are rebasing for the current job
+                while true; do
+                    git pull --rebase
+                    if [ $? -ne 0 ]; then
+                        echo "Failed to rebase. Please review manually."
+                        exit 1
+                    fi
+        
+                    git push
+                    if [ $? -eq 0 ]; then
+                        echo "Successfully pushed HTML reports to repo."
+                        exit 0
+                    fi
+                done
+                


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/incus-ui-canonical/.github/workflows/delete_test_reports.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).