### PR TITLE
Proposal: add `bootloaders-upstream-sync.yaml` skeleton

### DIFF
--- a/.github/workflows/bootloaders-upstream-sync.yaml
+++ b/.github/workflows/bootloaders-upstream-sync.yaml
@@ -1,0 +1,172 @@
+name: Sync bootloaders from upstream
+
+# Tracks: https://github.com/${GITHUB_OWNER}/penguins-bootloaders
+# Scope:  bootloaders/ directory in this repo
+#
+# Behaviour:
+#   - Checks the upstream HEAD SHA against the last known SHA stored in
+#     .github/upstream-bootloaders-sha.
+#   - No change   -> exits silently.
+#   - Clean merge -> commits directly to main.
+#   - Conflict    -> opens a GitHub issue with a diff summary; no files changed.
+
+on:
+  schedule:
+    - cron: "0 8 1 * *"  # TODO: set schedule for your project
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+
+    steps:
+      - name: Checkout ${REPO_NAME}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fetch upstream penguins-bootloaders
+        run: |
+          git remote add bootloaders-upstream \
+            https://github.com/${GITHUB_OWNER}/penguins-bootloaders.git
+          git fetch bootloaders-upstream main
+
+      - name: Check for upstream changes
+        id: check
+        run: |
+          UPSTREAM_SHA=$(git rev-parse bootloaders-upstream/main)
+          echo "upstream_sha=$UPSTREAM_SHA" >> "$GITHUB_OUTPUT"
+
+          SHA_FILE=".github/upstream-bootloaders-sha"
+          if [ -f "$SHA_FILE" ]; then
+            LAST_SHA=$(cat "$SHA_FILE")
+          else
+            LAST_SHA=""
+          fi
+          echo "last_sha=$LAST_SHA" >> "$GITHUB_OUTPUT"
+
+          if [ "$UPSTREAM_SHA" = "$LAST_SHA" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: No changes -- exit early
+        if: steps.check.outputs.changed == 'false'
+        run: echo "Upstream has not changed since last sync. Nothing to do."
+
+      - name: Attempt merge
+        if: steps.check.outputs.changed == 'true'
+        id: merge
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git checkout -b upstream-bootloaders-sync
+
+          git merge \
+            --allow-unrelated-histories \
+            --strategy-option subtree=bootloaders \
+            --no-commit \
+            bootloaders-upstream/main \
+            2>&1 | tee /tmp/merge-output.txt || true
+
+          if git diff --cached --quiet && git diff --quiet; then
+            echo "result=noop" >> "$GITHUB_OUTPUT"
+          elif grep -q "CONFLICT" /tmp/merge-output.txt; then
+            echo "result=conflict" >> "$GITHUB_OUTPUT"
+            git diff HEAD > /tmp/conflict-diff.txt || true
+            git merge --abort 2>/dev/null || git checkout -- . 2>/dev/null || true
+          else
+            echo "result=clean" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit clean merge
+        if: steps.check.outputs.changed == 'true' && steps.merge.outputs.result == 'clean'
+        run: |
+          SHA="${{ steps.check.outputs.upstream_sha }}"
+          SHORT="${SHA:0:7}"
+
+          echo "$SHA" > .github/upstream-bootloaders-sha
+          git add .github/upstream-bootloaders-sha
+          git add bootloaders/
+
+          git commit -m "chore(bootloaders): sync upstream penguins-bootloaders @ ${SHORT}"
+
+          git checkout main
+          git merge --ff-only upstream-bootloaders-sync
+          git push origin main
+          git branch -d upstream-bootloaders-sync
+
+      - name: Open conflict issue
+        if: steps.check.outputs.changed == 'true' && steps.merge.outputs.result == 'conflict'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          SHA="${{ steps.check.outputs.upstream_sha }}"
+          SHORT="${SHA:0:7}"
+          LAST="${{ steps.check.outputs.last_sha }}"
+          LAST_SHORT="${LAST:0:7}"
+
+          DIFF_BODY=""
+          if [ -s /tmp/conflict-diff.txt ]; then
+            DIFF_BODY=$(head -c 6000 /tmp/conflict-diff.txt)
+          fi
+
+          printf '%s\n' \
+            "## Upstream sync conflict" \
+            "" \
+            "Upstream penguins-bootloaders moved from \`${LAST_SHORT}\` to \`${SHORT}\` but the merge into \`bootloaders/\` produced conflicts." \
+            "" \
+            "Upstream repo: https://github.com/${GITHUB_OWNER}/penguins-bootloaders" \
+            "Upstream commit: https://github.com/${GITHUB_OWNER}/penguins-bootloaders/commit/${SHA}" \
+            "" \
+            "**No files were changed.** Manual resolution is required." \
+            "" \
+            "### Steps to resolve" \
+            "" \
+            '```bash' \
+            "git remote add bootloaders-upstream https://github.com/${GITHUB_OWNER}/penguins-bootloaders.git || true" \
+            "git fetch bootloaders-upstream main" \
+            "git merge --allow-unrelated-histories --strategy-option subtree=bootloaders bootloaders-upstream/main" \
+            "# resolve conflicts, then:" \
+            "echo '${SHA}' > .github/upstream-bootloaders-sha" \
+            "git add .github/upstream-bootloaders-sha" \
+            "git commit" \
+            '```' \
+            "" \
+            "### Conflict diff (truncated)" \
+            "" \
+            "<details><summary>Show diff</summary>" \
+            "" \
+            '```diff' \
+            "${DIFF_BODY}" \
+            '```' \
+            "" \
+            "</details>" \
+            > /tmp/issue-body.md
+
+          gh issue create \
+            --title "bootloaders upstream sync conflict (upstream @ ${SHORT})" \
+            --label "upstream-sync" \
+            --body-file /tmp/issue-body.md
+
+          git checkout main
+          git branch -D upstream-bootloaders-sync 2>/dev/null || true
+
+      - name: Update tracked SHA on noop
+        if: steps.check.outputs.changed == 'true' && steps.merge.outputs.result == 'noop'
+        run: |
+          SHA="${{ steps.check.outputs.upstream_sha }}"
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout main
+          echo "$SHA" > .github/upstream-bootloaders-sha
+          git add .github/upstream-bootloaders-sha
+          git commit -m "chore(bootloaders): record upstream SHA ${SHA} (no content change)"
+          git push origin main
+          git branch -D upstream-bootloaders-sync 2>/dev/null || true


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/penguins-recovery/.github/workflows/bootloaders-upstream-sync.yaml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).