### PR TITLE
Proposal: add `integration-misc-2-triggered.yaml` skeleton

### DIFF
--- a/.github/workflows/integration-misc-2-triggered.yaml
+++ b/.github/workflows/integration-misc-2-triggered.yaml
@@ -1,0 +1,130 @@
+# THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
+#
+# Generated on 2026-05-11T14:12:46Z by kres 1762ab2.
+
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+"on":
+  workflow_run:
+    workflows:
+      # TODO: list the workflow names that should trigger this
+    types:
+      - completed
+name: integration-misc-2-triggered
+jobs:
+  default:
+    name: ${{ matrix.test }}
+    permissions:
+      actions: read
+    runs-on:
+      group: large
+    if: github.event.workflow_run.conclusion == 'success'
+    strategy:
+      matrix:
+        include:
+          - extraTestArgs: -${REPO_NAME}.verifyukibooted=false
+            test: e2e-bios
+            withUefi: "false"
+          - extraTestArgs: -${REPO_NAME}.verifyukibooted=false
+            test: e2e-bios-iso
+            viaMaintenanceMode: "true"
+            withIso: "true"
+            withUefi: "false"
+          - test: e2e-disk-image
+            useDiskImage: "true"
+            viaMaintenanceMode: "true"
+            withDiskEncryption: "true"
+            withJsonLogs: "false"
+          - extraTestArgs: -${REPO_NAME}.verifyukibooted=false
+            test: e2e-disk-image-bios
+            useDiskImage: "true"
+            viaMaintenanceMode: "true"
+            withDiskEncryption: "true"
+            withUefi: "false"
+          - test: e2e-node-address-v2
+            withConfigPatch: '@hack/test/patches/node-address-v2.yaml'
+          - test: e2e-tpm1_2
+            withTpm12: "true"
+          - test: e2e-dns-over-tls
+            withConfigPatch: '@hack/test/patches/dns-over-tls.yaml'
+          - test: e2e-dns-over-http
+            withConfigPatch: '@hack/test/patches/dns-over-http.yaml'
+      fail-fast: false
+      max-parallel: 2
+    steps:
+      - name: gather-system-info
+        id: system-info
+        uses: kenchan0130/actions-system-info@59699597e84e80085a750998045983daa49274c4 # version: v1.4.0
+        continue-on-error: true
+      - name: print-system-info
+        run: |
+          MEMORY_GB=$((${{ steps.system-info.outputs.totalmem }}/1024/1024/1024))
+
+          OUTPUTS=(
+            "CPU Core: ${{ steps.system-info.outputs.cpu-core }}"
+            "CPU Model: ${{ steps.system-info.outputs.cpu-model }}"
+            "Hostname: ${{ steps.system-info.outputs.hostname }}"
+            "NodeName: ${NODE_NAME}"
+            "Kernel release: ${{ steps.system-info.outputs.kernel-release }}"
+            "Kernel version: ${{ steps.system-info.outputs.kernel-version }}"
+            "Name: ${{ steps.system-info.outputs.name }}"
+            "Platform: ${{ steps.system-info.outputs.platform }}"
+            "Release: ${{ steps.system-info.outputs.release }}"
+            "Total memory: ${MEMORY_GB} GB"
+          )
+
+          for OUTPUT in "${OUTPUTS[@]}";do
+            echo "${OUTPUT}"
+          done
+        continue-on-error: true
+      - name: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # version: v6.0.2
+      - name: Unshallow
+        run: |
+          git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # version: v4.0.0
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
+      - name: Download artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # version: v8.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${REPO_NAME}-artifacts
+          path: _out
+          run-id: ${{ github.event.workflow_run.id }}
+      - name: Fix artifact permissions
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: ci-temp-release-tag
+        run: |
+          make ci-temp-release-tag
+      - name: ${{ matrix.test }}
+        env:
+          EXTRA_TEST_ARGS: ${{ matrix.extraTestArgs }}
+          GITHUB_STEP_NAME: ${{ github.job}}-${{ matrix.test }}
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          SHORT_INTEGRATION_TEST: "yes"
+          USE_DISK_IMAGE: ${{ matrix.useDiskImage }}
+          VIA_MAINTENANCE_MODE: ${{ matrix.viaMaintenanceMode }}
+          WITH_CONFIG_PATCH: ${{ matrix.withConfigPatch }}
+          WITH_DISK_ENCRYPTION: ${{ matrix.withDiskEncryption }}
+          WITH_ISO: ${{ matrix.withIso }}
+          WITH_JSON_LOGS: ${{ matrix.withJsonLogs }}
+          WITH_TPM1_2: ${{ matrix.withTpm12 }}
+          WITH_UEFI: ${{ matrix.withUefi }}
+        run: |
+          sudo -E make e2e-qemu
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # version: v7.0.1
+        with:
+          name: ${REPO_NAME}-logs-integration-misc-2-${{ matrix.test }}
+          path: |-
+            /tmp/logs-*.tar.gz
+            /tmp/support-*.zip
+          retention-days: "5"


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/talos/.github/workflows/integration-misc-2-triggered.yaml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).