### PR TITLE
Proposal: add `0-build-publish-packages.yaml` skeleton

### DIFF
--- a/.github/workflows/0-build-publish-packages.yaml
+++ b/.github/workflows/0-build-publish-packages.yaml
@@ -1,0 +1,717 @@
+# ========================================================
+# NOME: 0-build-publish-packages
+# ========================================================
+name: 0-build-publish-packages
+env:
+  BOOTLOADERS_VERSION: v26.1.16
+on:
+  workflow_dispatch:
+
+jobs:
+  # ========================================================
+  # 1.1 - 1.7: JOB DI BUILD
+  # runs-on: ubuntu-latest (runner standard di GitHub)
+  # ========================================================
+
+    # ========================================================
+    # build-alpine
+    # ========================================================
+    build-alpine: 
+      runs-on: ubuntu-latest # Runner GitHub
+      container:
+        image: alpine:latest
+      steps:
+      - name: 1. Checkout ${REPO_NAME} code
+        uses: actions/checkout@v4
+
+      - name: 2. Prepare Build Environment
+        run: |
+          apk update
+          apk add alpine-sdk git nodejs npm sudo device-mapper jq
+
+      - name: 3. Install PNPM
+        run: npm install -g pnpm
+
+      - name: 4. Create Build User, Keys, and Fix Environment
+        run: |
+          ln -s /usr/lib/libdevmapper.so.1.02 /usr/lib/libdevmapper.so.1.02.1
+          ln -s /lib/ld-musl-x86_64.so.1 /lib/libdl.so.2
+          adduser -D builder
+          addgroup builder abuild
+          echo | sudo -u builder abuild-keygen -a
+          cp /home/builder/.abuild/*.pub /etc/apk/keys/
+          chown -R builder:builder "$GITHUB_WORKSPACE"
+      
+      - name: 5. Update APKBUILD version and release
+        run: |
+          VERSION=$(jq -r .version package.json)
+          RELEASE_NUM=$(cat release | tr -d '[:space:]')
+          echo "Building version: $VERSION, release: $RELEASE_NUM"
+          sed -i "s/^pkgver=.*/pkgver=$VERSION/" ./packaging/alpine/APKBUILD
+          sed -i "s/^pkgrel=.*/pkgrel=$RELEASE_NUM/" ./packaging/alpine/APKBUILD
+      
+      - name: 6. Build The Package as Non-Root User
+        run: |
+          sudo -u builder abuild checksum
+          sudo -u builder abuild -r
+        working-directory: ./packaging/alpine
+      - name: 7. Upload Package Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: alpine-package
+          path: /home/builder/packages/**/*.apk
+    # END build-alpine 
+
+
+  # ========================================================
+  # build-arch
+  # ========================================================
+    build-arch:
+      runs-on: ubuntu-latest # Runner GitHub
+      container:
+        image: archlinux
+      steps:
+      - name: 1. Checkout ${REPO_NAME} code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0       # Scarica tutta la cronologia (necessario per calcolare versioni/checksum)
+          fetch-tags: true     # Assicura che i tag vengano scaricati
+
+      - name: 2. Prepare Build Environment
+        run: |
+          pacman -Syu --noconfirm
+          pacman -S --noconfirm base-devel git pnpm jq pacman-contrib gnupg
+      
+      - name: 2a. Update PKGBUILD
+        run: |
+          VERSION=$(jq -r .version package.json)
+          RELEASE_NUM=$(cat release | tr -d '[:space:]')
+          echo "Updating PKGBUILD to $VERSION-$RELEASE_NUM"
+          sed -i "s/^pkgver=.*/pkgver=$VERSION/" ./packaging/arch/PKGBUILD
+          sed -i "s/^pkgrel=.*/pkgrel=$RELEASE_NUM/" ./packaging/arch/PKGBUILD
+          sed -i "s|https://github.com/pieroproietti/${REPO_NAME}.git|file://${GITHUB_WORKSPACE}|" ./packaging/arch/PKGBUILD
+      
+      - name: 3. Create Build User
+        run: |
+          useradd -m builder
+          echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+          chown -R builder:builder "$GITHUB_WORKSPACE"
+
+      - name: 4. Import GPG Key and Prime Agent (for builder)
+        run: |
+          echo "${{ secrets.GPG_SIGNING_KEY }}" | sudo -u builder gpg --import --batch
+          sudo -u builder bash -c 'mkdir -p ~/.gnupg'
+          sudo -u builder bash -c 'echo "pinentry-mode loopback" > ~/.gnupg/gpg.conf'
+          sudo -u builder bash -c 'echo "allow-loopback-pinentry" > ~/.gnupg/gpg-agent.conf'
+          sudo -u builder gpg-connect-agent reloadagent /bye
+          echo "${{ secrets.GPG_PASSPHRASE }}" | sudo -u builder gpg --batch --yes --passphrase-fd 0 -o /dev/null -s /dev/null
+      
+      - name: 5. Update Checksums and Build Package
+        run: |
+          sudo -u builder GPGKEY=${{ secrets.GPG_KEY_ID }} bash -c "cd ./packaging/arch && updpkgsums && makepkg -s -f --noconfirm"
+      
+      - name: 6. Upload Arch Package Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: arch-packages
+          path: |
+            ./packaging/arch/*.pkg.tar.zst
+            ./packaging/arch/*.pkg.tar.zst.sig
+    # END build-arch
+
+
+  # ========================================================
+  # build-debian
+  # ========================================================
+    build-debian:
+      runs-on: ubuntu-latest # Runner GitHub
+      container:
+        image: debian:13
+      steps:
+      - name: 1. Checkout ${REPO_NAME} code
+        uses: actions/checkout@v4
+      - name: 2. Install Debian Build Dependencies
+        run: |
+          apt-get update
+          apt-get install -y curl gpg git build-essential dpkg-dev fakeroot gnupg2 apt-utils xz-utils sudo
+          mkdir -p /etc/apt/keyrings
+          curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+          echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+          apt-get update
+          apt-get install -y nodejs
+          npm install -g pnpm
+      - name: 3. Import GPG Key and Prime Agent
+        run: |
+          echo "${{ secrets.GPG_SIGNING_KEY }}" | gpg --import --batch
+          mkdir -p ~/.gnupg
+          echo "pinentry-mode loopback" > ~/.gnupg/gpg.conf
+          echo "allow-loopback-pinentry" > ~/.gnupg/gpg-agent.conf
+          gpg-connect-agent reloadagent /bye
+          echo "${{ secrets.GPG_PASSPHRASE }}" | gpg --batch --yes --passphrase-fd 0 -o /dev/null -s /dev/null
+      - name: 4. Build .deb packages for all architectures
+        run: |
+          export GPG_TTY=$(tty)
+          pnpm install
+          pnpm deb -a
+      - name: 5. Upload Debian Package Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: debian-packages
+          path: |
+            releases/*.deb
+            releases/*.sha256
+          retention-days: 1
+    # END build-debian
+
+  # ========================================================
+  # build-el9
+  # ========================================================
+    build-el9:
+      runs-on: ubuntu-latest # Runner GitHub
+      container:
+        image: almalinux:9
+      steps:
+      - name: 0. Install Prerequisite Tools
+        run: |
+          dnf install -y --allowerasing git tar gzip
+      - name: 1. Checkout ${REPO_NAME} code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: 2. Install Build Dependencies (with jq)
+        run: |
+          dnf install -y --allowerasing 'dnf-plugins-core' rpm-build curl gnupg2 rpm-sign jq
+          dnf install -y epel-release
+          /usr/bin/crb enable
+          dnf module enable nodejs:22 -y
+          dnf install -y nodejs npm
+          npm install -g pnpm
+          echo "Installing RPM build dependencies from spec file..."
+          for package in $(grep '^BuildRequires:' packaging/rpm/${REPO_NAME}.spec | grep -v 'pnpm' | awk '{print $2}'); do
+            echo "Installing $package..."
+            dnf install -y --allowerasing "$package"
+          done
+
+      - name: 3. Get Package Version from package.json
+        id: version
+        run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
+      
+      - name: 4. Get Package Release from 'release' file
+        id: release
+        run: echo "release_num=$(cat release | tr -d '[:space:]')" >> $GITHUB_OUTPUT
+
+      - name: 5. Update Version and Release in .spec File
+        run: |
+          echo "Updating .spec file to version ${{ steps.version.outputs.version }} and release ${{ steps.release.outputs.release_num }}"
+          sed -i "s/^\(Version: *\).*/\1${{ steps.version.outputs.version }}/" packaging/rpm/${REPO_NAME}.spec
+          sed -i "s/^\(Release: *\).*/\1${{ steps.release.outputs.release_num }}%{?dist}/" packaging/rpm/${REPO_NAME}.spec
+      
+      - name: 6. Import GPG Key and Configure RPM
+        run: |
+          echo "${{ secrets.GPG_SIGNING_KEY }}" | gpg --import --batch
+          echo '%_signature gpg' > ~/.rpmmacros
+          echo '%_gpg_name ${{ secrets.GPG_KEY_ID }}' >> ~/.rpmmacros
+
+      - name: 7. Prepare RPM Sources
+        run: |
+          mkdir -p $HOME/rpmbuild/SOURCES
+          tar -czf $HOME/rpmbuild/SOURCES/${REPO_NAME}.tar.gz \
+            --transform='s,^\.,${REPO_NAME}-${{ steps.version.outputs.version }},' \
+            --exclude=.git --exclude=.github .
+          curl -LO https://github.com/pieroproietti/penguins-bootloaders/releases/download/${{ env.BOOTLOADERS_VERSION }}/bootloaders.tar.gz
+          cp bootloaders.tar.gz $HOME/rpmbuild/SOURCES/
+
+      - name: 8. Build and Sign RPM package
+        id: build
+        run: |
+          mkdir -p ~/.gnupg
+          echo "pinentry-mode loopback" > ~/.gnupg/gpg.conf
+          echo "allow-loopback-pinentry" > ~/.gnupg/gpg-agent.conf
+          gpg-connect-agent reloadagent /bye
+          echo "${{ secrets.GPG_PASSPHRASE }}" | gpg --batch --yes --passphrase-fd 0 -o /dev/null -s /dev/null
+          rpmbuild -ba packaging/rpm/${REPO_NAME}.spec
+          rpmsign --addsign $(find $HOME/rpmbuild/RPMS -name '*.rpm')
+          echo "rpm_path=$(find $HOME/rpmbuild/RPMS -name '*.rpm')" >> $GITHUB_OUTPUT
+
+      - name: 9. Upload RPM Artifact for publishing
+        uses: actions/upload-artifact@v4
+        with:
+          name: el9-rpm-for-repo
+          path: ${{ steps.build.outputs.rpm_path }}
+    # END build-el9
+
+  # ========================================================
+  # build-fc42
+  # ========================================================
+    build-fc42:
+      runs-on: ubuntu-latest # Runner GitHub
+      container:
+        image: fedora:42
+      steps:
+      - name: 1. Checkout ${REPO_NAME} code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: 2. Install Build Dependencies (with jq)
+        run: |
+          dnf install -y 'dnf-plugins-core' rpm-build git tar gzip curl gnupg2 rpmsign jq
+          for package in $(grep '^BuildRequires:' packaging/rpm/${REPO_NAME}.spec | awk '{print $2}'); do
+            dnf install -y "$package"
+          done
+      - name: 3. Get Package Version from package.json
+        id: version
+        run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
+      
+      - name: 3a. Get Package Release from 'release' file
+        id: release
+        run: echo "release_num=$(cat release | tr -d '[:space:]')" >> $GITHUB_OUTPUT
+
+      - name: 4. Update Version and Release in .spec File
+        run: |
+          echo "Updating .spec file to version ${{ steps.version.outputs.version }} and release ${{ steps.release.outputs.release_num }}"
+          sed -i "s/^\(Version: *\).*/\1${{ steps.version.outputs.version }}/" packaging/rpm/${REPO_NAME}.spec
+          sed -i "s/^\(Release: *\).*/\1${{ steps.release.outputs.release_num }}%{?dist}/" packaging/rpm/${REPO_NAME}.spec
+      
+      - name: 5. Import GPG Key and Configure RPM
+        run: |
+          echo "${{ secrets.GPG_SIGNING_KEY }}" | gpg --import --batch
+          echo '%_signature gpg' > ~/.rpmmacros
+          echo '%_gpg_name ${{ secrets.GPG_KEY_ID }}' >> ~/.rpmmacros
+      - name: 6. Prepare RPM Sources
+        run: |
+          mkdir -p $HOME/rpmbuild/SOURCES
+          tar -czf $HOME/rpmbuild/SOURCES/${REPO_NAME}.tar.gz \
+            --transform='s,^\.,${REPO_NAME}-${{ steps.version.outputs.version }},' \
+            --exclude=.git --exclude=.github .
+          curl -LO https://github.com/pieroproietti/penguins-bootloaders/releases/download/${{ env.BOOTLOADERS_VERSION }}/bootloaders.tar.gz
+          cp bootloaders.tar.gz $HOME/rpmbuild/SOURCES/
+      - name: 7. Build and Sign RPM package
+        id: build
+        env:
+          GPG_PASSPHRASE_ENV: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          mkdir -p ~/.gnupg
+          echo "pinentry-mode loopback" > ~/.gnupg/gpg.conf
+          echo "allow-loopback-pinentry" > ~/.gnupg/gpg-agent.conf
+          gpg-connect-agent reloadagent /bye
+          echo "$GPG_PASSPHRASE_ENV" | gpg --batch --yes --passphrase-fd 0 -o /dev/null -s /dev/null
+          rpmbuild -ba packaging/rpm/${REPO_NAME}.spec
+          rpmsign --addsign $(find $HOME/rpmbuild/RPMS -name '*.rpm')
+          echo "rpm_path=$(find $HOME/rpmbuild/RPMS -name '*.rpm')" >> $GITHUB_OUTPUT
+      - name: 8. Upload RPM Artifact for publishing
+        uses: actions/upload-artifact@v4
+        with:
+          name: fedora-42-rpm-for-repo
+          path: ${{ steps.build.outputs.rpm_path }}
+    # END build-fc42
+
+  # ========================================================
+  # build-manjaro
+  # ========================================================
+    build-manjaro:
+      runs-on: ubuntu-latest # Runner GitHub
+      container:
+        image: manjarolinux/base
+      steps:
+      - name: Update Arch Linux & Manjaro Keyrings
+        run: |
+          sudo pacman -Sy --noconfirm archlinux-keyring manjaro-keyring
+          sudo pacman-key --init
+          sudo pacman-key --populate archlinux manjaro
+
+      - name: 1. Checkout ${REPO_NAME} code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0       # Scarica tutta la cronologia (necessario per calcolare versioni/checksum)
+          fetch-tags: true     # Assicura che i tag vengano scaricati
+
+      - name: 2. Prepare Build Environment and Dependencies
+        run: |
+          pacman -Syu --noconfirm
+          pacman -S --noconfirm base-devel git pnpm jq pacman-contrib gnupg
+
+      - name: 3. Update PKGBUILD with version and release
+        run: |
+          VERSION=$(jq -r .version package.json)
+          RELEASE_NUM=$(cat release | tr -d '[:space:]')
+          echo "Updating Manjaro PKGBUILD to version: $VERSION, release: $RELEASE_NUM"
+          sed -i "s/^pkgver=.*/pkgver=$VERSION/" ./packaging/manjaro/PKGBUILD
+          sed -i "s/^pkgrel=.*/pkgrel=$RELEASE_NUM/" ./packaging/manjaro/PKGBUILD
+          sed -i "s|https://github.com/pieroproietti/${REPO_NAME}.git|file://${GITHUB_WORKSPACE}|" ./packaging/manjaro/PKGBUILD
+          echo "PKGBUILD updated:"
+          grep -E "^(pkgver|pkgrel)=" ./packaging/manjaro/PKGBUILD
+      
+      - name: 4. Prepare Build User
+        run: |
+          echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+          chown -R builder:builder "$GITHUB_WORKSPACE"
+      
+      - name: 5. Import GPG Key and Prime Agent (for builder)
+        run: |
+          echo "${{ secrets.GPG_SIGNING_KEY }}" | sudo -u builder gpg --import --batch
+          sudo -u builder bash -c 'mkdir -p ~/.gnupg'
+          sudo -u builder bash -c 'echo "pinentry-mode loopback" > ~/.gnupg/gpg.conf'
+          sudo -u builder bash -c 'echo "allow-loopback-pinentry" > ~/.gnupg/gpg-agent.conf'
+          sudo -u builder gpg-connect-agent reloadagent /bye
+          echo "${{ secrets.GPG_PASSPHRASE }}" | sudo -u builder gpg --batch --yes --passphrase-fd 0 -o /dev/null -s /dev/null
+      
+      - name: 6. Update Checksums and Build Package as Non-Root User
+        run: |
+          sudo -u builder GPGKEY=${{ secrets.GPG_KEY_ID }} updpkgsums
+          sudo -u builder GPGKEY=${{ secrets.GPG_KEY_ID }} makepkg -s -f --noconfirm
+        working-directory: ./packaging/manjaro
+      
+      - name: 7. Upload Package Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: manjaro-package
+          path: |
+            ./packaging/manjaro/*.pkg.tar.zst
+            ./packaging/manjaro/*.pkg.tar.zst.sig
+  # END build-manjaro
+
+  # ========================================================
+  # build-opensuse
+  # ========================================================
+    build-opensuse:
+      runs-on: ubuntu-latest # Runner GitHub
+      container:
+        image: opensuse/leap
+      steps:
+      - name: 0. Install Prerequisite Tools
+        run: |
+          zypper --non-interactive refresh
+          zypper --non-interactive install git tar gzip
+      - name: 1. Checkout ${REPO_NAME} code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: 2. Install Build Dependencies (with jq)
+        run: |
+          zypper --non-interactive install rpm-build curl gpg2 rsync nodejs-devel jq
+          zypper modifyrepo --enable repo-source
+          zypper --non-interactive refresh
+          npm install -g pnpm
+
+      - name: 3. Get Package Version from package.json
+        id: version
+        run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
+      
+      - name: 4. Get Package Release from 'release' file
+        id: release
+        run: echo "release_num=$(cat release | tr -d '[:space:]')" >> $GITHUB_OUTPUT
+
+      - name: 5. Update .spec and Install Dependencies
+        run: |
+          echo "Updating .spec file to version ${{ steps.version.outputs.version }} and release ${{ steps.release.outputs.release_num }}"
+          sed -i "s/^\(Version: *\).*/\1${{ steps.version.outputs.version }}/" packaging/rpm/${REPO_NAME}.spec
+          sed -i "s/^\(Release: *\).*/\1${{ steps.release.outputs.release_num }}%{?dist}/" packaging/rpm/${REPO_NAME}.spec
+          
+          cp packaging/rpm/${REPO_NAME}.spec packaging/rpm/${REPO_NAME}.spec.suse
+          sed -i -e '/%if 0%{?suse_version}/,/%endif/c\BuildRequires:  nodejs-devel' packaging/rpm/${REPO_NAME}.spec.suse
+          sed -i -e '/%if %{expr: 0%{?fedora} || 0%{?suse_version}}/,/%endif/c\BuildRequires:  pnpm' packaging/rpm/${REPO_NAME}.spec.suse
+          sed -i '/BuildRequires: *pnpm/d' packaging/rpm/${REPO_NAME}.spec.suse
+          echo "Installing RPM build dependencies from simplified spec file..."
+          for package in $(grep '^BuildRequires:' packaging/rpm/${REPO_NAME}.spec.suse | awk '{print $2}'); do
+            echo "Installing $package..."
+            zypper --non-interactive install "$package"
+          done
+      
+      - name: 6. Import GPG Key and Configure RPM
+        run: |
+          echo "${{ secrets.GPG_SIGNING_KEY }}" | gpg --import --batch
+          echo '%_signature gpg' > ~/.rpmmacros
+          echo '%_gpg_name ${{ secrets.GPG_KEY_ID }}' >> ~/.rpmmacros
+
+      - name: 7. Prepare RPM Sources
+        working-directory: ${{ github.workspace }}
+        run: |
+          STAGING_DIR="/tmp/staging"
+          SOURCE_DIR_NAME="${REPO_NAME}-${{ steps.version.outputs.version }}"
+          mkdir -p "$STAGING_DIR/$SOURCE_DIR_NAME"
+          rsync -av --exclude '.git' --exclude '.github' ./ "$STAGING_DIR/$SOURCE_DIR_NAME/"
+          mkdir -p $HOME/rpmbuild/SOURCES
+          tar -czf $HOME/rpmbuild/SOURCES/${REPO_NAME}.tar.gz -C "$STAGING_DIR" "$SOURCE_DIR_NAME"
+          curl -LO https://github.com/pieroproietti/penguins-bootloaders/releases/download/${{ env.BOOTLOADERS_VERSION }}/bootloaders.tar.gz
+          cp bootloaders.tar.gz $HOME/rpmbuild/SOURCES/
+
+      - name: 8. Build and Sign RPM package
+        id: build
+        run: |
+          export GPG_TTY=$(tty)
+          echo '%_topdir %(echo $HOME)/rpmbuild' >> ~/.rpmmacros
+          mkdir -p ~/.gnupg
+          echo "pinentry-mode loopback" > ~/.gnupg/gpg.conf
+          echo "allow-loopback-pinentry" > ~/.gnupg/gpg-agent.conf
+          gpg-connect-agent reloadagent /bye
+          echo "${{ secrets.GPG_PASSPHRASE }}" | gpg --batch --yes --passphrase-fd 0 -o /dev/null -s /dev/null
+          rpmbuild -ba packaging/rpm/${REPO_NAME}.spec.suse
+          echo "rpm_path=$(find $HOME/rpmbuild/RPMS -name '*.rpm')" >> $GITHUB_OUTPUT
+
+      - name: 9. Upload RPM Artifact for publishing
+        uses: actions/upload-artifact@v4
+        with:
+          name: opensuse-leap-rpm-for-repo
+          path: ${{ steps.build.outputs.rpm_path }}
+
+    # END build-opensuse
+
+
+
+
+# ========================================================
+  # 2.0 JOB DI PUBBLICAZIONE DEBIAN
+  # runs-on: self-hosted (runner vps) CON CONTAINER
+  # ========================================================
+    publish-debian-repo:
+      needs: [build-debian]
+      runs-on: self-hosted
+      
+      container:
+        image: debian:13
+        volumes:
+          - /var/www/html/repos/deb:/mnt/deb-repo # HostPath:ContainerPath
+    
+      steps:
+      - name: 1. Install Debian Dependencies on Host
+        run: |
+          # --- MODIFICA: 'sudo' non è più necessario ---
+          apt-get update
+          apt-get install -y apt-utils gnupg dpkg dpkg-dev
+
+      - name: 2. Import GPG Key
+        env:
+          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          echo "${{ secrets.GPG_SIGNING_KEY }}" | gpg --import --batch
+          mkdir -p ~/.gnupg
+          echo "pinentry-mode loopback" > ~/.gnupg/gpg.conf
+          echo "allow-loopback-pinentry" > ~/.gnupg/gpg-agent.conf
+          gpg-connect-agent reloadagent /bye
+          echo "$GPG_PASSPHRASE" | gpg --batch --yes --passphrase-fd 0 -o /dev/null -s /dev/null
+
+      - name: 3. Create Debian Repo Structure
+        run: |
+          # --- MODIFICA: Usiamo il percorso del container mappato ---
+          mkdir -p /mnt/deb-repo/pool/main
+          mkdir -p /mnt/deb-repo/dists/stable/main/binary-amd64
+          mkdir -p /mnt/deb-repo/dists/stable/main/binary-arm64
+          mkdir -p /mnt/deb-repo/dists/stable/main/binary-i386
+
+      - name: 4. Download Debian artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: debian-packages
+          # --- MODIFICA: Usiamo il percorso del container mappato ---
+          path: /mnt/deb-repo/pool/main/
+
+      - name: 5. Update Debian Repo (NO Pruning)
+        env:
+          GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        # --- MODIFICA: Usiamo il percorso del container mappato ---
+        working-directory: /mnt/deb-repo
+        run: |
+          set -e
+          echo "--- DEBIAN: Genero file Packages ---"
+          dpkg-scanpackages -a amd64 pool/main > dists/stable/main/binary-amd64/Packages
+          gzip -9c dists/stable/main/binary-amd64/Packages > dists/stable/main/binary-amd64/Packages.gz
+          
+          dpkg-scanpackages -a arm64 pool/main > dists/stable/main/binary-arm64/Packages
+          gzip -9c dists/stable/main/binary-arm64/Packages > dists/stable/main/binary-arm64/Packages.gz
+          
+          dpkg-scanpackages -a i386 pool/main > dists/stable/main/binary-i386/Packages
+          gzip -9c dists/stable/main/binary-i386/Packages > dists/stable/main/binary-i386/Packages.gz
+          
+          echo "--- DEBIAN: Genero file Release ---"
+          apt-ftparchive \
+            -o APT::FTPArchive::Release::Origin="Penguins-Eggs" \
+            -o APT::FTPArchive::Release::Label="Penguins-Eggs" \
+            -o APT::FTPArchive::Release::Suite="stable" \
+            -o APT::FTPArchive::Release::Codename="stable" \
+            -o APT::FTPArchive::Release::Architectures="amd64 arm64 i386" \
+            -o APT::FTPArchive::Release::Components="main" \
+            release dists/stable > dists/stable/Release
+            
+          echo "--- DEBIAN: Firmo file Release (creo InRelease) ---"
+          gpg --default-key "$GPG_KEY_ID" \
+              --clearsign \
+              -o dists/stable/InRelease \
+              --batch --yes --passphrase "$GPG_PASSPHRASE" \
+              dists/stable/Release
+
+
+
+
+              
+  # ========================================================
+  # 3.0 JOB DI PUBBLICAZIONE FINALE
+  # runs-on: self-hosted (runner vps) 
+  # ========================================================
+    publish-all-repos:
+      needs: [build-alpine, build-arch, build-el9, build-fc42, build-manjaro, build-opensuse, publish-debian-repo]
+      runs-on: self-hosted 
+
+      container:
+        image: archlinux
+        volumes:
+          - /var/www/html/repos:/mnt/repos # HostPath:ContainerPath
+    
+      steps:
+      - name: 1. Install Dependencies
+        run: |
+          pacman-key --init && pacman-key --populate archlinux
+          pacman -Syu --noconfirm
+          pacman -S --noconfirm pacman-contrib gnupg createrepo_c apk-tools
+      
+      - name: 3.1 Download Alpine artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: alpine-package
+          path: /mnt/repos/alpine/
+
+      - name: 3.2 Download Arch artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: arch-packages
+          path: /mnt/repos/arch/
+
+      # - name: Download Debian artifacts -- no-needs --
+
+      - name: 3.3 Download Fedora 42 artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: fedora-42-rpm-for-repo
+          path: /mnt/repos/rpm/fedora/42/
+
+      - name: 3.4 Download EL9 artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: el9-rpm-for-repo
+          path: /mnt/repos/rpm/el9/
+
+      - name: 3.5 Download Manjaro artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: manjaro-package
+          path: /mnt/repos/manjaro/
+
+      - name: 3.6 Download openSUSE artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: opensuse-leap-rpm-for-repo
+          path: /mnt/repos/rpm/opensuse/leap/
+
+      - name: 4. Import GPG Key
+        env:
+          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+        run: echo "$GPG_SIGNING_KEY" | gpg --import --batch
+
+      - name: 5. Immetti la passphrase!!!
+        env:
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          mkdir -p ~/.gnupg
+          echo "pinentry-mode loopback" > ~/.gnupg/gpg.conf
+          echo "allow-loopback-pinentry" > ~/.gnupg/gpg-agent.conf
+          gpg-connect-agent reloadagent /bye
+          echo "$GPG_PASSPHRASE" | gpg --batch --yes --passphrase-fd 0 -o /dev/null -s /dev/null
+
+
+      # Update 
+      - name: 6. Update Alpine Repo (WITH Pruning)
+        env:
+          ALPINE_SIGNING_KEY_PUB: ${{ secrets.ALPINE_SIGNING_KEY_PUB }}
+        run: |
+          set -ex
+          cd /mnt/repos/alpine
+
+          echo "--- ALPINE: Flattening directory structure ---"
+          find . -mindepth 2 -type f -name '*.apk' -exec mv {} . \;
+          
+          echo "--- ALPINE: Files BEFORE cleaning ---"
+          ls -l
+
+          echo '--- ALPINE: Cleaning old packages ---'
+          PKG_BASES=$(find . -maxdepth 1 -name '*.apk' -exec basename {} \; | sed -E 's/(.*)-[0-9]+\..*/\1/' | sort -u)
+          echo "--- ALPINE: Found package bases: $PKG_BASES"
+          for base in $PKG_BASES; do
+            echo "--- Processing: $base ---"
+            ls ${base}-[0-9]*.apk 2>/dev/null | sort -V | head -n -1 | xargs -r rm -vf
+          done
+          echo '--- ALPINE: Cleaning complete ---'
+          
+          rm -f APKINDEX.tar.gz
+          apk index -o APKINDEX.tar.gz *.apk --allow-untrusted
+          echo "$ALPINE_SIGNING_KEY_PUB" > ${REPO_NAME}.rsa.pub
+          cd / # Ritorna alla root      
+
+      - name: 7. Update Arch Repo (WITH Pruning)
+        env:
+          GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
+        run: |
+          set -ex
+          cd /mnt/repos/arch
+
+          echo "--- ARCH: Flattening directory structure ---"
+          find . -mindepth 2 -type f \( -name '*.pkg.tar.zst' -o -name '*.pkg.tar.zst.sig' \) -exec mv -t . {} +
+
+          echo "--- ARCH: Files BEFORE cleaning ---"
+          ls -l
+          
+          echo '--- ARCH: Cleaning old packages ---'
+          PKG_BASES=$(find . -maxdepth 1 -name '*.pkg.tar.zst' -exec basename {} \; | sed -E 's/(.*)-[0-9]+\..*/\1/' | sort -u)
+          echo "--- ARCH: Found package bases: $PKG_BASES"
+          for base in $PKG_BASES; do
+            echo "--- Processing: $base ---"
+            ls ${base}-*.pkg.tar.zst 2>/dev/null | sort -V | head -n -1 | xargs -r rm -vf
+            ls ${base}-*.pkg.tar.zst.sig 2>/dev/null | sort -V | head -n -1 | xargs -r rm -vf
+          done
+          echo '--- ARCH: Cleaning complete ---'
+          echo "--- ARCH: Files AFTER cleaning ---"
+          ls -l
+          
+          rm -f ${REPO_NAME}.db.tar.gz ${REPO_NAME}.files.tar.gz
+          repo-add --sign --key "$GPG_KEY_ID" ${REPO_NAME}.db.tar.gz *.pkg.tar.zst
+          cd / # Ritorna alla root
+
+      - name: 8. Update RPM Repos
+        run: |
+          set -e
+          echo "--- RPM: Re-indexing ---"
+          cd /mnt/repos/rpm/fedora/42; rm -rf repodata; createrepo_c .;
+          cd /mnt/repos/rpm/opensuse/leap; rm -rf repodata; createrepo_c .;
+          cd /mnt/repos/rpm/el9; rm -rf repodata; createrepo_c .;
+          cd / # Ritorna alla root
+
+
+      - name: 9. Update Manjaro Repo (WITH Pruning)
+        env:
+          GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
+        run: |
+          set -ex
+          cd /mnt/repos/manjaro
+
+          echo "--- MANJARO: Flattening directory structure ---"
+          find . -mindepth 2 -type f \( -name '*.pkg.tar.zst' -o -name '*.pkg.tar.zst.sig' \) -exec mv -t . {} +
+
+          echo "--- MANJARO: Files BEFORE cleaning ---"
+          ls -l
+          
+          echo '--- MANJARO: Cleaning old packages ---'
+          PKG_BASES=$(find . -maxdepth 1 -name '*.pkg.tar.zst' -exec basename {} \; | sed -E 's/(.*)-[0-9]+\..*/\1/' | sort -u)
+
+          echo "--- MANJARO: Found package bases: $PKG_BASES"
+          for base in $PKG_BASES; do
+            echo "--- Processing: $base ---"
+            ls ${base}-*.pkg.tar.zst 2>/dev/null | sort -V | head -n -1 | xargs -r rm -vf
+            ls ${base}-*.pkg.tar.zst.sig 2>/dev/null | sort -V | head -n -1 | xargs -r rm -vf
+          done
+          echo '--- MANJARO: Cleaning complete ---'
+          
+          rm -f ${REPO_NAME}.db.tar.gz ${REPO_NAME}.files.tar.gz
+          repo-add --sign --key "$GPG_KEY_ID" ${REPO_NAME}.db.tar.gz *.pkg.tar.zst
+          cd / # Ritorna alla root


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/penguins-eggs/.github/workflows/0-build-publish-packages.yaml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).