### PR TITLE
Proposal: add `release.yml` skeleton

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,71 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release-test:
+    name: Release Tests
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout ${REPO_NAME}
+      uses: actions/checkout@v4
+    
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.11
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    
+    - name: Run all tests
+      run: |
+        echo "Running comprehensive test suite..."
+        python3 tests.py --unit
+        python3 tests.py --demo
+    
+    - name: Test installation
+      run: |
+        echo "Testing installation process..."
+        chmod +x install.sh
+        # Test the installer in a controlled way
+        echo "Testing installer script syntax..."
+        bash -n install.sh
+        echo "✅ Installer script syntax is valid"
+    
+    - name: Create release artifacts
+      run: |
+        echo "Creating release artifacts..."
+        mkdir -p dist
+        cp ${REPO_NAME}.py dist/
+        cp requirements.txt dist/
+        cp install.sh dist/
+        cp README.md dist/
+        cp TESTING.md dist/
+        cp LICENSE dist/
+        cp example.yaml dist/
+        echo "✅ Release artifacts created"
+    
+    - name: Upload release artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: release-files
+        path: dist/
+    
+    - name: Create checksums
+      run: |
+        echo "Creating checksums..."
+        cd dist
+        sha256sum * > checksums.txt
+        echo "✅ Checksums created"
+    
+    - name: Upload checksums
+      uses: actions/upload-artifact@v4
+      with:
+        name: checksums
+        path: dist/checksums.txt 


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/yaml-fuse/.github/workflows/release.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`


---

### Backlog audit disposition (2026-08-21)

Closed as an incomplete automated proposal. It adds a source-project workflow directly under `.github/workflows/` without the required fork-sync-all allowlist, workflow-sync, priority-tier, and quota-cost integration. The audit also found competing proposals for the same destination filenames and unsafe project-specific triggers, placeholders, or dependencies. Reopen only after deliberately adapting and validating it as an FSA workflow with every required registration.

The proposal generator is made dry-run-first, bounded, deduplicated by destination filename, and draft-only in [PR #607](https://github.com/Interested-Deving-1896/fork-sync-all/pull/607).