### PR TITLE
Proposal: add `runner-reset.yml` skeleton

### DIFF
--- a/.github/workflows/runner-reset.yml
+++ b/.github/workflows/runner-reset.yml
@@ -1,0 +1,67 @@
+name: Reset Incus KVM Runner
+
+# Re-registers the self-hosted Incus KVM runner on the 1st of each month,
+# aligned with the GitHub shared runner quota reset. Also runs on demand.
+#
+# The runner host must already be provisioned via scripts/ci/incus-setup-runner.sh.
+# This workflow only handles re-registration — it does not re-provision Incus.
+#
+# Required secrets:
+#   RUNNER_HOST_SSH_KEY  — SSH private key for the runner host
+#   RUNNER_HOST          — hostname or IP of the runner host
+#   RUNNER_HOST_USER     — SSH user on the runner host (default: runner)
+#   SYNC_TOKEN           — PAT with manage_runners:org or repo scope
+
+on:
+  schedule:
+    - cron: '0 2 1 * *'   # Monthly on the 1st at 02:00 UTC (before quota resets at 00:00 PST)  # TODO: set schedule for your project
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run — print what would happen without re-registering"
+        type: boolean
+        required: false
+        default: false
+      runner_dir:
+        description: "Runner install directory on host (default: /opt/actions-runner)"
+        required: false
+        default: "/opt/actions-runner"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: runner-reset
+  cancel-in-progress: false   # never cancel a running reset mid-flight
+
+jobs:
+  reset:
+    name: Re-register Incus KVM runner
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Re-register runner
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+          SSH_KEY: ${{ secrets.RUNNER_HOST_SSH_KEY }}
+          RUNNER_HOST: ${{ secrets.RUNNER_HOST }}
+          RUNNER_HOST_USER: ${{ secrets.RUNNER_HOST_USER || 'runner' }}
+          RUNNER_DIR: ${{ inputs.runner_dir || '/opt/actions-runner' }}
+          GH_REPO: ${{ github.repository }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: bash scripts/runner-reset.sh
+
+      - name: Write summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: |
+          echo "## Runner Reset" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Repo: \`${{ github.repository }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Triggered: \`${{ github.event_name }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Status: \`${{ job.status }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Dry run: \`${{ inputs.dry_run || 'false' }}\`" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/penguins-pivot/.github/workflows/runner-reset.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).