### PR TITLE
Proposal: add `server-test.yml` skeleton

### DIFF
--- a/.github/workflows/server-test.yml
+++ b/.github/workflows/server-test.yml
@@ -1,0 +1,74 @@
+name: Server Integration Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      backend:
+        description: HTTP backend to test
+        required: false
+        default: shell2http
+        type: choice
+        options: [shell2http, webhook]
+  schedule:
+    - cron: '0 4 * * 1'  # Monday 04:00 UTC  # TODO: set schedule for your project
+
+concurrency:
+  group: server-test
+  cancel-in-progress: true
+
+jobs:
+  integration:
+    name: Server integration (${{ inputs.backend || 'shell2http' }})
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install shell2http
+        run: |
+          curl -sfL https://github.com/msoap/shell2http/releases/latest/download/shell2http_linux_amd64.tar.gz \
+            | tar -xz -C /usr/local/bin shell2http
+          chmod +x /usr/local/bin/shell2http
+
+      - name: Make scripts executable
+        run: find . -name '*.sh' -exec chmod +x {} \;
+
+      - name: Start server
+        env:
+          UAA_FS_ROOTS: /tmp
+          UAA_PORT: 18080
+        run: |
+          ./server/start.sh --port 18080 --backend shell2http &
+          SERVER_PID=$!
+          echo "SERVER_PID=$SERVER_PID" >> "$GITHUB_ENV"
+          # Wait for server to be ready
+          for i in $(seq 1 15); do
+            curl -sf http://localhost:18080/health && break || sleep 1
+          done
+
+      - name: Test /health
+        run: |
+          out=$(curl -sf http://localhost:18080/health)
+          echo "$out" | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['status']=='ok'"
+          echo "health: ok"
+
+      - name: Test /api/adapters
+        run: |
+          out=$(curl -sf http://localhost:18080/api/adapters)
+          echo "$out" | python3 -c "import json,sys; d=json.load(sys.stdin); assert len(d['adapters'])>0"
+          echo "adapters: ok"
+
+      - name: Test /api/filesystem/ls
+        run: |
+          out=$(curl -sf "http://localhost:18080/api/filesystem/ls?path=/tmp")
+          echo "$out" | python3 -c "import json,sys; d=json.load(sys.stdin); assert 'entries' in d"
+          echo "filesystem/ls: ok"
+
+      - name: Test /api/os/info
+        run: |
+          out=$(curl -sf http://localhost:18080/api/os/info)
+          echo "$out" | python3 -c "import json,sys; d=json.load(sys.stdin); assert 'os' in d"
+          echo "os/info: ok"
+
+      - name: Stop server
+        if: always()
+        run: kill "$SERVER_PID" 2>/dev/null || true


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/unified-agnostic-api/.github/workflows/server-test.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).