### PR TITLE
Proposal: add `pr.yaml` skeleton

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,210 @@
+name: PR checks
+on: pull_request
+
+permissions:
+  contents: read
+
+jobs:
+
+  commits:
+    permissions:
+      pull-requests: read   # to get list of commits from the PR
+    name: Canonical CLA signed and Signed-off-by (DCO)
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check if CLA signed
+      uses: canonical/has-signed-canonical-cla@v1
+    - name: Get PR Commits
+      id: 'get-pr-commits'
+      uses: tim-actions/get-pr-commits@master
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Check that all commits are signed-off
+      uses: tim-actions/dco@master
+      with:
+        commits: ${{ steps.get-pr-commits.outputs.commits }}
+        
+  lint-scss:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Lint scss
+        run: yarn lint-scss
+
+  lint-js:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install node dependencies
+        run: yarn install --immutable
+
+      - name: Lint JS
+        run: yarn lint-js
+
+  check-inclusive-naming:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check inclusive naming
+        uses: canonical/Inclusive-naming@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-review
+          fail-on-error: true
+
+  browser-e2e-test:
+    name: e2e-tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: ["chromium", "firefox"]
+    outputs:
+      job_status: ${{job.status}}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Dotrun
+        run: |
+          sudo pip3 install dotrun
+
+      - name: Restore cached keys
+        uses: actions/cache/restore@v3
+        with:
+          path: keys
+          key: keys-folder
+
+      - name: Install LXD-UI dependencies
+        run: |
+          set -x
+          sudo chmod 0777 ../lxd-ui
+          dotrun install
+
+      - name: Run LXD-UI
+        env:
+          ENVIRONMENT: devel
+          PORT: 8407
+          LXD_UI_BACKEND_IP: 172.17.0.1
+        run: |
+          dotrun &
+          curl --head --fail --retry-delay 2 --retry 100 --retry-connrefused --insecure https://localhost:8407
+
+      - name: Set keys permissions
+        run: |
+          set -x
+          sudo chmod -R 0666 keys
+          sudo chmod 0777 keys
+          
+      - name: Save keys
+        uses: actions/cache/save@v3
+        with:
+          path: keys
+          key: keys-folder
+
+      - name: Install LXD
+        uses: canonical/setup-lxd@v0.1.1
+        with:
+          channel: latest/edge
+
+      - name: Setup LXD
+        shell: bash
+        run: |
+          set -x
+          sudo lxc config set core.https_address "[::]:8443"
+          sudo lxc config trust add keys/lxd-ui.crt
+          sudo lxc config set cluster.https_address "127.0.0.1"
+          sudo lxc cluster enable local
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps ${{ matrix.browser }}
+
+      - name: Run Playwright tests
+        run: npx playwright test --project ${{ matrix.browser }}
+
+      - name: Rename Playwright report
+        run: mv blob-report/report.zip blob-report/${{ matrix.browser }}-report.zip
+
+      - name: Upload ${{ matrix.browser }} blob reports to be merged
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: blob-report-${{ matrix.browser }}
+          path: blob-report
+          retention-days: 1
+
+  merge-e2e-reports:
+    if: always()
+    needs: [browser-e2e-test]
+    env:
+      HTML_REPORT_URL_PATH: reports/pr-${{ github.event.number }}/${{ github.run_id }}/${{ github.run_attempt }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 18
+
+    - name: Download blob reports from GitHub Actions Artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: playwright-report
+        pattern: blob-report-*
+        merge-multiple: true
+    
+    # NOTE: there is no need to install playwright dependencies since we only need to merge reports here
+    - name: Merge into HTML Report
+      run: npx playwright merge-reports --reporter html ./playwright-report
+
+    - name: Save additional test information
+      if: always()
+      run: |
+        touch playwright-report/info.txt
+        echo "HTML_REPORT_URL_PATH:$HTML_REPORT_URL_PATH" >> playwright-report/info.txt
+        cat playwright-report/info.txt
+    
+    - uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 14
+
+    - name: Output Report URL as Worfklow Annotation
+      if: always()
+      run: |
+        FULL_HTML_REPORT_URL=https://canonical.github.io/lxd-ui/$HTML_REPORT_URL_PATH
+        echo "::notice title=Published Playwright Test Report::$FULL_HTML_REPORT_URL"
+        echo "Please wait a few minute for the reports to get published before accessing the url!"
+
+  js-tests:
+    name: js-tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Dotrun
+        run: |
+          sudo pip3 install dotrun
+
+      - name: Install LXD-UI dependencies
+        run: |
+          set -x
+          sudo chmod 0777 ../lxd-ui
+          dotrun install
+
+      - name: Run Javascript tests
+        run: dotrun test-js


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/incus-ui-canonical/.github/workflows/pr.yaml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).