### PR TITLE
Proposal: add `deploy-worker.yml` skeleton

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -1,0 +1,89 @@
+name: Deploy Cloudflare Worker
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'cloudflare-worker.js'
+      - 'wrangler.toml.template'
+      - '.github/workflows/deploy-worker.yml'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Cloudflare secrets
+        id: cf_check
+        env:
+          CF_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ACCOUNT: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          if [[ -z "$CF_TOKEN" || -z "$CF_ACCOUNT" ]]; then
+            echo "Cloudflare secrets not configured — skipping deploy."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Checkout ${REPO_NAME}
+        if: steps.cf_check.outputs.skip != 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Look up KV namespace ID by name
+        if: steps.cf_check.outputs.skip != 'true'
+        id: kv_namespace
+        run: |
+          NAMESPACE_NAME="interested-deving-1896-images"
+          
+          # Use Cloudflare API directly (more reliable than wrangler in CI)
+          RESPONSE=$(curl -s -X GET "https://api.cloudflare.com/client/v4/accounts/${{ secrets.CLOUDFLARE_ACCOUNT_ID }}/storage/kv/namespaces" \
+            -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+            -H "Content-Type: application/json")
+          
+          # Check if API call succeeded
+          if echo "$RESPONSE" | jq -e '.success == false' >/dev/null 2>&1; then
+            echo "Error: Cloudflare API request failed"
+            echo "$RESPONSE" | jq .
+            exit 1
+          fi
+          
+          # Extract namespace ID by name
+          NAMESPACE_ID=$(echo "$RESPONSE" | jq -r --arg name "$NAMESPACE_NAME" '.result[] | select(.title == $name) | .id' || echo "")
+          
+          if [ -z "$NAMESPACE_ID" ] || [ "$NAMESPACE_ID" = "null" ]; then
+            echo "Error: KV namespace '$NAMESPACE_NAME' not found"
+            echo ""
+            echo "Available namespaces:"
+            echo "$RESPONSE" | jq -r '.result[] | "  - \(.title) (ID: \(.id))"'
+            echo ""
+            echo "Please create the namespace in Cloudflare Dashboard:"
+            echo "  Workers & Pages → KV → Create a namespace"
+            echo "  Name it: $NAMESPACE_NAME"
+            exit 1
+          fi
+          
+          echo "✓ Found KV namespace '$NAMESPACE_NAME' with ID: $NAMESPACE_ID"
+          echo "namespace_id=$NAMESPACE_ID" >> $GITHUB_OUTPUT
+
+      - name: Generate wrangler.toml with namespace ID
+        if: steps.cf_check.outputs.skip != 'true'
+        run: |
+          # Generate wrangler.toml from template with namespace ID (not committed)
+          if [ ! -f wrangler.toml.template ]; then
+            echo "Error: wrangler.toml.template not found"
+            exit 1
+          fi
+          
+          NAMESPACE_ID="${{ steps.kv_namespace.outputs.namespace_id }}"
+          sed "s/id = \".*\"/id = \"$NAMESPACE_ID\"/" wrangler.toml.template > wrangler.toml
+          
+          echo "Generated wrangler.toml (not committed to repo):"
+          cat wrangler.toml
+
+      - name: Deploy Worker
+        if: steps.cf_check.outputs.skip != 'true'
+        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/talos-incus/.github/workflows/deploy-worker.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).