### PR TITLE
Proposal: add `ipfs-mirror.yml` skeleton

### DIFF
--- a/.github/workflows/ipfs-mirror.yml
+++ b/.github/workflows/ipfs-mirror.yml
@@ -1,0 +1,74 @@
+# .github/workflows/ipfs-mirror.yml
+# Mirrors the repository and release assets to IPFS on each release.
+# Uses Helia (the current JS IPFS implementation) via scripts/ipfs-mirror.ts.
+
+name: IPFS Mirror
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download release assets
+        if: github.event_name == 'release'
+        run: |
+          mkdir -p /tmp/release-assets
+          gh release download "${{ github.event.release.tag_name }}" \
+            -D /tmp/release-assets || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Mirror to IPFS
+        id: ipfs
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            pnpm tsx scripts/ipfs-mirror.ts --assets /tmp/release-assets
+          else
+            pnpm tsx scripts/ipfs-mirror.ts
+          fi
+
+      - name: Update release notes with CID
+        if: github.event_name == 'release' && steps.ipfs.outputs.REPO_CID != ''
+        run: |
+          BODY=$(gh release view "${{ github.event.release.tag_name }}" --json body -q .body)
+          BODY="${BODY}
+
+          ---
+          **IPFS Mirror**
+          - Source: \`${{ steps.ipfs.outputs.REPO_CID }}\`
+          - Gateway: https://ipfs.io/ipfs/${{ steps.ipfs.outputs.REPO_CID }}"
+
+          if [ -n "${{ steps.ipfs.outputs.ASSETS_CID }}" ]; then
+            BODY="${BODY}
+          - Assets: \`${{ steps.ipfs.outputs.ASSETS_CID }}\`"
+          fi
+
+          gh release edit "${{ github.event.release.tag_name }}" --notes "${BODY}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/penguins-eggs/.github/workflows/ipfs-mirror.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).