### PR TITLE
Proposal: add `web-dashboard.yml` skeleton

### DIFF
--- a/.github/workflows/web-dashboard.yml
+++ b/.github/workflows/web-dashboard.yml
@@ -1,0 +1,37 @@
+name: Web Dashboard Checks
+
+on:
+  push:
+    paths-ignore:
+    - '.github/ISSUE_TEMPLATE/**'
+    - 'src/**'
+    - 'pg_impl/**'
+    - 'api-service/**'
+    - '*.md'
+    - '*.sh'
+    - 'LICENSE'
+    branches:
+    - develop
+  pull_request:
+    branches:
+    - develop
+
+concurrency:
+  group: web-dashboard-checks-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_ENV: 'production'
+  NEXT_TELEMETRY_DISABLED: 1
+
+jobs:
+  test-build:
+    runs-on: ubuntu-latest
+    container: oven/bun:1-slim
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build
+        run: bun --bun install --frozen-lockfile && bun --bun run build
+        working-directory: web-dashboard


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/repo-manage-util/.github/workflows/web-dashboard.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).