### PR TITLE
Proposal: add `1-reindex-repository.yaml` skeleton

### DIFF
--- a/.github/workflows/1-reindex-repository.yaml
+++ b/.github/workflows/1-reindex-repository.yaml
@@ -1,0 +1,202 @@
+name: 1-reindex-repository
+
+on:
+  workflow_dispatch:
+
+jobs:
+  reindex-repositories:
+    runs-on: ubuntu-latest
+    name: 1-reindex-on-host-dockerized-clean-alpine-arch-manjaro
+    
+    steps:
+      - name: Re-index repositories
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          
+          script: |
+            set -e
+            echo "--- Esecuzione re-indicizzazione (Full Docker) su host: $HOSTNAME ---"
+
+            # --- 0. Prepara i secret come file temporanei ---
+            echo "Creazione file secret temporanei..."
+            echo "${{ secrets.GPG_SIGNING_KEY }}" > /tmp/penguins-gpg.key
+            echo "${{ secrets.ALPINE_PUBLIC_KEY }}" > /tmp/penguins-alpine.pub
+            chmod 600 /tmp/penguins-gpg.key
+            chmod 644 /tmp/penguins-alpine.pub
+
+            # --- 1. Definisci percorso base ---
+            REPO_PATH="/var/www/html/repos"
+            echo "Percorso repository: $REPO_PATH"
+
+            # --- 2. Re-index Debian & RPM (INVARIATO) ---
+            echo "--- DEBIAN/RPM: Re-indexing (Container) ---"
+            docker run --rm \
+              -v "$REPO_PATH:/repo" \
+              -v "/tmp/penguins-gpg.key:/tmp/gpg.key:ro" \
+              -e "GPG_KEY_ID=${{ secrets.GPG_KEY_ID }}" \
+              -e "GPG_PASSPHRASE=${{ secrets.GPG_PASSPHRASE }}" \
+              deb-rpm-indexer \
+              bash -c "
+                set -e
+                
+                echo '--- Container: Importing GPG key from file ---'
+                gpg --import --batch /tmp/gpg.key
+                
+                mkdir -p ~/.gnupg
+                echo 'pinentry-mode loopback' > ~/.gnupg/gpg.conf
+                echo 'allow-loopback-pinentry' > ~/.gnupg/gpg-agent.conf
+                gpg-connect-agent reloadagent /bye
+                
+                echo '--- DEBIAN: Indexing ---'
+                cd /repo/deb
+                dpkg-scanpackages --multiversion -a amd64 pool/main > dists/stable/main/binary-amd64/Packages
+                gzip -9c dists/stable/main/binary-amd64/Packages > dists/stable/main/binary-amd64/Packages.gz
+                dpkg-scanpackages --multiversion -a arm64 pool/main > dists/stable/main/binary-arm64/Packages
+                gzip -9c dists/stable/main/binary-arm64/Packages > dists/stable/main/binary-arm64/Packages.gz
+                dpkg-scanpackages --multiversion -a i386 pool/main > dists/stable/main/binary-i386/Packages
+                gzip -9c dists/stable/main/binary-i386/Packages > dists/stable/main/binary-i386/Packages.gz
+                
+                apt-ftparchive \
+                  -o APT::FTPArchive::Release::Origin=\"Penguins-Eggs\" \
+                  -o APT::FTPArchive::Release::Label=\"Penguins-Eggs\" \
+                  -o APT::FTPArchive::Release::Suite=\"stable\" \
+                  -o APT::FTPArchive::Release::Codename=\"stable\" \
+                  -o APT::FTPArchive::Release::Architectures=\"amd64 arm64 i386\" \
+                  -o APT::FTPArchive::Release::Components=\"main\" \
+                  release dists/stable > dists/stable/Release
+                
+                gpg --default-key \"\$GPG_KEY_ID\" \
+                    --clearsign \
+                    -o dists/stable/InRelease \
+                    --batch --yes --passphrase \"\$GPG_PASSPHRASE\" \
+                    dists/stable/Release
+                
+                echo '--- RPM: Indexing ---'
+                cd /repo/rpm/fedora/42; rm -rf repodata; createrepo_c .;
+                cd /repo/rpm/opensuse/leap; rm -rf repodata; createrepo_c .;
+                cd /repo/rpm/el9; rm -rf repodata; createrepo_c .;
+              "
+            
+            # --- 3. Re-index Arch (MODIFICATO CON PULIZIA) ---
+            echo "--- ARCH: Re-indexing (Container) ---"
+            docker run --rm \
+              -v "$REPO_PATH/arch:/repo" \
+              -v "/tmp/penguins-gpg.key:/tmp/gpg.key:ro" \
+              -e "GPG_KEY_ID=${{ secrets.GPG_KEY_ID }}" \
+              -e "GPG_PASSPHRASE=${{ secrets.GPG_PASSPHRASE }}" \
+              arch-indexer \
+              bash -c "
+                set -e
+                echo '--- Container: Importing GPG key from file ---'
+                gpg --import --batch /tmp/gpg.key
+                
+                mkdir -p ~/.gnupg
+                echo 'pinentry-mode loopback' > ~/.gnupg/gpg.conf
+                echo 'allow-loopback-pinentry' > ~/.gnupg/gpg-agent.conf
+                gpg-connect-agent reloadagent /bye
+                
+                echo \"\$GPG_PASSPHRASE\" | gpg --batch --yes --passphrase-fd 0 -o /dev/null -s /dev/null
+                
+                # --- LOGICA DI PULIZIA ARCH ---
+                echo '--- ARCH: Cleaning old packages ---'
+                # Trova tutti i nomi base unici (es. '${REPO_NAME}', 'calamares-eggs')
+                PKG_BASES=\$(find . -maxdepth 1 -name \"*.pkg.tar.zst\" -exec basename {} \\; | sed -E 's/(.*)-[0-9]+\..*/\1/' | sort -u)
+                for base in \$PKG_BASES; do
+                  echo \"Processing: \$base\"
+                  # Per ogni nome base, elenca tutti i file, ordinali per versione (-V),
+                  # tieni tutti tranne l'ultimo (head -n -1) e cancellali
+                  ls \${base}-*.pkg.tar.zst 2>/dev/null | sort -V | head -n -1 | xargs -r rm -vf
+                  # Fai lo stesso per i file .sig
+                  ls \${base}-*.pkg.tar.zst.sig 2>/dev/null | sort -V | head -n -1 | xargs -r rm -vf
+                done
+                # --- FINE LOGICA DI PULIZIA ---
+                
+                echo '--- ARCH: Indexing remaining packages ---'
+                rm -f ${REPO_NAME}.db.tar.gz ${REPO_NAME}.files.tar.gz && \
+                repo-add --sign --key \"\$GPG_KEY_ID\" ${REPO_NAME}.db.tar.gz *.pkg.tar.zst
+              "
+            
+            # --- 4. Re-index Manjaro (MODIFICATO CON PULIZIA) ---
+            echo "--- MANJARO: Re-indexing (Container) ---"
+            docker run --rm \
+              -v "$REPO_PATH/manjaro:/repo" \
+              -v "/tmp/penguins-gpg.key:/tmp/gpg.key:ro" \
+              -e "GPG_KEY_ID=${{ secrets.GPG_KEY_ID }}" \
+              -e "GPG_PASSPHRASE=${{ secrets.GPG_PASSPHRASE }}" \
+              arch-indexer \
+              bash -c "
+                set -e
+                echo '--- Container: Importing GPG key from file ---'
+                gpg --import --batch /tmp/gpg.key
+                
+                mkdir -p ~/.gnupg
+                echo 'pinentry-mode loopback' > ~/.gnupg/gpg.conf
+                echo 'allow-loopback-pinentry' > ~/.gnupg/gpg-agent.conf
+                gpg-connect-agent reloadagent /bye
+                
+                echo \"\$GPG_PASSPHRASE\" | gpg --batch --yes --passphrase-fd 0 -o /dev/null -s /dev/null
+                
+                # --- LOGICA DI PULIZIA MANJARO ---
+                echo '--- MANJARO: Cleaning old packages ---'
+                PKG_BASES=\$(find . -maxdepth 1 -name \"*.pkg.tar.zst\" -exec basename {} \\; | sed -E 's/(.*)-[0-9]+\..*/\1/' | sort -u)
+                for base in \$PKG_BASES; do
+                  echo \"Processing: \$base\"
+                  ls \${base}-*.pkg.tar.zst 2>/dev/null | sort -V | head -n -1 | xargs -r rm -vf
+                  ls \${base}-*.pkg.tar.zst.sig 2>/dev/null | sort -V | head -n -1 | xargs -r rm -vf
+                done
+                # --- FINE LOGICA DI PULIZIA ---
+
+                echo '--- MANJARO: Indexing remaining packages ---'
+                rm -f ${REPO_NAME}.db.tar.gz ${REPO_NAME}.files.tar.gz && \
+                repo-add --sign --key \"\$GPG_KEY_ID\" ${REPO_NAME}.db.tar.gz *.pkg.tar.zst
+              "
+
+            # --- 5. Re-index Alpine (MODIFICATO CON PULIZIA) ---
+            echo "--- ALPINE: Re-indexing (Container) ---"
+            
+            mkdir -p "$REPO_PATH/alpine/x86_64"
+            
+            docker run --rm \
+              -v "$REPO_PATH/alpine/x86_64:/repo" \
+              alpine-indexer \
+              sh -c "
+                set -ex 
+                
+                # 1. Abilitiamo 'community' (come root)
+                echo '--- ALPINE: Enabling community repository ---'
+                sed -i -E 's|#(.*v[0-9]+\.[0-9]+/community)|\1|g' /etc/apk/repositories
+                
+                # 2. Popoliamo la cache (LA TUA INTUIZIONE CHIAVE)
+                echo '--- ALPINE: Fetching upstream indexes (apk update) ---'
+                apk update
+                
+                # --- LOGICA DI PULIZIA ALPINE ---
+                echo '--- ALPINE: Cleaning old packages ---'
+                # Assicurati che il container 'alpine-indexer' abbia 'coreutils' per 'sort -V'
+                PKG_BASES=\$(find . -maxdepth 1 -name \"*.apk\" -exec basename {} \\; | sed -E 's/(.*)-[0-9]+\..*/\1/' | sort -u)
+                for base in \$PKG_BASES; do
+                  echo \"Processing: \$base\"
+                  ls ${base}-[0-9]*.apk 2>/dev/null | sort -V | head -n -1 | xargs -r rm -vf
+                done
+                # --- FINE LOGICA DI PULIZIA ---
+                
+                echo '--- ALPINE: Indexing remaining packages ---'
+                rm -f APKINDEX.tar.gz
+                
+                # --- DEBUG: Vediamo cosa c'è nella cartella ---
+                echo '--- DEBUG: Listing files in /repo ---'
+                ls -la /repo
+                
+                # crea APKINDEX.tar.gz
+                apk index --merge -o APKINDEX.tar.gz *.apk --allow-untrusted
+              "
+
+            # --- 6. Pulizia file temporanei ---
+            echo "Pulizia file secret temporanei..."
+            rm /tmp/penguins-gpg.key
+            rm /tmp/penguins-alpine.pub
+
+            echo "--- ✅ Re-index (Full Docker) completato ---"


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/penguins-eggs/.github/workflows/1-reindex-repository.yaml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).