### PR TITLE
Proposal: add `linux.yml` skeleton

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,53 @@
+name:
+  💀 Linux Tomb
+
+on:
+  push:
+    paths-ignore:
+      - 'doc/**'
+      - 'extras/portable/**'
+      - '*.md'
+    branches:
+    - master
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - 'extras/portable/**'
+      - '*.md'
+    branches:
+    - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build-matrix:
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Install ${REPO_NAME} dependencies
+        run: |
+          sudo apt-get update -y -q
+          sudo apt-get install -y -q zsh cryptsetup gpg gawk libgcrypt20-dev steghide qrencode python3-pip python3-dev libssl-dev make gcc sudo gettext bsdmainutils file pinentry-curses xxd libsodium23 libsodium-dev argon2
+      - name: Install python2 on ubuntu 22
+        if: matrix.os == 'ubuntu-22.04'
+        run: sudo apt-get install -y -q python2
+      - name: Install doas where found
+        if: matrix.os == 'ubuntu-24.04'
+        run: |
+          sudo apt-get install -y -q opendoas
+          echo "permit nopass root" | sudo tee /etc/doas.conf
+      - uses: actions/checkout@v3
+      - name: Build the pbkdf2 extras
+        run: |
+          make --directory=extras/kdf-keys
+          sudo make --directory=extras/kdf-keys install
+      - name: Run pbkdf2 tests
+        run: sudo make -C extras/kdf-keys test
+      - name: Disable swap
+        run: sudo swapoff -a
+      - name: Run main tests
+        run: sudo make test


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/tomb/.github/workflows/linux.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).