### PR TITLE
Proposal: add `mirror-orgs.yml` skeleton

### DIFF
--- a/.github/workflows/mirror-orgs.yml
+++ b/.github/workflows/mirror-orgs.yml
@@ -1,0 +1,24 @@
+name: Mirror OSP → OOC
+
+on:
+  schedule:
+    - cron: '30 1 * * *' # Daily at 01:30 UTC  # TODO: set schedule for your project
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Mirror all repos from OSP to OOC
+        env:
+          MIRROR_TOKEN: ${{ secrets.MIRROR_TOKEN }}
+          SOURCE_ORG: ${OSP_ORG}
+          TARGET_ORG: ${OOC_ORG}
+        run: bash scripts/mirror-orgs.sh


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/org-mirror/.github/workflows/mirror-orgs.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).