### PR TITLE
Proposal: add `deployment.yml` skeleton

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,0 +1,81 @@
+name: 'Deployment'
+
+on:
+  workflow_run: 
+    workflows: ["CI"]
+      # TODO: list the workflow names that should trigger this
+    branches: [main, develop]
+    types: 
+      - completed
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 0
+
+      - name: Setup Pakman
+        uses: upmaru/pakman@v8
+        with:
+          alpine: v3.19
+
+      - name: Bootstrap Configuration
+        run: |
+          pakman bootstrap
+        shell: alpine.sh {0}
+        env:
+          ABUILD_PRIVATE_KEY: ${{secrets.ABUILD_PRIVATE_KEY}}
+          ABUILD_PUBLIC_KEY: ${{secrets.ABUILD_PUBLIC_KEY}}
+
+      - name: 'Build Package'
+        run: |
+          cd "$GITHUB_WORKSPACE"/.apk/"$GITHUB_REPOSITORY" || exit
+
+          abuild snapshot
+          abuild -r
+        shell: alpine.sh {0}
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ runner.arch }}
+          path: /home/runner/packages
+
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    steps: 
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with: 
+          path: /home/runner/artifacts
+
+      - name: Setup Pakman
+        uses: upmaru/pakman@v8
+        with:
+          alpine: v3.19
+
+      - name: Merge Artifact
+        run: |
+          cp -R /home/runner/artifacts/X64/. /home/runner/packages/
+          sudo zip -r /home/runner/packages.zip "$HOME"/packages
+        shell: alpine.sh {0}
+
+      - name: Push
+        run: pakman push
+        shell: alpine.sh {0}
+        env:
+          WORKFLOW_REF: ${{ github.event.workflow_run.head_branch }}
+          WORKFLOW_SHA: ${{ github.event.workflow_run.head_sha }}
+          INSTELLAR_ENDPOINT: ${{vars.INSTELLAR_ENDPOINT}}
+          INSTELLAR_PACKAGE_TOKEN: ${{secrets.INSTELLAR_PACKAGE_TOKEN}}
+          INSTELLAR_AUTH_TOKEN: ${{secrets.INSTELLAR_AUTH_TOKEN}}


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/polar/.github/workflows/deployment.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).