### PR TITLE
Proposal: add `main.yml` skeleton

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,66 @@
+name: E2E Tests
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  test_job:
+    name: Single Doc
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: ${REPO_NAME}
+        uses: ./
+        id: ${REPO_NAME}
+        with:
+          yaml-file: "__tests__/test.yaml"
+
+      # Use the output from the ${REPO_NAME} step
+      - name: Output Test
+        run: |
+          echo "${{ steps.${REPO_NAME}.outputs.yaml }}"
+          echo "${{ steps.${REPO_NAME}.outputs.what_it_is }}"
+          echo "${{ steps.${REPO_NAME}.outputs.yaml_resources__yaml_1_2_3rd_edition }}"
+  test_multidoc_job:
+    name: Multi Doc
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: ${REPO_NAME}
+        uses: ./
+        id: ${REPO_NAME}
+        with:
+          yaml-file: "__tests__/test-multidoc.yaml"
+          multidoc: true
+
+      # Use the output from the ${REPO_NAME} step
+      - name: Output Test
+        run: |
+          echo "${{ steps.${REPO_NAME}.outputs.doc0__name }}"
+          echo "${{ steps.${REPO_NAME}.outputs.doc0__purpose }}"  
+  test_front_matter_job:
+    name: Front Matter
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: ${REPO_NAME}
+        uses: ./
+        id: ${REPO_NAME}
+        with:
+          yaml-file: "__tests__/front-matter.md"
+          multidoc: true
+
+      # Use the output from the ${REPO_NAME} step
+      - name: Output Test
+        run: |
+          echo "${{ steps.${REPO_NAME}.outputs.doc0__title }}"
+          echo "${{ steps.${REPO_NAME}.outputs.doc0__permalink }}"
+          echo "${{ steps.${REPO_NAME}.outputs.doc0__redirect_from }}"
+          echo "${{ steps.${REPO_NAME}.outputs.doc0__reviewed_on }}"
+          echo "${{ steps.${REPO_NAME}.outputs.doc0__reviewed_by }}"


### PR DESCRIPTION
## Upstream workflow proposal

**Source:** `Interested-Deving-1896/yamler/.github/workflows/main.yml`

This workflow was detected in an OSP-bound repo and does not yet exist in `fork-sync-all`.
The file has been sanitised:
- Hardcoded org/repo names replaced with generic placeholders
- Cron schedules marked with `# TODO` comments
- Project-specific `run-name` lines removed

**Review checklist before merging:**
- [ ] Workflow is genuinely reusable across projects (not repo-specific logic)
- [ ] No hardcoded repo or org names remain in `run:` shell blocks (sanitisation covers `env:`, `with:`, and `default:` fields but not inline shell strings)
- [ ] Cron schedule is appropriate for a template (or removed entirely)
- [ ] `workflow_run:` trigger names updated or removed (replaced with TODO by sanitisation)
- [ ] Add to the allowlist in `scripts/validate-workflows.sh`
