### PR TITLE
Proposal: add `ci.yml` skeleton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,148 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+
+jobs:
+  # Unit tests (no FUSE required)
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.11']
+    
+    steps:
+    - name: Checkout ${REPO_NAME}
+      uses: actions/checkout@v4
+    
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    
+    - name: Cache pip dependencies
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install pytest pytest-cov
+    
+    - name: Run unit tests
+      run: |
+        python3 tests.py --unit
+    
+    - name: Run demo
+      run: |
+        python3 tests.py --demo || echo "Demo tests may fail without FUSE - this is expected in CI"
+    
+    - name: Check code style
+      run: |
+        pip install flake8
+        flake8 ${REPO_NAME}.py tests.py --max-line-length=120 --ignore=E501,W503,W291,W293,E302,E305,F401,F841,F541,E301,E128,W292,E722
+
+  # Note: FUSE integration and functional tests are excluded from CI
+  # as they require actual filesystem mounting which is complex in CI environments.
+  # These tests are designed for local development and testing.
+
+  # Security and dependency checks
+  security:
+    name: Security Checks
+    runs-on: ubuntu-latest
+    needs: unit-tests
+    
+    steps:
+    - name: Checkout ${REPO_NAME}
+      uses: actions/checkout@v4
+    
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.11
+    
+    - name: Install security tools
+      run: |
+        python -m pip install --upgrade pip
+        pip install bandit safety
+    
+    - name: Run security scan
+      run: |
+        bandit -r . -f json -o bandit-report.json --skip B404,B603,B607,B108,B110 || true
+        safety scan --json || echo "Safety scan completed (deprecated command)"
+    
+    - name: Upload security reports
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: security-reports
+        path: |
+          bandit-report.json
+
+  # Documentation check
+  docs:
+    name: Documentation Check
+    runs-on: ubuntu-latest
+    needs: unit-tests
+    
+    steps:
+    - name: Checkout ${REPO_NAME}
+      uses: actions/checkout@v4
+    
+    - name: Check documentation files exist
+      run: |
+        echo "Checking documentation files..."
+        test -f README.md && echo "✅ README.md exists"
+        test -f TESTING.md && echo "✅ TESTING.md exists"
+        test -f LICENSE && echo "✅ LICENSE exists"
+        test -f requirements.txt && echo "✅ requirements.txt exists"
+        test -f install.sh && echo "✅ install.sh exists"
+    
+    - name: Check documentation links
+      run: |
+        echo "Checking for broken links in documentation..."
+        # Check if referenced files exist
+        grep -r "\.md" README.md TESTING.md || true
+        grep -r "\.py" README.md TESTING.md || true
+
+  # Build and package test
+  build:
+    name: Build Test
+    runs-on: ubuntu-latest
+    needs: unit-tests
+    
+    steps:
+    - name: Checkout ${REPO_NAME}
+      uses: actions/checkout@v4
+    
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.11
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    
+    - name: Test basic functionality
+      run: |
+        echo "Testing basic functionality..."
+        python3 -c "import yaml; print('✅ PyYAML import successful')"
+        python3 -c "import sys; sys.path.append('.'); exec(open('${REPO_NAME}.py').read().split('if __name__')[0]); print('✅ ${REPO_NAME}.py syntax check passed')"
+    
+    - name: Test installation script
+      run: |
+        echo "Testing installation script..."
+        chmod +x install.sh
+        # Run install script in dry-run mode or check syntax
+        bash -n install.sh && echo "✅ install.sh syntax check passed" 


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/yaml-fuse/.github/workflows/ci.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).