### PR TITLE
Proposal: add `build-multiple.yml` skeleton

### DIFF
--- a/.github/workflows/build-multiple.yml
+++ b/.github/workflows/build-multiple.yml
@@ -1,0 +1,111 @@
+name: Build Multiple Versions
+
+on:
+  workflow_dispatch:
+    inputs:
+      versions:
+        description: 'Comma-separated list of Talos versions to build (e.g., v1.10.7,v1.10.8,v1.11.4)'
+        required: true
+        type: string
+
+jobs:
+  trigger-builds:
+    name: Trigger builds for versions
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Checkout ${REPO_NAME}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      
+      - name: Parse versions
+        id: versions
+        run: |
+          VERSIONS="${{ github.event.inputs.versions }}"
+          # Remove spaces and split by comma
+          VERSIONS=$(echo "$VERSIONS" | tr -d ' ' | tr ',' '\n')
+          
+          # Filter out empty lines and validate format
+          VALID_VERSIONS=()
+          while IFS= read -r version; do
+            if [ -n "$version" ] && [[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              VALID_VERSIONS+=("$version")
+            fi
+          done <<< "$VERSIONS"
+          
+          if [ ${#VALID_VERSIONS[@]} -eq 0 ]; then
+            echo "Error: No valid versions provided"
+            exit 1
+          fi
+          
+          # Output as compact JSON array (no pretty printing)
+          printf '%s\n' "${VALID_VERSIONS[@]}" | jq -R . | jq -s -c . > versions.json
+          echo "versions=$(cat versions.json)" >> $GITHUB_OUTPUT
+          echo "Found ${#VALID_VERSIONS[@]} valid versions:"
+          printf '  - %s\n' "${VALID_VERSIONS[@]}"
+      
+      - name: Check existing releases
+        id: check_releases
+        run: |
+          VERSIONS=$(echo '${{ steps.versions.outputs.versions }}' | jq -r '.[]')
+          EXISTING=()
+          MISSING=()
+          
+          while IFS= read -r version; do
+            if gh release view "$version" >/dev/null 2>&1; then
+              EXISTING+=("$version")
+              echo "✓ $version already exists"
+            else
+              MISSING+=("$version")
+              echo "→ $version needs to be built"
+            fi
+          done <<< "$VERSIONS"
+          
+          if [ ${#MISSING[@]} -eq 0 ]; then
+            echo "All versions already exist!"
+            echo "needs_build=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          
+          printf '%s\n' "${MISSING[@]}" | jq -R . | jq -s -c . > missing_versions.json
+          echo "missing_versions=$(cat missing_versions.json)" >> $GITHUB_OUTPUT
+          echo "needs_build=true" >> $GITHUB_OUTPUT
+          echo ""
+          echo "Will build ${#MISSING[@]} versions:"
+          printf '  - %s\n' "${MISSING[@]}"
+        env:
+          GH_TOKEN: ${{ github.token }}
+      
+      - name: Trigger CI workflow for each version
+        if: steps.check_releases.outputs.needs_build == 'true'
+        run: |
+          MISSING_VERSIONS=$(echo '${{ steps.check_releases.outputs.missing_versions }}' | jq -r '.[]')
+          
+          while IFS= read -r version; do
+            echo ""
+            echo "Triggering build for $version..."
+            gh workflow run ci.yml \
+              --ref main \
+              -f version="$version" || {
+              echo "⚠️  Failed to trigger workflow for $version"
+              continue
+            }
+            echo "✓ Triggered workflow for $version"
+            
+            # Small delay to avoid rate limiting
+            sleep 1
+          done <<< "$MISSING_VERSIONS"
+        env:
+          GH_TOKEN: ${{ github.token }}
+      
+      - name: Summary
+        run: |
+          echo ""
+          echo "=========================================="
+          echo "Build triggers completed!"
+          echo "=========================================="
+          echo ""
+          echo "Monitor progress at:"
+          echo "https://github.com/${{ github.repository }}/actions"
+          echo ""


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/talos-incus/.github/workflows/build-multiple.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).