### PR TITLE
Proposal: add `publish-on-tag.yml` skeleton

### DIFF
--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -1,0 +1,39 @@
+name: publish-on-tag
+
+# Declare default permissions as read only.
+permissions: read-all
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: npm install
+      - name: Build
+        run: npm run build
+      - name: Publish ${REPO_NAME}
+        env:
+          NPM_TOKEN: ${{secrets.NPM_TOKEN_PUPPETEER}}
+        run: |
+          npm config set registry 'https://wombat-dressing-room.appspot.com/'
+          npm config set '//wombat-dressing-room.appspot.com/:_authToken' '${NPM_TOKEN}'
+          echo "Publishing ${REPO_NAME}"
+          npm publish
+          # DEPRECATED_RANGE=$(node utils/get_deprecated_version_range.js)
+          # echo "Deprecating old ${REPO_NAME} versions: $DEPRECATED_RANGE"
+          # npm deprecate ${REPO_NAME}@$DEPRECATED_RANGE "Version no longer supported. Upgrade to @latest"
+      - name: Publish ${REPO_NAME}-core
+        env:
+          NPM_TOKEN: ${{secrets.NPM_TOKEN_PUPPETEER_CORE}}
+        run: |
+          utils/prepare_${REPO_NAME}_core.js
+          npm config set registry 'https://wombat-dressing-room.appspot.com/'
+          npm config set '//wombat-dressing-room.appspot.com/:_authToken' '${NPM_TOKEN}'
+          npm publish


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/puppeteer/.github/workflows/publish-on-tag.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).