### PR TITLE
Proposal: add `build_plugin_binaries.yml` skeleton

### DIFF
--- a/.github/workflows/build_plugin_binaries.yml
+++ b/.github/workflows/build_plugin_binaries.yml
@@ -1,0 +1,146 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+name: hashicorp/${REPO_NAME}/build_plugin_binaries
+permissions:
+  contents: read
+on:
+  push:
+    branches:
+    - main
+jobs:
+  build_darwin:
+    defaults:
+      run:
+        working-directory: ~/go/src/github.com/hashicorp/${REPO_NAME}
+    runs-on: ubuntu-latest
+    container:
+      image: docker.mirror.hashicorp.services/cimg/go:1.20
+    steps:
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+    - uses: "./.github/actions/build-and-persist-plugin-binary"
+      with:
+        GOOS: darwin
+        GOARCH: amd64
+    - uses: "./.github/actions/build-and-persist-plugin-binary"
+      with:
+        GOOS: darwin
+        GOARCH: arm64
+  build_freebsd:
+    defaults:
+      run:
+        working-directory: ~/go/src/github.com/hashicorp/${REPO_NAME}
+    runs-on: ubuntu-latest
+    container:
+      image: docker.mirror.hashicorp.services/cimg/go:1.20
+    steps:
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+    - uses: "./.github/actions/build-and-persist-plugin-binary"
+      with:
+        GOOS: freebsd
+        GOARCH: 386
+    - uses: "./.github/actions/build-and-persist-plugin-binary"
+      with:
+        GOOS: freebsd
+        GOARCH: amd64
+    - uses: "./.github/actions/build-and-persist-plugin-binary"
+      with:
+        GOOS: freebsd
+        GOARCH: arm
+  build_linux:
+    defaults:
+      run:
+        working-directory: ~/go/src/github.com/hashicorp/${REPO_NAME}
+    runs-on: ubuntu-latest
+    container:
+      image: docker.mirror.hashicorp.services/cimg/go:1.20
+    steps:
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+    - uses: "./.github/actions/build-and-persist-plugin-binary"
+      with:
+        GOOS: linux
+        GOARCH: 386
+    - uses: "./.github/actions/build-and-persist-plugin-binary"
+      with:
+        GOOS: linux
+        GOARCH: amd64
+    - uses: "./.github/actions/build-and-persist-plugin-binary"
+      with:
+        GOOS: linux
+        GOARCH: arm
+    - uses: "./.github/actions/build-and-persist-plugin-binary"
+      with:
+        GOOS: linux
+        GOARCH: arm64
+  build_netbsd:
+    defaults:
+      run:
+        working-directory: ~/go/src/github.com/hashicorp/${REPO_NAME}
+    runs-on: ubuntu-latest
+    container:
+      image: docker.mirror.hashicorp.services/cimg/go:1.20
+    steps:
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+    - uses: "./.github/actions/build-and-persist-plugin-binary"
+      with:
+        GOOS: netbsd
+        GOARCH: 386
+    - uses: "./.github/actions/build-and-persist-plugin-binary"
+      with:
+        GOOS: netbsd
+        GOARCH: amd64
+    - uses: "./.github/actions/build-and-persist-plugin-binary"
+      with:
+        GOOS: netbsd
+        GOARCH: arm
+  build_openbsd:
+    defaults:
+      run:
+        working-directory: ~/go/src/github.com/hashicorp/${REPO_NAME}
+    runs-on: ubuntu-latest
+    container:
+      image: docker.mirror.hashicorp.services/cimg/go:1.20
+    steps:
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+    - uses: "./.github/actions/build-and-persist-plugin-binary"
+      with:
+        GOOS: openbsd
+        GOARCH: 386
+    - uses: "./.github/actions/build-and-persist-plugin-binary"
+      with:
+        GOOS: openbsd
+        GOARCH: amd64
+    - uses: "./.github/actions/build-and-persist-plugin-binary"
+      with:
+        GOOS: openbsd
+        GOARCH: arm
+  build_solaris:
+    defaults:
+      run:
+        working-directory: ~/go/src/github.com/hashicorp/${REPO_NAME}
+    runs-on: ubuntu-latest
+    container:
+      image: docker.mirror.hashicorp.services/cimg/go:1.20
+    steps:
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+    - uses: "./.github/actions/build-and-persist-plugin-binary"
+      with:
+        GOOS: solaris
+        GOARCH: amd64
+  build_windows:
+    defaults:
+      run:
+        working-directory: ~/go/src/github.com/hashicorp/${REPO_NAME}
+    runs-on: ubuntu-latest
+    container:
+      image: docker.mirror.hashicorp.services/cimg/go:1.20
+    steps:
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+    - uses: "./.github/actions/build-and-persist-plugin-binary"
+      with:
+        GOOS: windows
+        GOARCH: 386
+    - uses: "./.github/actions/build-and-persist-plugin-binary"
+      with:
+        GOOS: windows
+        GOARCH: amd64


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/packer-plugin-incus/.github/workflows/build_plugin_binaries.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).