### PR TITLE
Proposal: add `publish_test_reports.yml` skeleton

### DIFF
--- a/.github/workflows/publish_test_reports.yml
+++ b/.github/workflows/publish_test_reports.yml
@@ -1,0 +1,79 @@
+name: Publish playwright test reports
+on:
+    workflow_run:
+        workflows: [PR checks]
+        types: [completed]
+
+jobs:
+    publish_report:
+        name: publish-e2e-report
+        runs-on: ubuntu-latest
+        continue-on-error: true
+        steps:
+          - uses: actions/checkout@v4
+            with:
+              ref: gh-pages
+              token: ${{ secrets.GITHUB_TOKEN }}
+          - name: Download test report artifact
+            uses: actions/github-script@v6
+            with:
+                script: |
+                    let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        run_id: context.payload.workflow_run.id,
+                    });
+                    let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+                        return artifact.name == "playwright-report"
+                    })[0];
+                    let download = await github.rest.actions.downloadArtifact({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        artifact_id: matchArtifact.id,
+                        archive_format: 'zip',
+                    });
+                    let fs = require('fs');
+                    fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/playwright-report.zip`, Buffer.from(download.data));
+          - name: Unzip artifact and cleanup
+            run: |
+                mkdir tmp
+                unzip playwright-report.zip -d tmp
+
+                # Extract parent workflow info from info.txt in artifact
+                HTML_REPORT_URL_PATH=$(grep "HTML_REPORT_URL_PATH:" tmp/info.txt | sed 's/HTML_REPORT_URL_PATH://g')
+                echo "HTML_REPORT_URL_PATH=$HTML_REPORT_URL_PATH" >> "$GITHUB_ENV"
+                
+                mkdir -p $HTML_REPORT_URL_PATH
+                mv -f tmp/* $HTML_REPORT_URL_PATH
+                rm -rf playwright-report.zip
+                rm -rf tmp
+          # user git configs are needed for git commands to work
+          # actual authentication is done using secrets.GITHUB_TOKEN with write permission
+          - name: Set Git User
+            run: |
+              git config --global user.email "github-action@example.com"
+              git config --global user.name "GitHub Action"
+          - name: Push ${REPO_NAME} Report
+            timeout-minutes: 3
+            run: |
+              git add .
+              git commit -m "workflow: add HTML report published at $HTML_REPORT_URL_PATH"
+              
+              # In case if another action job pushed to gh-pages while we are rebasing for the current job
+              while true; do
+                git pull --rebase
+                if [ $? -ne 0 ]; then
+                  echo "Failed to rebase. Please review manually."
+                  exit 1
+                fi
+    
+                git push
+                if [ $? -eq 0 ]; then
+                  echo "Successfully pushed HTML report to repo."
+                  exit 0
+                fi
+              done
+          - name: Output Report URL as Worfklow Annotation
+            run: |
+              FULL_HTML_REPORT_URL=https://canonical.github.io/lxd-ui/$HTML_REPORT_URL_PATH
+              echo "::notice title=Published Playwright Test Report::$FULL_HTML_REPORT_URL"


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/incus-ui-canonical/.github/workflows/publish_test_reports.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).