### PR TITLE
Proposal: add `update_demo.yml` skeleton

### DIFF
--- a/.github/workflows/update_demo.yml
+++ b/.github/workflows/update_demo.yml
@@ -1,0 +1,24 @@
+name: Demo update
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  updateBranch:
+    name: Update demo branch
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == '${GITHUB_OWNER}' }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: demo
+    - name: Fetch rebase and push
+      if: github.ref == 'refs/heads/main'
+      run: |
+        git config --global user.email "github-action@example.com"
+        git config --global user.name "GitHub Action"
+        git fetch origin main --depth 1
+        git checkout demo
+        git rebase -X ours origin/main # in rebase ours is the incoming branch
+        git push --force


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/incus-ui-canonical/.github/workflows/update_demo.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).