### PR TITLE
Proposal: add `distro-matrix.yml` skeleton

### DIFF
--- a/.github/workflows/distro-matrix.yml
+++ b/.github/workflows/distro-matrix.yml
@@ -1,0 +1,204 @@
+name: Distro Matrix
+
+on:
+  push:
+    branches: ["main", "feat/**", "fix/**"]
+  pull_request:
+    branches: ["main"]
+  # Allow manual trigger for full matrix runs.
+  workflow_dispatch:
+
+jobs:
+  build-ci-images:
+    name: "Build CI image: ${{ matrix.image }}"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Changed to write to allow pushing images
+      packages: write   # Ensure packages permission is set to write
+      id-token: write  # Added permission for Docker image push
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: opensuse-tumbleweed-ci
+            context: .github/images/opensuse-tumbleweed-ci
+          - image: voidlinux-ci
+            context: .github/images/voidlinux-ci
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set lowercase owner
+        run: echo "OWNER=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: ${{ matrix.context }}
+          push: true
+          tags: |
+            ghcr.io/${{ env.OWNER }}/${{ matrix.image }}:latest
+            ghcr.io/${{ env.OWNER }}/${{ matrix.image }}:${{ github.sha }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+
+  smoke-test:
+    name: "${{ matrix.distro }} / ${{ matrix.backend }}"
+    runs-on: ubuntu-latest
+    needs: [build-ci-images]
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - distro: arch
+            image: archlinux:latest
+            backend: ashos
+            pkg_install: "pacman -Sy --noconfirm"
+            ca_install: "pacman -Sy --noconfirm ca-certificates"
+
+          - distro: arch
+            image: archlinux:latest
+            backend: akshara
+            pkg_install: "pacman -Sy --noconfirm"
+            ca_install: "pacman -Sy --noconfirm ca-certificates"
+
+          - distro: arch
+            image: archlinux:latest
+            backend: frzr
+            pkg_install: "pacman -Sy --noconfirm"
+            ca_install: "pacman -Sy --noconfirm ca-certificates"
+
+          - distro: debian
+            image: debian:bookworm-slim
+            backend: ashos
+            pkg_install: "apt-get update -qq && apt-get install -y -qq"
+            ca_install: "apt-get update -qq && apt-get install -y -qq ca-certificates"
+
+          - distro: debian
+            image: debian:bookworm-slim
+            backend: akshara
+            pkg_install: "apt-get update -qq && apt-get install -y -qq"
+            ca_install: "apt-get update -qq && apt-get install -y -qq ca-certificates"
+
+          - distro: debian
+            image: ubuntu:24.04
+            backend: abroot
+            pkg_install: "apt-get update -qq && apt-get install -y -qq"
+            ca_install: "apt-get update -qq && apt-get install -y -qq ca-certificates"
+
+          - distro: fedora
+            image: fedora:latest
+            backend: ashos
+            pkg_install: "dnf install -y -q"
+            ca_install: "dnf install -y -q ca-certificates"
+
+          - distro: fedora
+            image: fedora:latest
+            backend: akshara
+            pkg_install: "dnf install -y -q"
+            ca_install: "dnf install -y -q ca-certificates"
+
+          - distro: alpine
+            image: alpine:latest
+            backend: ashos
+            pkg_install: "apk add --no-cache"
+            ca_install: "apk add --no-cache ca-certificates"
+
+          - distro: alpine
+            image: alpine:latest
+            backend: akshara
+            pkg_install: "apk add --no-cache"
+            ca_install: "apk add --no-cache ca-certificates"
+
+          - distro: rocky
+            image: rockylinux:9
+            backend: ashos
+            pkg_install: "dnf install -y -q"
+            ca_install: "dnf install -y -q ca-certificates"
+
+          - distro: rocky
+            image: rockylinux:9
+            backend: akshara
+            pkg_install: "dnf install -y -q"
+            ca_install: "dnf install -y -q ca-certificates"
+
+          - distro: void
+            image: ghcr.io/interested-deving-1896/voidlinux-ci:latest
+            backend: ashos
+            pkg_install: "xbps-install -Sy"
+            ca_install: "true"
+
+          - distro: opensuse
+            image: ghcr.io/interested-deving-1896/opensuse-tumbleweed-ci:latest
+            backend: ashos
+            pkg_install: "zypper install -y"
+            ca_install: "true"
+
+    container:
+      image: ${{ matrix.image }}
+      options: --privileged
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.22"
+          cache: true
+
+      - name: Install ca-certificates
+        run: ${{ matrix.ca_install }}
+
+      - name: Build pif
+        run: go build -buildvcs=false -o /usr/local/bin/pif ./tools/pif
+
+      - name: Write pif.toml
+        run: |
+          mkdir -p /etc/pif
+          printf '[pif]\ndistro        = "%s"\narch          = "x86_64"\nbackend       = "%s"\nmax_snapshots = 5\nauto_update   = false\n\n[backend.%s]\nsnapshot_root = "/mnt/@"\nsystem_yaml   = "/system.yaml"\nsource        = "test/test:stable"\nimage         = "test/test"\ntag           = "stable"\n' \
+            "${{ matrix.distro }}" "${{ matrix.backend }}" "${{ matrix.backend }}" \
+            > /etc/pif/pif.toml
+
+      - name: Smoke — pif backends
+        run: |
+          pif backends
+          pif backends | grep -F "${{ matrix.backend }}"
+
+      - name: Smoke — pif status (graceful error without backend binary)
+        run: |
+          pif status 2>&1 || true
+          pif status 2>&1 | grep -v "panic" | grep -v "nil pointer" | grep -v "segfault" || true
+
+      - name: Smoke — pif upgrade --dry-run
+        run: |
+          out="$(pif upgrade --dry-run 2>&1 || true)"
+          printf '%s\n' "$out" | grep -iF "dry-run" || \
+          printf '%s\n' "$out" | grep -iF "would"   || \
+          printf '%s\n' "$out" | grep -iF "error"   || true
+
+      - name: Smoke — pif snapshot create (graceful error without backend)
+        run: |
+          pif snapshot create --label ci-test 2>&1 || true
+          pif snapshot create --label ci-test 2>&1 | grep -v "panic" | grep -v "nil pointer" || true
+
+      - name: Smoke — pif mutable exit without session
+        run: |
+          out="$(pif mutable exit 2>&1 || true)"
+          printf '%s\n' "$out" | grep -iF "no active session" || \
+          printf '%s\n' "$out" | grep -iF "not found"         || \
+          printf '%s\n' "$out" | grep -iF "error"             || true
+
+      - name: Smoke — pif init (no disk, graceful error)
+        run: |
+          pif init --distro "${{ matrix.distro }}" --backend "${{ matrix.backend }}" 2>&1 || true
+          pif init --distro "${{ matrix.distro }}" --backend "${{ matrix.backend }}" 2>&1 \
+            | grep -v "panic" | grep -v "nil pointer" || true


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/penguins-immutable-framework/.github/workflows/distro-matrix.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).