### PR TITLE
Proposal: add `update-playground-version.yml` skeleton

### DIFF
--- a/.github/workflows/update-playground-version.yml
+++ b/.github/workflows/update-playground-version.yml
@@ -1,0 +1,32 @@
+name: CI/Update playground package
+on:
+  push:
+    branches:
+      - ignroe
+jobs:
+  Deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+      - name: Install dependencies
+        run: yarn
+      - name: Run tests
+        run: yarn run test:ci
+      - uses: actions/checkout@v2
+        with:
+          ref: playground-version
+      - name: Install dependencies
+        run: yarn
+      - name: Build
+        run: yarn build
+      - name: Commit & Push
+        run: |
+          git config --global user.name 'Playground bot 🤖'
+          git config --global user.email 'playground@doriaviram.com'
+          git merge origin/master --allow-unrelated-histories --strategy-option theirs
+          git add .
+          git commit -am "Update playground version 🤖" --no-verify
+          git push


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/super-yaml/.github/workflows/update-playground-version.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).