### PR TITLE
Proposal: add `ci-2005.yml` skeleton

### DIFF
--- a/.github/workflows/ci-2005.yml
+++ b/.github/workflows/ci-2005.yml
@@ -1,0 +1,36 @@
+name: 105-vagrant-arch-linux
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Setup Brain Profile
+      run: |
+        echo "Setting up Brain Profile configuration..."
+        mkdir -p ~/.config/coa
+        echo "brain_profile_configuration_content" > ~/.config/coa/brain_profile.yaml
+        # Ensure the Brain Profile is correctly set up before running tests
+        if [ ! -f ~/.config/coa/brain_profile.yaml ]; then
+          echo "Brain Profile configuration file not found!"
+          exit 1
+        fi
+
+    - name: run build and test
+      run: |
+        if [ ! -f ~/.config/coa/brain_profile.yaml ]; then
+          echo "Brain Profile configuration file not found before running tests!"
+          exit 1
+        fi
+        vagrant ssh -c 'sudo /vagrant/coa remaster --mode clone'
+        ./tests/105-vagrant-arch-linux/vagrant.install.build.test.sh


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/oa-tools/.github/workflows/ci-2005.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).