### PR TITLE
Proposal: add `watchdog.yml` skeleton

### DIFF
--- a/.github/workflows/watchdog.yml
+++ b/.github/workflows/watchdog.yml
@@ -1,0 +1,41 @@
+name: Mirror Watchdog
+
+# Triggers when the main mirror workflow fails.
+# Waits 5 minutes (to allow transient GitHub API issues to clear) then
+# retries once. If the retry also fails, the failure surfaces normally
+# in the Actions tab and inbox.
+
+on:
+  workflow_run:
+    workflows: ["Mirror OSP → OOC"]
+      # TODO: list the workflow names that should trigger this
+    types: [completed]
+
+permissions:
+  actions: write   # needed to re-trigger workflows
+  contents: read
+  workflows: write # added permission to trigger workflows
+
+jobs:
+  retry:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'failure'
+    steps:
+      - name: Log failure context
+        run: |
+          echo "Mirror workflow failed:"
+          echo "  Run ID  : ${{ github.event.workflow_run.id }}"
+          echo "  Branch  : ${{ github.event.workflow_run.head_branch }}"
+          echo "  Started : ${{ github.event.workflow_run.created_at }}"
+
+      - name: Wait before retry
+        run: sleep 300   # 5 minutes
+
+      - name: Retry mirror
+        env:
+          GITHUB_TOKEN: ${{ secrets.MIRROR_TOKEN }} # Changed from GH_TOKEN to GITHUB_TOKEN
+        run: |
+          gh workflow run mirror-orgs.yml \
+            --repo ${OSP_ORG}/${REPO_NAME} \
+            --ref main
+          echo "Retry triggered."


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/org-mirror/.github/workflows/watchdog.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).