### PR TITLE
Proposal: add `api-service.yml` skeleton

### DIFF
--- a/.github/workflows/api-service.yml
+++ b/.github/workflows/api-service.yml
@@ -1,0 +1,112 @@
+name: API Service Checks
+
+on:
+  push:
+    paths-ignore:
+    - '.github/ISSUE_TEMPLATE/**'
+    - 'src/**'
+    - 'pg_impl/**'
+    - '*.md'
+    - '*.sh'
+    - 'LICENSE'
+    branches:
+    - develop
+  pull_request:
+    branches:
+    - develop
+
+concurrency:
+  group: api-service-checks-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CTEST_OUTPUT_ON_FAILURE: 1
+
+jobs:
+  cpp-linter-api-service:
+    name: Test API service build
+    runs-on: ubuntu-latest
+    container: archlinux:base-devel
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install deps
+        run: |
+          pacman -Syu --noconfirm \
+          cmake pkg-config ninja meson clang lld llvm libc++ python boost boost-libs libbsd tcl libxml2 util-linux zlib git sudo ccache \
+          python-virtualenv python-jinja python-voluptuous python-yaml crypto++ yaml-cpp c-ares libev libnghttp2 \
+          postgresql postgresql-libs rust
+        shell: bash
+
+      - name: Create builder user and install dependency
+        run: |
+          useradd -ms /bin/bash builder
+          echo 'builder ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+
+          echo 'LANG=en_US.UTF-8\nLANG_ALL=en_US.UTF-8' > /etc/locale.conf
+          echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen
+          locale-gen
+
+          cd /tmp
+          sudo -u builder bash -c "git clone https://aur.archlinux.org/cctz.git && cd cctz && makepkg --rmdeps -sicf --cleanbuild --noconfirm --noprogressbar --nocheck"
+          sudo -u builder bash -c "git clone https://gitlab.archlinux.org/archlinux/packaging/packages/http-parser.git && cd http-parser && makepkg --rmdeps -sicf --cleanbuild --noconfirm --noprogressbar --nocheck"
+        shell: bash
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: "ccache-linter"
+          max-size: 512M
+
+      - name: Configure third-party
+        run: |
+          export AR=llvm-ar
+          export CC='ccache clang'
+          export CXX='ccache clang++'
+          export NM=llvm-nm
+          export RANLIB=llvm-ranlib
+
+          cd api-service
+          ./setup_libpq.py $PWD
+          ./setup_userver.py $PWD
+          cd ..
+        shell: bash
+
+      - name: Configure & Build
+        run: |
+          cd api-service
+          ./configure.sh -t=Debug -p=/tmp/api-service-build --use_clang --enable_tests
+          ./build.sh
+        shell: bash
+
+      - name: Run API tests
+        run: |
+          sudo chown -R builder .
+          cd /tmp/api-service-build/Debug/
+          sudo chown -R builder ..
+
+          # should make it possible to access userfaultfd without obtaining CAP_SYS_PTRACE capability
+          if [ -e /proc/sys/vm/unprivileged_userfaultfd ]; then
+              echo 1 > /proc/sys/vm/unprivileged_userfaultfd
+          fi
+          ulimit -n 4096
+          sudo -u builder bash -c "ctest -V"
+        shell: bash
+
+      - name: Run clang-tidy
+        run: |
+          cd api-service
+          clang-tidy -p /tmp/api-service-build/Debug src/*.cpp
+        shell: bash
+
+  check_clang_format:
+    name: "Check API service C++ style"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Run clang-format style check for C/C++/Protobuf programs.
+      uses: jidicula/clang-format-action@5cc331b319e3ad388e0e16ccae131363f0a82c37
+      with:
+        clang-format-version: '20'
+        check-path: 'api-service/src'


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/repo-manage-util/.github/workflows/api-service.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).