### PR TITLE
Proposal: add `integration.yml` skeleton

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,116 @@
+name: Integration
+
+on:
+  push:
+    branches: ["main", "feat/**", "fix/**", "chore/**"]
+    paths:
+      - "vendor/penguins-eggs"
+      - "src/waydroid_toolkit/utils/android_shared.py"
+      - "src/waydroid_toolkit/modules/builder/**"
+      - "tests/unit/test_android_shared.py"
+      - "tests/unit/test_builder.py"
+      - ".github/workflows/integration.yml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "vendor/penguins-eggs"
+      - "src/waydroid_toolkit/utils/android_shared.py"
+      - "src/waydroid_toolkit/modules/builder/**"
+      - "tests/unit/test_android_shared.py"
+      - "tests/unit/test_builder.py"
+      - ".github/workflows/integration.yml"
+
+jobs:
+  # ── Verify transpiled Python matches the .fu source ───────────────────────
+  verify-transpile:
+    name: Verify android_shared.py is up to date
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - name: Install fut
+        run: |
+          curl -sL https://github.com/fusionlanguage/fut/releases/download/fut-3.2.14/fut_3.2.14-1_amd64.deb \
+            -o /tmp/fut.deb
+          sudo dpkg -i /tmp/fut.deb
+
+      - name: Regenerate android-shared.py from .fu source
+        run: |
+          cd vendor/penguins-eggs/shared
+          fut -l py -o android-shared.regen.py android-shared.fu
+
+      - name: Diff regenerated vs committed android_shared.py
+        run: |
+          diff \
+            vendor/penguins-eggs/shared/android-shared.regen.py \
+            src/waydroid_toolkit/utils/android_shared.py \
+            || (echo "android_shared.py is out of sync with android-shared.fu." \
+                "Run: cd vendor/penguins-eggs/shared && make && cp android-shared.py" \
+                "../../../src/waydroid_toolkit/utils/android_shared.py" && exit 1)
+
+  # ── waydroid-toolkit unit tests ───────────────────────────────────────────
+  test-waydroid-toolkit:
+    name: waydroid-toolkit tests (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    needs: verify-transpile
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run android_shared + builder tests
+        run: |
+          pytest tests/unit/test_android_shared.py tests/unit/test_builder.py \
+            -v --tb=short
+
+      - name: Run full test suite
+        run: pytest tests/unit/ -v --tb=short
+
+  # ── penguins-eggs shared/ sanity check ───────────────────────────────────
+  test-penguins-eggs-shared:
+    name: penguins-eggs shared/ (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    needs: verify-transpile
+    strategy:
+      matrix:
+        node-version: ["22"]
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install shared/ dev dependencies
+        run: |
+          cd vendor/penguins-eggs/shared
+          npm install
+
+      - name: Type-check shared/ (android-shared.ts + manifest-writer.ts)
+        run: |
+          cd vendor/penguins-eggs/shared
+          npx tsc --project tsconfig.json


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/incus-waydroid-toolkit/.github/workflows/integration.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).