### PR TITLE
Proposal: add `watch-upstream.yml` skeleton

### DIFF
--- a/.github/workflows/watch-upstream.yml
+++ b/.github/workflows/watch-upstream.yml
@@ -1,0 +1,133 @@
+name: Watch upstream
+
+# Runs daily. Checks damentz/liquorix-package for new kernel branches.
+# When a new branch is found that we haven't released yet, opens a PR
+# to update a VERSION file and trigger the release pipeline.
+on:
+  schedule:
+    - cron: "0 6 * * *" # 06:00 UTC daily  # TODO: set schedule for your project
+  workflow_dispatch: # allow manual trigger
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check:
+    name: Check for new upstream release
+    runs-on: ubuntu-latest
+    # Only run in the canonical source repo — skip in mirrors
+    if: github.repository == 'OSPF1896/${REPO_NAME}'
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+        with:
+          fetch-depth: 0
+
+      - name: Get latest upstream branch
+        id: upstream
+        run: |
+          # Branch names are like "6.19/master" — parse changelog for exact version
+          BRANCH=$(git ls-remote --heads \
+              https://github.com/damentz/liquorix-package \
+            | grep -oP '\d+\.\d+/master' \
+            | sort -V | tail -1)
+
+          if [[ -z "$BRANCH" ]]; then
+            echo "Could not determine upstream branch"
+            echo "latest=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          MAJOR="${BRANCH%/master}"
+
+          # Parse changelog: "linux-liquorix (6.19-5) unstable" -> 6.19.10-lqx5
+          CHANGELOG=$(curl -fsSL \
+            "https://raw.githubusercontent.com/damentz/liquorix-package/${BRANCH}/linux-liquorix/debian/changelog")
+
+          # Get package version (e.g. 6.19-5) and kernel version from merge commit
+          PKG_VER=$(echo "$CHANGELOG" | grep -oP '^\S+ \(\K[\d.]+-\d+(?=\))' | head -1)
+          LQX_REL=$(echo "$PKG_VER" | grep -oP '\d+$')
+          KERNEL_VER=$(echo "$CHANGELOG" | grep -oP 'merge v\K[\d.]+' | head -1)
+
+          if [[ -z "$KERNEL_VER" ]]; then
+            KERNEL_VER="${MAJOR}.0"
+          fi
+
+          LATEST="${KERNEL_VER}-lqx${LQX_REL}"
+          echo "latest=${LATEST}" >> "$GITHUB_OUTPUT"
+          echo "Latest upstream version: ${LATEST}"
+
+      - name: Get current version
+        id: current
+        run: |
+          CURRENT=""
+          if [[ -f VERSION ]]; then
+            CURRENT=$(cat VERSION)
+          fi
+          echo "current=${CURRENT}" >> "$GITHUB_OUTPUT"
+          echo "Current version: ${CURRENT}"
+
+      - name: Check if update needed
+        id: check
+        run: |
+          LATEST="${{ steps.upstream.outputs.latest }}"
+          CURRENT="${{ steps.current.outputs.current }}"
+
+          if [[ -z "$LATEST" ]]; then
+            echo "Could not determine upstream version, skipping"
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "$LATEST" == "$CURRENT" ]]; then
+            echo "Already at latest version ${CURRENT}"
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Update available: ${CURRENT} -> ${LATEST}"
+            echo "needed=true"  >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Ensure upstream-update label exists
+        if: steps.check.outputs.needed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create "upstream-update" \
+            --description "Automated upstream version bump" \
+            --color "0075ca" 2>/dev/null || true
+
+      - name: Create update branch and PR
+        if: steps.check.outputs.needed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LATEST="${{ steps.upstream.outputs.latest }}"
+          BRANCH="update/liquorix-${LATEST}"
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Create branch
+          git checkout -b "$BRANCH"
+
+          # Update VERSION file
+          echo "$LATEST" > VERSION
+          git add VERSION
+          git commit -m "Update to Liquorix ${LATEST}"
+          
+          # Pull latest changes to avoid non-fast-forward error with rebase
+          git pull --rebase origin main || true
+          
+          # Force push to handle non-fast-forward errors
+          git push --force origin "$BRANCH"
+
+          # Open PR
+          gh pr create \
+            --title "Update to Liquorix ${LATEST}" \
+            --body "$(printf 'Upstream damentz/liquorix-package has a new release: `%s`.\n\nThis PR updates the VERSION file. Once merged, tag the commit to trigger the release pipeline:\n\n```bash\ngit tag v%s\ngit push origin v%s\n```' "${LATEST}" "${LATEST}" "${LATEST}")" \
+            --base main \
+            --head "$BRANCH" \
+            --label "upstream-update" || true


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/liquorix-unified-kernel/.github/workflows/watch-upstream.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).