### PR TITLE
Proposal: add `ci.yml` skeleton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,154 @@
+name: CI
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+
+jobs:
+  rust:
+    name: Rust engine
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Install protobuf compiler
+        run: sudo apt-get install -y protobuf-compiler
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            engine/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('engine/Cargo.lock') }}
+
+      - name: Check formatting
+        working-directory: engine
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        working-directory: engine
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Build
+        working-directory: engine
+        run: cargo build --all
+
+      - name: Test
+        working-directory: engine
+        run: cargo test --all
+
+  go:
+    name: Go CLI
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+          cache-dependency-path: client/cli/go.sum
+
+      - name: Build
+        working-directory: client/cli
+        run: go build ./...
+
+      - name: Vet
+        working-directory: client/cli
+        run: go vet ./...
+
+      - name: Test
+        working-directory: client/cli
+        run: go test ./...
+
+  python:
+    name: Python server
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Lint
+        run: |
+          pip install ruff
+          ruff check server/
+
+      - name: Type check
+        run: |
+          pip install mypy
+          mypy server/nebraska/nebraska.py server/omaha/android.py server/hawkbit/server.py \
+            --ignore-missing-imports
+
+      - name: Test Nebraska server
+        run: |
+          python3 -c "
+          import sys
+          sys.path.insert(0, 'server/nebraska')
+          from nebraska import PackageRegistry, parse_omaha_request, build_omaha_response
+          # Smoke test: parse a minimal Omaha request
+          xml = b'<?xml version=\"1.0\"?><request protocol=\"3.0\"><app id=\"linux\" version=\"1.0\" track=\"stable\" arch=\"amd64\"><updatecheck /></app></request>'
+          req = parse_omaha_request(xml)
+          assert req['apps'][0]['appid'] == 'linux'
+          print('Nebraska smoke test passed')
+          "
+
+  shellcheck:
+    name: Shell scripts
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install shellcheck
+        run: sudo apt-get install -y shellcheck
+
+      - name: Check runtime scripts
+        run: |
+          find runtime/ client/hooks/ packaging/ -name '*.sh' \
+            | xargs shellcheck --severity=warning
+
+  android-scripts:
+    name: Android runtime scripts
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install shellcheck
+        run: sudo apt-get install -y shellcheck
+
+      - name: Check Android scripts
+        run: |
+          find runtime/android/ -name '*.sh' \
+            | xargs shellcheck --severity=warning
+
+  bundle-test:
+    name: Bundle creation smoke test
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create test payload
+        run: |
+          dd if=/dev/urandom of=/tmp/test-payload bs=1M count=1
+          chmod +x packaging/bundle/bundle.sh
+
+      - name: Create and verify bundle
+        run: |
+          packaging/bundle/bundle.sh create \
+            --version 0.0.1-test \
+            --arch amd64 \
+            --payload /tmp/test-payload \
+            --output /tmp/test-bundle
+          packaging/bundle/bundle.sh verify \
+            --bundle /tmp/test-bundle/bundle-0.0.1-test-amd64.lota
+          packaging/bundle/bundle.sh inspect \
+            --bundle /tmp/test-bundle/bundle-0.0.1-test-amd64.lota


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/linux-over-the-air/.github/workflows/ci.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).