### PR TITLE
Proposal: add `integration-misc-3-triggered.yaml` skeleton

### DIFF
--- a/.github/workflows/integration-misc-3-triggered.yaml
+++ b/.github/workflows/integration-misc-3-triggered.yaml
@@ -1,0 +1,127 @@
+# THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
+#
+# Generated on 2026-04-27T17:59:00Z by kres e4dc583.
+
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+"on":
+  workflow_run:
+    workflows:
+      # TODO: list the workflow names that should trigger this
+    types:
+      - completed
+name: integration-misc-3-triggered
+jobs:
+  default:
+    name: ${{ matrix.test }}-${{ matrix.variant }}
+    permissions:
+      actions: read
+    runs-on:
+      group: large
+    if: github.event.workflow_run.conclusion == 'success'
+    strategy:
+      matrix:
+        include:
+          - test: e2e-network-chaos
+            variant: default
+            withNetworkChaos: "yes"
+          - test: e2e-metal-iso
+            variant: default
+            withConfigInjectionMethod: metal-iso
+          - test: e2e-iommu-pcidriverrebind
+            variant: default
+            withIommu: "yes"
+          - extraTestArgs: -${REPO_NAME}.enforcing
+            tagSuffixIn: -enforcing
+            test: e2e-network-chaos
+            variant: enforcing
+            withEnforcing: "true"
+            withNetworkChaos: "yes"
+          - extraTestArgs: -${REPO_NAME}.enforcing
+            tagSuffixIn: -enforcing
+            test: e2e-metal-iso
+            variant: enforcing
+            withConfigInjectionMethod: metal-iso
+            withEnforcing: "true"
+          - extraTestArgs: -${REPO_NAME}.enforcing
+            tagSuffixIn: -enforcing
+            test: e2e-iommu-pcidriverrebind
+            variant: enforcing
+            withEnforcing: "true"
+            withIommu: "yes"
+      fail-fast: false
+      max-parallel: 2
+    steps:
+      - name: gather-system-info
+        id: system-info
+        uses: kenchan0130/actions-system-info@59699597e84e80085a750998045983daa49274c4 # version: v1.4.0
+        continue-on-error: true
+      - name: print-system-info
+        run: |
+          MEMORY_GB=$((${{ steps.system-info.outputs.totalmem }}/1024/1024/1024))
+
+          OUTPUTS=(
+            "CPU Core: ${{ steps.system-info.outputs.cpu-core }}"
+            "CPU Model: ${{ steps.system-info.outputs.cpu-model }}"
+            "Hostname: ${{ steps.system-info.outputs.hostname }}"
+            "NodeName: ${NODE_NAME}"
+            "Kernel release: ${{ steps.system-info.outputs.kernel-release }}"
+            "Kernel version: ${{ steps.system-info.outputs.kernel-version }}"
+            "Name: ${{ steps.system-info.outputs.name }}"
+            "Platform: ${{ steps.system-info.outputs.platform }}"
+            "Release: ${{ steps.system-info.outputs.release }}"
+            "Total memory: ${MEMORY_GB} GB"
+          )
+
+          for OUTPUT in "${OUTPUTS[@]}";do
+            echo "${OUTPUT}"
+          done
+        continue-on-error: true
+      - name: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # version: v6.0.2
+      - name: Unshallow
+        run: |
+          git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # version: v4.0.0
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
+      - name: Download artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # version: v8.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${REPO_NAME}-enforcing-artifacts
+          path: _out
+          run-id: ${{ github.event.workflow_run.id }}
+      - name: Fix artifact permissions
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: ci-temp-release-tag
+        run: |
+          make ci-temp-release-tag
+      - name: ${{ matrix.test }}
+        env:
+          EXTRA_TEST_ARGS: ${{ matrix.extraTestArgs }}
+          GITHUB_STEP_NAME: ${{ github.job}}-${{ matrix.test }}-${{ matrix.variant }}
+          IMAGE_REGISTRY: registry.dev.siderolabs.io
+          SHORT_INTEGRATION_TEST: "yes"
+          TAG_SUFFIX_IN: ${{ matrix.tagSuffixIn }}
+          WITH_CONFIG_INJECTION_METHOD: ${{ matrix.withConfigInjectionMethod }}
+          WITH_ENFORCING: ${{ matrix.withEnforcing }}
+          WITH_IOMMU: ${{ matrix.withIommu }}
+          WITH_NETWORK_CHAOS: ${{ matrix.withNetworkChaos }}
+        run: |
+          sudo -E make e2e-qemu
+      - name: save artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # version: v7.0.1
+        with:
+          name: ${REPO_NAME}-logs-integration-misc-3-${{ matrix.test }}-${{ matrix.variant }}
+          path: |-
+            /tmp/logs-*.tar.gz
+            /tmp/support-*.zip
+          retention-days: "5"


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/talos/.github/workflows/integration-misc-3-triggered.yaml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).