### PR TITLE
Proposal: add `watch-upstream.yml` skeleton

### DIFF
--- a/.github/workflows/watch-upstream.yml
+++ b/.github/workflows/watch-upstream.yml
@@ -1,0 +1,87 @@
+name: Watch Upstream
+
+on:
+  schedule:
+    # Check for new XanMod releases daily at 06:00 UTC
+    - cron: '0 6 * * *'  # TODO: set schedule for your project
+  workflow_dispatch:
+    inputs:
+      xanmod_branch:
+        description: 'XanMod branch to watch'
+        required: false
+        default: 'main'
+
+jobs:
+  check-upstream:
+    name: Check for new XanMod commits
+    runs-on: ubuntu-latest
+    outputs:
+      new_version: ${{ steps.check.outputs.new_version }}
+      current_sha: ${{ steps.check.outputs.current_sha }}
+      upstream_sha: ${{ steps.check.outputs.upstream_sha }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check upstream XanMod HEAD
+        id: check
+        env:
+          XANMOD_BRANCH: ${{ inputs.xanmod_branch || 'main' }}
+        run: |
+          UPSTREAM_SHA="$(git ls-remote https://gitlab.com/xanmod/linux.git \
+            "refs/heads/${XANMOD_BRANCH}" | awk '{print $1}')"
+
+          # Fallback to GitHub mirror if GitLab unreachable
+          if [[ -z "${UPSTREAM_SHA}" ]]; then
+            UPSTREAM_SHA="$(git ls-remote https://github.com/xanmod/linux.git \
+              "refs/heads/${XANMOD_BRANCH}" | awk '{print $1}')"
+          fi
+
+          echo "upstream_sha=${UPSTREAM_SHA}" >> "$GITHUB_OUTPUT"
+
+          # Read last known SHA from repo state file
+          STATE_FILE=".cache/upstream-sha-${XANMOD_BRANCH}"
+          if [[ -f "${STATE_FILE}" ]]; then
+            CURRENT_SHA="$(cat "${STATE_FILE}")"
+          else
+            CURRENT_SHA=""
+          fi
+          echo "current_sha=${CURRENT_SHA}" >> "$GITHUB_OUTPUT"
+
+          if [[ "${UPSTREAM_SHA}" != "${CURRENT_SHA}" ]]; then
+            echo "new_version=true" >> "$GITHUB_OUTPUT"
+            echo "New XanMod commit detected: ${UPSTREAM_SHA} (was: ${CURRENT_SHA:-none})"
+          else
+            echo "new_version=false" >> "$GITHUB_OUTPUT"
+            echo "No new commits on ${XANMOD_BRANCH}"
+          fi
+
+  trigger-release:
+    name: Trigger release build
+    needs: check-upstream
+    if: needs.check-upstream.outputs.new_version == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update upstream SHA state
+        env:
+          XANMOD_BRANCH: ${{ inputs.xanmod_branch || 'main' }}
+          UPSTREAM_SHA: ${{ needs.check-upstream.outputs.upstream_sha }}
+        run: |
+          mkdir -p .cache
+          echo "${UPSTREAM_SHA}" > ".cache/upstream-sha-${XANMOD_BRANCH}"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git add ".cache/upstream-sha-${XANMOD_BRANCH}"
+          git commit -m "chore: update upstream SHA for ${XANMOD_BRANCH} to ${UPSTREAM_SHA:0:12}"
+          git push
+
+      - name: Trigger release workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run release.yml \
+            --field xanmod_branch="${{ inputs.xanmod_branch || 'main' }}" \
+            --field tier=tier1


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/xanmod-unified-kernel/.github/workflows/watch-upstream.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).