### PR TITLE
Proposal: add `stale.yml` skeleton

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,27 @@
+# THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
+#
+# Generated on 2026-03-05T15:46:00Z by kres 1dd7316.
+
+"on":
+  schedule:
+    - cron: 30 1 * * *  # TODO: set schedule for your project
+name: Close stale issues and PRs
+permissions:
+  issues: write
+  pull-requests: write
+jobs:
+  stale:
+    runs-on:
+      - ubuntu-latest
+    steps:
+      - name: Close stale issues and PRs
+        uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # version: v10.2.0
+        with:
+          close-issue-message: This issue was closed because it has been stalled for 7 days with no activity.
+          days-before-issue-close: "5"
+          days-before-issue-stale: "180"
+          days-before-pr-close: "-1"
+          days-before-pr-stale: "45"
+          operations-per-run: "2000"
+          stale-issue-message: This issue is stale because it has been open 180 days with no activity. Remove stale label or comment or this will be closed in 7 days.
+          stale-pr-message: This PR is stale because it has been open 45 days with no activity.


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/talos/.github/workflows/stale.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).