### PR TITLE
Proposal: add `CICD.md` skeleton

### DIFF
--- a/.github/workflows/CICD.md
+++ b/.github/workflows/CICD.md
@@ -1,0 +1,140 @@
+# CI/CD Flows
+
+## PR Quality Gates (ci.yml)
+
+Trigger: pull_request to develop or master
+
+```
+                          ┌──────────────────┐
+                          │    PR opened      │
+                          └────────┬─────────┘
+                                   │
+                          ┌────────▼─────────┐
+                          │    fmt --all     │
+                          └────────┬─────────┘
+                                   │
+                       ┌───────────▼──────────┐
+                       │ clippy --all-targets │
+                       └───┬───┬───┬───┬───┬──┘
+                           │   │   │   │   │
+           ┌───────────────┘   │   │   │   └────────────────┐
+           │       ┌───────────┘   │   └───────────┐        │
+           ▼       ▼              ▼               ▼        ▼
+     ┌──────────┐ ┌──────────┐ ┌───────────┐ ┌─────────┐ ┌──────────┐
+     │ test     │ │ security │ │ semgrep   │ │benchmark│ │ doc      │
+     │ ubuntu   │ │ cargo    │ │ AST-aware │ │ >=80%   │ │ review   │
+     │ windows  │ │ audit    │ │ diff-only │ │ savings │ │ ai agent │
+     │ macos    │ │ patterns │ │           │ │         │ │          │
+     └────┬─────┘ └────┬─────┘ └─────┬─────┘ └────┬────┘ └────┬─────┘
+          │            │             │             │            │
+          └────────────┴─────────┬───┴─────────────┴────────────┘
+                                 │
+                      ┌──────────▼─────────┐
+                      │  All must pass     │
+                      │  to merge          │
+                      └────────────────────┘
+
+     + DCO check (independent, develop PRs only)
+     + Dependabot (weekly: Cargo deps + GitHub Actions)
+```
+
+## Merge to develop — pre-release (cd.yml)
+
+Trigger: push to develop | workflow_dispatch (not master) | Concurrency: cancel-in-progress
+
+```
+     ┌──────────────────┐
+     │ push to develop   │
+     │ OR dispatch       │
+     └────────┬─────────┘
+              │
+     ┌────────▼──────────────────┐
+     │ pre-release                │
+     │ compute next version      │
+     │ from conventional commits │
+     │ tag = v{next}-rc.{run}    │
+     └────────┬──────────────────┘
+              │
+     ┌────────▼──────────────────┐
+     │ release.yml               │
+     │ prerelease = true         │
+     └────────┬──────────────────┘
+              │
+     ┌────────▼──────────────────┐
+     │ Build                     │
+     │ 5 platforms + DEB + RPM   │
+     └────────┬──────────────────┘
+              │
+     ┌────────▼──────────────────┐
+     │ GitHub Release            │
+     │ (pre-release badge)       │
+     │                           │
+     │ Discord:  SKIPPED         │
+     │ Homebrew: SKIPPED         │
+     └──────────────────────────┘
+```
+
+## Merge to master — stable release (cd.yml)
+
+Trigger: push to master (only) | Concurrency: never cancelled
+
+```
+     ┌──────────────────┐
+     │ push to master    │
+     └────────┬─────────┘
+              │
+     ┌────────▼──────────────────┐
+     │ release-please            │
+     │ analyze conventional      │
+     │ commits                   │
+     └────────┬──────────────────┘
+              │
+         ┌────┴────────────────┐
+         │                     │
+    no release           release created
+         │                     │
+         ▼                     ▼
+  ┌──────────────┐    ┌───────────────────────┐
+  │ create/update│    │ release.yml            │
+  │ release PR   │    │ prerelease = false     │
+  └──────────────┘    └───────────┬───────────┘
+                                  │
+                     ┌────────────▼────────────┐
+                     │ Build                   │
+                     │ 5 platforms + DEB + RPM  │
+                     └────────────┬────────────┘
+                                  │
+                     ┌────────────▼────────────┐
+                     │ GitHub Release           │
+                     │ (stable, "Latest" badge) │
+                     └──┬─────────┬─────────┬──┘
+                        │         │         │
+                        ▼         ▼         ▼
+                    Discord   Homebrew   latest
+                    notify    tap update  tag
+```
+
+## Manual release (release.yml)
+
+Trigger: workflow_dispatch
+
+```
+     ┌────────────────────────┐
+     │ workflow_dispatch       │
+     │ inputs: tag, prerelease │
+     └───────────┬────────────┘
+                 │
+     ┌───────────▼────────────┐
+     │ Full build pipeline     │
+     │ 5 platforms + DEB + RPM │
+     └───────────┬────────────┘
+                 │
+          ┌──────┴──────┐
+          │             │
+   prerelease=false  prerelease=true
+          │             │
+          ▼             ▼
+     Discord        pre-release
+     Homebrew       badge only
+     latest tag
+```


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/rtk/.github/workflows/CICD.md`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).