### PR TITLE
Proposal: add `trigger-book-sync.yml` skeleton

### DIFF
--- a/.github/workflows/trigger-book-sync.yml
+++ b/.github/workflows/trigger-book-sync.yml
@@ -1,0 +1,37 @@
+name: Trigger book sync on docs change
+
+# Dispatches a repository_dispatch to fork-sync-all whenever docs/chromiumos/
+# changes on the all-features branch. fork-sync-all then copies the updated
+# docs into ${REPO_NAME}-book automatically.
+
+on:
+  push:
+    branches: [all-features]
+    paths: [docs/**]
+
+permissions:
+  contents: read
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Dispatch sync-eggs-docs-to-book in fork-sync-all
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+        run: |
+          curl --disable --silent --fail -X POST \
+            -H "Authorization: token ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "Content-Type: application/json" \
+            "https://api.github.com/repos/OSPF1896/fork-sync-all/dispatches" \
+            -d "{
+              \"event_type\": \"eggs-docs-updated\",
+              \"client_payload\": {
+                \"ref\": \"all-features\",
+                \"sha\": \"${{ github.sha }}\",
+                \"pusher\": \"${{ github.actor }}\"
+              }
+            }"
+          echo "Dispatched eggs-docs-updated to fork-sync-all for ${{ github.sha }}"


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/penguins-eggs/.github/workflows/trigger-book-sync.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).