### PR TITLE
Proposal: add `update-deps.yaml` skeleton

### DIFF
--- a/.github/workflows/update-deps.yaml
+++ b/.github/workflows/update-deps.yaml
@@ -1,0 +1,29 @@
+name: update-deno-dependencies
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 1 * *"  # TODO: set schedule for your project
+
+jobs:
+  udd:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: denoland/setup-deno@v1
+      - name: Update dependencies
+        run: >
+          deno run -A https://deno.land/x/udd/main.ts
+          $(find . -name "*.ts")
+      - name: Create Pull ${REPO_NAME}
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: ":arrow_up: update deno dependencies"
+          title: Update Deno Dependencies
+          body: >
+            Automated updates by [deno-udd](https://github.com/hayd/deno-udd)
+            and [create-pull-request](https://github.com/peter-evans/create-pull-request)
+            GitHub action.
+          branch: update-deno-dependencies
+          author: GitHub <noreply@github.com>
+          delete-branch: true


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/y2j/.github/workflows/update-deps.yaml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).