### PR TITLE
Proposal: add `next-release.yml` skeleton

### DIFF
--- a/.github/workflows/next-release.yml
+++ b/.github/workflows/next-release.yml
@@ -1,0 +1,126 @@
+name: Update Next Release PR
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [develop]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  update-next-release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update Next Release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          REPO: ${{ github.repository }}
+          ALLOWED_REPOS: "${REPO_NAME}-ai/${REPO_NAME}"
+        run: |
+          set -euo pipefail
+
+          URL_PATTERN=""
+          for repo in $ALLOWED_REPOS; do
+            URL_PATTERN="${URL_PATTERN}|https://github\\.com/${repo}/issues/[0-9]+"
+          done
+          URL_PATTERN="${URL_PATTERN#|}"
+
+          if printf '%s' "$PR_TITLE" | grep -qiE '^feat'; then
+            SECTION="Feats"
+          elif printf '%s' "$PR_TITLE" | grep -qiE '^fix'; then
+            SECTION="Fix"
+          else
+            SECTION="Other"
+          fi
+
+          ISSUE_REFS=""
+          if [ -n "$PR_BODY" ]; then
+            ISSUE_REFS=$(echo "$PR_BODY" \
+              | grep -oiE "(closes|fixes|resolves):?\s+#[0-9]+|${URL_PATTERN}" \
+              | grep -oE '#[0-9]+|issues/[0-9]+' \
+              | sed 's|issues/|#|' \
+              | sort -u \
+              || true)
+          fi
+
+          ENTRY="- ${PR_TITLE} [#${PR_NUMBER}](${PR_URL})"
+          if [ -n "$ISSUE_REFS" ]; then
+            CLOSES_PARTS=""
+            while IFS= read -r ref; do
+              [ -z "$ref" ] && continue
+              NUM="${ref#\#}"
+              ISSUE_URL="https://github.com/${REPO}/issues/${NUM}"
+              if [ -n "$CLOSES_PARTS" ]; then
+                CLOSES_PARTS="${CLOSES_PARTS}, [${ref}](${ISSUE_URL}) (to verify)"
+              else
+                CLOSES_PARTS="Closes [${ref}](${ISSUE_URL}) (to verify)"
+              fi
+            done <<< "$ISSUE_REFS"
+            ENTRY="${ENTRY} — ${CLOSES_PARTS}"
+          fi
+
+          NEXT_PR=$(gh pr list \
+            --repo "$REPO" \
+            --label next-release \
+            --base master \
+            --head develop \
+            --state open \
+            --json number,body \
+            --jq '.[0] // empty')
+
+          NEXT_PR_NUMBER=""
+          if [ -n "$NEXT_PR" ]; then
+            NEXT_PR_NUMBER=$(echo "$NEXT_PR" | jq -r '.number')
+          fi
+
+          if [ -z "$NEXT_PR_NUMBER" ]; then
+            TEMPLATE="### Feats
+
+          ### Fix
+
+          ### Other"
+
+            PR_CREATE_URL=$(gh pr create \
+              --repo "$REPO" \
+              --base master \
+              --head develop \
+              --title "Next Release" \
+              --label next-release \
+              --body "$TEMPLATE")
+
+            NEXT_PR_NUMBER=$(echo "$PR_CREATE_URL" | grep -oE '/pull/[0-9]+' | grep -oE '[0-9]+')
+            CURRENT_BODY="$TEMPLATE"
+          else
+            CURRENT_BODY=$(echo "$NEXT_PR" | jq -r '.body')
+          fi
+
+          SECTION_HEADER="### ${SECTION}"
+          export ENTRY
+          if echo "$CURRENT_BODY" | grep -qF "$SECTION_HEADER"; then
+            UPDATED_BODY=$(echo "$CURRENT_BODY" | awk -v section="$SECTION_HEADER" '
+              $0 == section {
+                print
+                print ENVIRON["ENTRY"]
+                next
+              }
+              { print }
+            ')
+          else
+            UPDATED_BODY="${CURRENT_BODY}
+
+          ${SECTION_HEADER}
+          ${ENTRY}"
+          fi
+
+          gh pr edit "$NEXT_PR_NUMBER" \
+            --repo "$REPO" \
+            --body "$UPDATED_BODY"
+
+          echo "Updated Next Release PR #${NEXT_PR_NUMBER} — added entry to ### ${SECTION}"


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/rtk/.github/workflows/next-release.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).